### PR TITLE
[Fix] Use MUI v4 `CssBaseline` to fix global styling 

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -38,6 +38,7 @@ import { createApp } from '@backstage/app-defaults';
 import { entityPage } from './components/catalog/EntityPage';
 import { orgPlugin } from '@backstage/plugin-org';
 import { searchPage } from './components/search/SearchPage';
+import { CssBaseline } from '@material-ui/core';
 
 const app = createApp({
   apis,
@@ -75,7 +76,10 @@ const app = createApp({
       title: 'Aperture',
       variant: 'light',
       Provider: ({ children }) => (
-        <UnifiedThemeProvider theme={apertureTheme} children={children} />
+        <UnifiedThemeProvider theme={apertureTheme} noCssBaseline>
+          <CssBaseline />
+          {children}
+        </UnifiedThemeProvider>
       ),
     },
   ],


### PR DESCRIPTION
| Before (demo.backstage.io) | After (local dev) |
|:---:|:---:|
| [<img width="1055" alt="Screenshot 2023-06-29 at 18 51 42" src="https://github.com/backstage/demo/assets/8904624/932df59d-2f02-4a8b-a774-8418b16d3744">](https://github.com/backstage/backstage/pull/18495) | <img width="1059" alt="Screenshot 2023-06-29 at 18 51 26" src="https://github.com/backstage/demo/assets/8904624/e2979488-04d0-4b8f-8ba3-c8f744a3eec0">|

**Issue:**
- `a` tag adapts native Browser styles as `text-decoration` is not overwritten
- Slight changes in `font-size` etc. 

Relates to https://github.com/backstage/backstage/pull/18495 & is a temporary fix until the PR is merged & shipped.