### PR TITLE
Corrected base when creating pull request

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -102,7 +102,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               head: 'topic/v${{ steps.set_release_name.outputs.release_version }}',
-              base: 'main',
+              base: 'master',
               body: [
                 'Backstage release v${{ steps.set_release_name.outputs.release_version }} has been published, this Pull Request contains the changes to upgrade to this new release',
                 ' ',


### PR DESCRIPTION
This should fix the issue we are seeing where the `version-bump` action/workflow is failing when it tries to create the Pull Request. This was working where I was testing as we use `main` instead of `master`. Totally overlooked that :(