### PR TITLE
Constrain size of entity graph

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -147,7 +147,7 @@ const overviewContent = (
     </Grid>
 
     <Grid item md={6} xs={12}>
-      <EntityCatalogGraphCard variant="gridItem" />
+      <EntityCatalogGraphCard variant="gridItem" height={400} />
     </Grid>
 
     <Grid item xs={12} md={4} sm={6}>


### PR DESCRIPTION
The entity graphs are appearing a bit tall, this adds the same height constraint the main repo uses.