### PR TITLE
Added version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -95,7 +95,7 @@ jobs:
         if: ${{ steps.check_for_changes.outputs.HAS_CHANGES == 1 }}
         uses: actions/github-script@v6
         with:
-          github-token: ${{secrets.VERSION_BUMP_TOKEN}}
+          github-token: ${{secrets.GH_SERVICE_ACCOUNT_TOKEN}}
           script: |
             await github.rest.pulls.create({
               title: 'v${{ steps.set_release_name.outputs.release_version }} version bump',

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,12 +19,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  RELEASE_NAME: ''
-  HAS_CHANGES: ''
-  CURRENT_VERSION: ''
-  RELEASE_VERSION: ''
-
 jobs:
   version-bump:
     runs-on: ubuntu-latest
@@ -35,10 +29,10 @@ jobs:
           fetch-depth: 1
 
       # Beginning of yarn setup
-      - name: use node.js 14.x
+      - name: use node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: https://registry.npmjs.org/ # Needed for auth
       - name: cache all node_modules
         id: cache-modules
@@ -63,76 +57,59 @@ jobs:
       # End of yarn setup
 
       - name: 'Set release name'
-        shell: pwsh
-        run: |
-          $backstageJson = Get-Content 'backstage.json' | Out-String | ConvertFrom-Json
-          $latestBackstageRelease = Invoke-RestMethod 'https://api.github.com/repos/backstage/backstage/releases/latest'
-
-          $backstageReleases = Invoke-RestMethod 'https://api.github.com/repos/backstage/backstage/releases'
-          $preReleases = $backstageReleases | Where-Object -FilterScript { $_.prerelease -eq 'true'} | Sort-Object -Descending { $_.published_at -as [datetime] }
-
-          Write-Host "Current Backstage version is: v$($backstageJson.Version)"
-          Write-Host "Latest Release version is: $($latestBackstageRelease.name), published on: $($latestBackstageRelease.published_at)"
-          Write-Host "Latest Pre-Release version is $($preReleases[0].name), published on: $($preReleases[0].published_at)"
-
-          if ($($latestBackstageRelease.published_at) -gt $($preReleases[0].published_at)){
-            Write-Host "Latest Release is newer than latest Pre-Release, using Latest Release name $($latestBackstageRelease.name)"
-            echo "RELEASE_NAME=$($latestBackstageRelease.name)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            echo "RELEASE_VERSION=$($latestBackstageRelease.name.substring(1))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-          }
-          else{
-            Write-Host "Latest Release is older than latest Pre-Release, using Latest Pre-Release name $($preReleases[0].name)"
-            echo "RELEASE_NAME=$($preReleases[0].name)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-            echo "RELEASE_VERSION=$($preReleases[0].name.substring(1))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-          }
-
-          echo "CURRENT_VERSION=$($backstageJson.Version)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+        id: set_release_name
+        run: node scripts/set-release-name.js
       - name: 'Configure git'
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
       - name: 'Create topic branch'
         run: |
-          echo "$GITHUB_WORKSPACE"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git branch -D topic/${{ env.RELEASE_NAME }} &>/dev/null
-          git checkout -b topic/${{ env.RELEASE_NAME }}
-      - name: 'Run yarn install command'
-        run: yarn install --ignore-scripts --prefer-offline --frozen-lockfile
-      - name: 'Run backstage-cli versions:bump --release ${{ inputs.release_line }} command'
-        run: yarn backstage-cli versions:bump --release ${{ inputs.release_line }}
+          BRANCH=$(git branch --list topic/v${{ steps.set_release_name.outputs.release_version }})
+          if [ ! -z "$BRANCH" ]; then
+              git branch -D topic/v${{ steps.set_release_name.outputs.release_version }}
+          fi
+          git checkout -b topic/v${{ steps.set_release_name.outputs.release_version }}
+      - name: Run backstage-cli versions:bump --release ${{ inputs.release_line || 'next' }} command
+        run: yarn backstage-cli versions:bump --release ${{ inputs.release_line || 'next' }}
       - name: 'Check for changes'
-        shell: pwsh
+        id: check_for_changes
         run: |
-          $result = git diff
-          $result = if ($result) {'1'} else {'0'}
-          echo "HAS_CHANGES=$result" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          CHANGES=$(git status --porcelain)
+          if [ -z "$CHANGES" ]; then
+              echo "No changes"
+              echo "HAS_CHANGES=0" >> $GITHUB_OUTPUT
+          else
+              echo "Has changes"
+              echo "HAS_CHANGES=1" >> $GITHUB_OUTPUT
+          fi
       - name: 'Commit changes'
-        if: ${{ env.HAS_CHANGES == 1 }}
+        if: ${{ steps.check_for_changes.outputs.HAS_CHANGES == 1 }}
         run: |
           git status
           git add -A -- :!.npmrc
-          git commit -m "${{ env.RELEASE_NAME }} version bump"
-          git push origin topic/${{ env.RELEASE_NAME }}
+          git commit -m "v${{ steps.set_release_name.outputs.release_version }} version bump"
+          git push origin topic/v${{ steps.set_release_name.outputs.release_version }}
       - name: 'Create Pull Request'
-        if: ${{ env.HAS_CHANGES == 1 }}
+        if: ${{ steps.check_for_changes.outputs.HAS_CHANGES == 1 }}
         uses: actions/github-script@v6
         with:
           github-token: ${{secrets.VERSION_BUMP_TOKEN}}
           script: |
             await github.rest.pulls.create({
-              title: '${{ env.RELEASE_NAME }} version bump',
+              title: 'v${{ steps.set_release_name.outputs.release_version }} version bump',
               owner: context.repo.owner,
               repo: context.repo.repo,
-              head: 'topic/${{ env.RELEASE_NAME }}',
+              head: 'topic/v${{ steps.set_release_name.outputs.release_version }}',
               base: 'main',
               body: [
-                'Backstage release ${{ env.RELEASE_NAME }} has been published, this Pull Request contains the changes to upgrade to this new release',
+                'Backstage release v${{ steps.set_release_name.outputs.release_version }} has been published, this Pull Request contains the changes to upgrade to this new release',
                 ' ',
                 'Please review the changelog before approving, there may be manual changes needed to enable new features:',
                 ' ',
-                '- Changelog: [${{ env.RELEASE_NAME }}](https://github.com/backstage/backstage/blob/master/docs/releases/${{ env.RELEASE_NAME }}-changelog.md)',
-                '- Upgrade Helper: [From ${{ env.CURRENT_VERSION }} to ${{ env.RELEASE_VERSION }}](https://backstage.github.io/upgrade-helper/?from=${{ env.CURRENT_VERSION }}&to=${{ env.RELEASE_VERSION }})',
+                '- Changelog: [v${{ steps.set_release_name.outputs.release_version }}](https://github.com/backstage/backstage/blob/master/docs/releases/v${{ steps.set_release_name.outputs.release_version }}-changelog.md)',
+                '- Upgrade Helper: [From ${{ steps.set_release_name.outputs.CURRENT_VERSION }} to ${{ steps.set_release_name.outputs.release_version }}](https://backstage.github.io/upgrade-helper/?from=${{ steps.set_release_name.outputs.CURRENT_VERSION }}&to=${{ steps.set_release_name.outputs.release_version }})',
                 ' ',
                 'Created by [Version Bump ${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})',
                 ' '

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,140 @@
+name: 'Version Bump'
+on:
+  workflow_dispatch:
+    inputs:
+      release_line:
+        description: 'Release Line'
+        required: true
+        default: next
+        type: choice
+        options:
+        - next
+        - main
+  
+  # Run Weekly on Wednesday at 10:00 UTC time
+  schedule:
+    - cron: "0 10 * * 3"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  RELEASE_NAME: ''
+  HAS_CHANGES: ''
+  CURRENT_VERSION: ''
+  RELEASE_VERSION: ''
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout backstage'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      # Beginning of yarn setup
+      - name: use node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+      - name: cache all node_modules
+        id: cache-modules
+        uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock', '**/package.json') }}
+      - name: find location of global yarn cache
+        id: yarn-cache
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: cache global yarn cache
+        uses: actions/cache@v2
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: yarn install
+        run: yarn install --frozen-lockfile
+      # End of yarn setup
+
+      - name: 'Set release name'
+        shell: pwsh
+        run: |
+          $backstageJson = Get-Content 'backstage.json' | Out-String | ConvertFrom-Json
+          $latestBackstageRelease = Invoke-RestMethod 'https://api.github.com/repos/backstage/backstage/releases/latest'
+
+          $backstageReleases = Invoke-RestMethod 'https://api.github.com/repos/backstage/backstage/releases'
+          $preReleases = $backstageReleases | Where-Object -FilterScript { $_.prerelease -eq 'true'} | Sort-Object -Descending { $_.published_at -as [datetime] }
+
+          Write-Host "Current Backstage version is: v$($backstageJson.Version)"
+          Write-Host "Latest Release version is: $($latestBackstageRelease.name), published on: $($latestBackstageRelease.published_at)"
+          Write-Host "Latest Pre-Release version is $($preReleases[0].name), published on: $($preReleases[0].published_at)"
+
+          if ($($latestBackstageRelease.published_at) -gt $($preReleases[0].published_at)){
+            Write-Host "Latest Release is newer than latest Pre-Release, using Latest Release name $($latestBackstageRelease.name)"
+            echo "RELEASE_NAME=$($latestBackstageRelease.name)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            echo "RELEASE_VERSION=$($latestBackstageRelease.name.substring(1))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          }
+          else{
+            Write-Host "Latest Release is older than latest Pre-Release, using Latest Pre-Release name $($preReleases[0].name)"
+            echo "RELEASE_NAME=$($preReleases[0].name)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+            echo "RELEASE_VERSION=$($preReleases[0].name.substring(1))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          }
+
+          echo "CURRENT_VERSION=$($backstageJson.Version)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+      - name: 'Configure git'
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+      - name: 'Create topic branch'
+        run: |
+          echo "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git branch -D topic/${{ env.RELEASE_NAME }} &>/dev/null
+          git checkout -b topic/${{ env.RELEASE_NAME }}
+      - name: 'Run yarn install command'
+        run: yarn install --ignore-scripts --prefer-offline --frozen-lockfile
+      - name: 'Run backstage-cli versions:bump --release ${{ inputs.release_line }} command'
+        run: yarn backstage-cli versions:bump --release ${{ inputs.release_line }}
+      - name: 'Check for changes'
+        shell: pwsh
+        run: |
+          $result = git diff
+          $result = if ($result) {'1'} else {'0'}
+          echo "HAS_CHANGES=$result" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+      - name: 'Commit changes'
+        if: ${{ env.HAS_CHANGES == 1 }}
+        run: |
+          git status
+          git add -A -- :!.npmrc
+          git commit -m "${{ env.RELEASE_NAME }} version bump"
+          git push origin topic/${{ env.RELEASE_NAME }}
+      - name: 'Create Pull Request'
+        if: ${{ env.HAS_CHANGES == 1 }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.VERSION_BUMP_TOKEN}}
+          script: |
+            await github.rest.pulls.create({
+              title: '${{ env.RELEASE_NAME }} version bump',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: 'topic/${{ env.RELEASE_NAME }}',
+              base: 'main',
+              body: [
+                'Backstage release ${{ env.RELEASE_NAME }} has been published, this Pull Request contains the changes to upgrade to this new release',
+                ' ',
+                'Please review the changelog before approving, there may be manual changes needed to enable new features:',
+                ' ',
+                '- Changelog: [${{ env.RELEASE_NAME }}](https://github.com/backstage/backstage/blob/master/docs/releases/${{ env.RELEASE_NAME }}-changelog.md)',
+                '- Upgrade Helper: [From ${{ env.CURRENT_VERSION }} to ${{ env.RELEASE_VERSION }}](https://backstage.github.io/upgrade-helper/?from=${{ env.CURRENT_VERSION }}&to=${{ env.RELEASE_VERSION }})',
+                ' ',
+                'Created by [Version Bump ${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})',
+                ' '
+              ].join('\n')
+            });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@spotify/prettier-config": "^7.0.0",
     "concurrently": "^6.0.0",
     "lerna": "^3.20.2",
+    "node-fetch": "^2.6.7",
     "prettier": "^2.3.2",
     "typescript": "^4.5.5"
   },

--- a/scripts/.eslintrc.js
+++ b/scripts/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint')],
+  rules: {
+    'no-console': 0,
+  },
+};

--- a/scripts/set-release-name.js
+++ b/scripts/set-release-name.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+const fs = require('fs-extra');
+const fetch = require('node-fetch')
+
+async function getBackstageVersion() {
+  const rootPath = path.resolve(__dirname, '../backstage.json');
+  return fs.readJson(rootPath).then(_ => _.version);
+}
+
+async function getLatestRelease() {
+  const response = await fetch('https://api.github.com/repos/backstage/backstage/releases/latest')
+  const json = await response.json();
+  return json
+}
+
+async function getLatestPreRelease() {
+  const response = await fetch('https://api.github.com/repos/backstage/backstage/releases')
+  const json = await response.json();
+
+  const preReleasesOnly = json.filter(release => {
+    return release.prerelease === true
+  })
+  
+  const latestPreRelease = preReleasesOnly.sort((a,b) => {return new Date(b.published_at) - new Date(a.published_at)})[0];
+
+  return latestPreRelease
+}
+
+async function main() {
+  
+  // Get the current Backstage version from the backstage.json file
+  const backstageVersion = await getBackstageVersion()
+  // Get the latest Backstage Release from the GitHub API
+  const latestRelease = await getLatestRelease()
+  // Get the latest Backstage Pre-release from the GitHub API
+  const latestPreRelease = await getLatestPreRelease()
+
+  console.log(`Current Backstage version is: v${backstageVersion}`)
+  console.log(`Latest Release version is: ${latestRelease.name}, published on: ${latestRelease.published_at}`)
+  console.log(`Latest Pre-release version is: ${latestPreRelease.name}, published on: ${latestPreRelease.published_at}`)
+  console.log()
+
+  if (Date(latestRelease.published_at) > Date(latestPreRelease.published_at)){
+    console.log(`Latest Release is newer than latest Pre-release, using Latest Release name ${latestRelease.name}`)
+    console.log()
+    // TODO: Update this with whatever the solution is in: https://github.com/backstage/backstage/pull/14376
+    console.log(`::set-output name=release_version::${latestRelease.name.substring(1)}`)
+  }
+  else {
+    console.log(`Latest Release is older than latest Pre-release, using Latest Pre-release name ${latestPreRelease.name}`)
+    console.log()
+    // TODO: Update this with whatever the solution is in: https://github.com/backstage/backstage/pull/14376
+    console.log(`::set-output name=release_version::${latestPreRelease.name.substring(1)}`)
+  }
+}
+
+main().catch(error => {
+  console.error(error.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

## Hey, I just made a Pull Request!

Added a new action/workflow that automates the version bump process to keep the demo site up to date and can also be used as an example for the large Backstage Community.

When this action/workflow runs it will run the `yarn backstage-cli versions:bump` command which will upgrade all the packages as needed and then create a Pull Request with the changes. The PR description will include the new version and links to the release's Changelog and to the Upgrade Helper with current and new version set. There is also a link to the action/workflow that created the PR. 

Finally a GitHub PAT will need to be provided as this will allow the new version-bump workflow/action to trigger the related CI build to validate the changes. This needs to be added as secret with the name `VERSION_BUMP_TOKEN` and will need "Full control of private repositories" access, but this might be adjusted as I haven't fully tested reduced access

Here's a screen shot of the Pull Request:

![Screen Shot 2022-09-02 at 12 53 58 PM](https://user-images.githubusercontent.com/67169551/188215605-ce43a1bf-6d28-4d6b-9545-4a25d80b336e.png)

Closes #63 