### PR TITLE
Fix back button on demo home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "jest": {
     "transformModules": [
-      "@kyma-project/asyncapi-react"
+      "@asyncapi/react-component"
     ]
   }
 }

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -4,18 +4,21 @@ import App from './App';
 
 describe('App', () => {
   it('should render', async () => {
-    Object.defineProperty(process.env, 'APP_CONFIG', {
-      configurable: true,
-      value: [
+    process.env = {
+      NODE_ENV: 'test',
+      APP_CONFIG: [
         {
           data: {
             app: { title: 'Test' },
             backend: { baseUrl: 'http://localhost:7000' },
+            techdocs: {
+              storageUrl: 'http://localhost:7000/api/techdocs/static/docs',
+            },
           },
           context: 'test',
         },
-      ],
-    });
+      ] as any,
+    };
 
     const rendered = await renderWithEffects(<App />);
     expect(rendered.baseElement).toBeInTheDocument();

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -43,7 +43,7 @@ const AppRouter = app.getRouter();
 
 const routes = (
   <FlatRoutes>
-    <Navigate key="/" to="/catalog" />
+    <Navigate key="/" to="/catalog" replace />
     <Route path="/api-docs" element={<ApiExplorerPage />} />
     <Route path="/catalog" element={<CatalogIndexPage />} />
     <Route


### PR DESCRIPTION
Fixes #28

Adds `replace` to the `/` -> `/catalog` redirect so the back button works. I ran `App.test.tsx` and discovered it was out of date; updated from the `create-app` template.