### PR TITLE
Disable immutable install

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -72,9 +72,9 @@ jobs:
           fi
           git checkout -b topic/v${{ steps.set_release_name.outputs.release_version }}
       - name: Run backstage-cli versions:bump --release ${{ inputs.release_line || 'next' }} command
-        run: |
-          export YARN_ENABLE_IMMUTABLE_INSTALLS=false 
-          yarn backstage-cli versions:bump --release ${{ inputs.release_line || 'next' }}
+        run: yarn backstage-cli versions:bump --release ${{ inputs.release_line || 'next' }}
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
       - name: 'Check for changes'
         id: check_for_changes
         run: |

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -72,7 +72,9 @@ jobs:
           fi
           git checkout -b topic/v${{ steps.set_release_name.outputs.release_version }}
       - name: Run backstage-cli versions:bump --release ${{ inputs.release_line || 'next' }} command
-        run: yarn backstage-cli versions:bump --release ${{ inputs.release_line || 'next' }}
+        run: |
+          export YARN_ENABLE_IMMUTABLE_INSTALLS=false 
+          yarn backstage-cli versions:bump --release ${{ inputs.release_line || 'next' }}
       - name: 'Check for changes'
         id: check_for_changes
         run: |


### PR DESCRIPTION
This disables the immutable install for the version bump workflow as by its very nature it will cause changes to the `yarn.lock` file. This is done by setting the `YARN_ENABLE_IMMUTABLE_INSTALLS` environment variable.