### PR TITLE
Minor corrects for TechDocs examples

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -32,6 +32,8 @@ backend:
         'https://img.shields.io/',
         'https://api.dicebear.com/',
         'https://kroki.io/',
+        'https://bestpractices.coreinfrastructure.org',
+        'https://api.securityscorecards.dev',
       ]
     frame-src: ['https://www.youtube.com']
   cors:
@@ -89,9 +91,9 @@ catalog:
     - type: url
       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-resources.yaml
 
-    # # The backstage demo deployment (this)
-    # - type: url
-    #   target: https://github.com/backstage/demo/blob/master/catalog-info.yaml
+    # The backstage demo deployment (this)
+    - type: url
+      target: https://github.com/backstage/demo/blob/master/catalog-info.yaml
 
     # The backstage library repository
     - type: url


### PR DESCRIPTION
This adds back the import of the `backstage-demo` entity, this was removed during testing and not added back by mistake. This also adds a few more CSP rules