### PR TITLE
Resolved set-output warning in Workflows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,7 +30,7 @@ jobs:
       - name: find location of global yarn cache
         id: yarn-cache
         if: steps.cache-modules.outputs.cache-hit != 'true'
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - name: cache global yarn cache
         uses: actions/cache@v3
         if: steps.cache-modules.outputs.cache-hit != 'true'

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -29,7 +29,7 @@ jobs:
       - name: find location of global yarn cache
         id: yarn-cache
         if: steps.cache-modules.outputs.cache-hit != 'true'
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - name: cache global yarn cache
         uses: actions/cache@v3
         if: steps.cache-modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR resolves the warnings in the Workflows by using the new environment files as per the GitHub [documentation on this topic](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).