### PR TITLE
Updated to show Catalog Graph on API Kind

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -271,7 +271,10 @@ const apiPage = (
       <Grid container spacing={3}>
         {entityWarningContent}
         <Grid item xs={12} md={6}>
-          <EntityAboutCard />
+          <EntityAboutCard variant="gridItem" />
+        </Grid>
+        <Grid item md={6} xs={12}>
+          <EntityCatalogGraphCard variant="gridItem" height={400} />
         </Grid>
         <Grid container item md={12}>
           <Grid item xs={12} md={6}>


### PR DESCRIPTION
Added the `EntityCatalogGraphCard` component to the API Kind view in the catalog and set the `EntityAboutCard` variant prop to `gridItem` so it looked nice

| Before  | After  |  
|---|---|
| ![Screenshot 2023-06-18 at 11 32 32 AM](https://github.com/backstage/demo/assets/67169551/9fdd03dc-9590-40db-b70b-2f40b42e3fd4)  | ![Screenshot 2023-06-18 at 11 32 05 AM](https://github.com/backstage/demo/assets/67169551/88cb9a9a-80a3-4b36-b0d6-e93f3f56a3c2)  | 


