### PR TITLE
chore: minor GraphQL related updates

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -34,7 +34,7 @@ backend:
     connection: ':memory:'
   reading:
     allow:
-      - host: https://demo.backstage.io
+      - host: demo.backstage.io
         paths:
           - /api/graphql/schema
 
@@ -87,10 +87,6 @@ catalog:
     # The backstage library repository
     - type: url
       target: https://github.com/backstage/backstage/blob/master/catalog-info.yaml
-
-    # The demo site
-    - type: url
-      target: https://github.com/backstage/demo/blob/master/catalog-info.yaml
 
 costInsights:
   engineerCost: 200000

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -89,7 +89,7 @@ const routes = (
   <FlatRoutes>
     <Navigate key="/" to="catalog" replace />
     <Route path="/api-docs" element={<ApiExplorerPage />} />
-    <Route path="/catalog" element={<CatalogIndexPage />} />
+    <Route path="/catalog" element={<CatalogIndexPage initiallySelectedFilter='all' />} />
     <Route
       path="/catalog/:namespace/:kind/:name"
       element={<CatalogEntityPage />}


### PR DESCRIPTION
This PR contains some minor GraphQL related updates:

- Removed the `https://` from the `reading.allow.host` for `demo.backstage.io`
- Set the `initiallySelectedFilter` to `all` for the Catalog so that users see all the items in the catalog making it easier to see all the examples/content

CC @taras 