### PR TITLE
Prevent all indexing/crawling

### DIFF
--- a/packages/app/public/robots.txt
+++ b/packages/app/public/robots.txt
@@ -1,2 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
+Disallow: /


### PR DESCRIPTION
I just did a google search for some Backstage documentation and the demo site's copy of the documentation in TechDocs ended up ranking higher than the documentation site itself. 🤷‍♂️ 

Let's...  Not allow that!