### PR TITLE
Fix local development port

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -1,9 +1,9 @@
 app:
   title: Backstage Demo
-  baseUrl: http://localhost:7000
+  baseUrl: http://localhost:3000
 
 organization:
-  name: Backstage 
+  name: Backstage
 
 backend:
   baseUrl: http://localhost:7000
@@ -27,7 +27,7 @@ integrations:
         $env: GITHUB_TOKEN
 auth:
   environment: development
-  providers: 
+  providers:
     github:
       development:
         clientId:
@@ -51,7 +51,7 @@ catalog:
     # Backstage example APIs
     - type: url
       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-apis.yaml
-  
+
     # The backstage demo deployment (this)
     - type: url
       target: https://github.com/backstage/demo/blob/master/catalog-info.yaml


### PR DESCRIPTION
Starting up the demo site yields this error in the browser:

```
ENOENT: no such file or directory, stat '/Users/timbonicush/Source/backstage-demo/packages/app/dist/index.html'
```

This seems to be due to the frontend and backend having the same port in the `app-config.yaml`. This changes the local frontend port to start up successfully. Or is there some method to run this without this change that I'm missing?