### PR TITLE
Workflow to publish Backstage TechDocs

### DIFF
--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -1,0 +1,44 @@
+name: 'Publish Backstage TechDocs'
+
+on:
+  workflow_dispatch:
+
+  # Run Daily at 10:00 UTC time
+  schedule:
+    - cron: "0 10 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-techdocs-site:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Backstage
+        uses: actions/checkout@v3
+        with:
+          repository: backstage/backstage
+          fetch-depth: 1
+
+      - name: use node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          registry-url: https://registry.npmjs.org/ # Needed for auth
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install techdocs-cli
+        run: sudo npm install -g @techdocs/cli
+
+      - name: Install mkdocs and mkdocs plugins
+        run: python -m pip install mkdocs-techdocs-core==1.*
+
+      - name: Generate docs site
+        run: techdocs-cli generate --no-docker --verbose
+
+      - name: Publish docs site
+        run: techdocs-cli publish --publisher-type googleGcs --storage-name ${{ secrets.TECHDOCS_GCS_BUCKET }} --entity default/component/backstage

--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -5,7 +5,7 @@ on:
 
   # Run Daily at 10:00 UTC time
   schedule:
-    - cron: "0 10 * * *"
+    - cron: '0 10 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR adds a workflow that runs daily at 10:00am UTC to publish the Backstage TechDocs to the GCS bucket and then can be displayed in the Demo site.

Currently this is not happening and the content is very stale. Keeping this up to date will provide a better "demo", give us a place to validate releases, and stay in sync with the actual documentation.

**Note:** I will need some support with this as I don't have access to the needed secret or anything on the GCS side