### PR TITLE
Added Discord notification for new release only

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,3 +67,17 @@ jobs:
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: heroku container:release -a ${{ secrets.HEROKU_APP_NAME }} web
+
+      # Post notification to Discord Announcements channel  
+      - name: 'Check if last commit is a release'
+        id: check_if_release
+        run: node scripts/check-if-release.js ${{ github.sha }} 
+      
+      - name: Discord notification
+        uses: Ilshidur/action-discord@0.3.2
+        if: steps.check_if_release.outputs.is_release === 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          CURRENT_VERSION: ${{ steps.check_if_release.outputs.current_version }}
+        with:
+          args: 'The Backstage Demo site has been upgraded to release {{CURRENT_VERSION}} go check it out: https://demo.backstage.io'  

--- a/scripts/check-if-release.js
+++ b/scripts/check-if-release.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/* eslint-disable import/no-extraneous-dependencies */
+const path = require('path');
+const fs = require('fs-extra');
+const fetch = require('node-fetch');
+const { EOL } = require('os');
+
+async function getBackstageVersion() {
+  const rootPath = path.resolve(__dirname, '../backstage.json');
+  return fs.readJson(rootPath).then(_ => _.version);
+}
+
+async function main() {
+  const [script, commitSha] = process.argv.slice(1);
+  if (!commitSha) {
+    throw new Error(`Argument must be ${script} <commit-sha>`);
+  }
+
+  // Check to see if commit has changes to the backstage.json file
+  const response = await fetch(
+    `https://api.github.com/repos/backstage/demo/commits/${commitSha}`,
+  );
+
+  if (!response.ok) {
+    console.log(
+      `Response from GitHub API for commit ${commitSha} failed with status ${response.status}`,
+    );
+    await fs.appendFile(process.env.GITHUB_OUTPUT, `is_release='false'${EOL}`);
+    return;
+  }
+
+  const json = await response.json();
+  const files = json.files;
+
+  if (!files) {
+    await fs.appendFile(process.env.GITHUB_OUTPUT, `is_release='false'${EOL}`);
+    return;
+  }
+
+  const isRelease = files.some(file => file.filename === 'backstage.json');
+  console.log(isRelease);
+  await fs.appendFile(
+    process.env.GITHUB_OUTPUT,
+    `is_release=${isRelease}${EOL}`,
+  );
+
+  // Get the current Backstage version from the backstage.json file
+  if (isRelease) {
+    const backstageVersion = await getBackstageVersion();
+    await fs.appendFile(
+      process.env.GITHUB_OUTPUT,
+      `current_version=${backstageVersion}${EOL}`,
+    );
+  }
+}
+
+main().catch(error => {
+  console.error(error.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
Signed-off-by: Andre Wanlin <67169551+awanlin@users.noreply.github.com>

This will create a notification in the Discord Announcements channel when the Demo site is upgraded. To limit this to just upgrades we check to see if the commit has changes to the `backstage.json` file.

**Note:** One of the Backstage Maintainers will need to setup the `DISCORD_RELEASE_WEBHOOK` secret.