### PR TITLE
Fixed bug in set-release-name.js

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -109,7 +109,7 @@ jobs:
                 'Please review the changelog before approving, there may be manual changes needed to enable new features:',
                 ' ',
                 '- Changelog: [v${{ steps.set_release_name.outputs.release_version }}](https://github.com/backstage/backstage/blob/master/docs/releases/v${{ steps.set_release_name.outputs.release_version }}-changelog.md)',
-                '- Upgrade Helper: [From ${{ steps.set_release_name.outputs.CURRENT_VERSION }} to ${{ steps.set_release_name.outputs.release_version }}](https://backstage.github.io/upgrade-helper/?from=${{ steps.set_release_name.outputs.CURRENT_VERSION }}&to=${{ steps.set_release_name.outputs.release_version }})',
+                '- Upgrade Helper: [From ${{ steps.set_release_name.outputs.current_version }} to ${{ steps.set_release_name.outputs.release_version }}](https://backstage.github.io/upgrade-helper/?from=${{ steps.set_release_name.outputs.current_version }}&to=${{ steps.set_release_name.outputs.release_version }})',
                 ' ',
                 'Created by [Version Bump ${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})',
                 ' '

--- a/scripts/set-release-name.js
+++ b/scripts/set-release-name.js
@@ -42,7 +42,9 @@ async function main() {
   console.log(`Latest Pre-release version is: ${latestPreRelease.name}, published on: ${latestPreRelease.published_at}`)
   console.log()
 
-  if (Date(latestRelease.published_at) > Date(latestPreRelease.published_at)){
+  const latestReleaseDate = new Date(latestRelease.published_at).getTime()
+  const latestPreReleaseDate = new Date(latestPreRelease.published_at).getTime()
+  if (latestReleaseDate > latestPreReleaseDate){
     console.log(`Latest Release is newer than latest Pre-release, using Latest Release name ${latestRelease.name}`)
     console.log()
     // TODO: Update this with whatever the solution is in: https://github.com/backstage/backstage/pull/14376
@@ -54,6 +56,9 @@ async function main() {
     // TODO: Update this with whatever the solution is in: https://github.com/backstage/backstage/pull/14376
     console.log(`::set-output name=release_version::${latestPreRelease.name.substring(1)}`)
   }
+
+  // TODO: Update this with whatever the solution is in: https://github.com/backstage/backstage/pull/14376
+  console.log(`::set-output name=current_version::${backstageVersion}`)
 }
 
 main().catch(error => {


### PR DESCRIPTION
Found two bugs:

- The release date logic was always false so you'd end up with a pre-release version
- The `current_version` variable wasn't being set so we ended up with some blanks in the PR description and the link would not work

This PR fixed both of these bugs