### PR TITLE
Cleaned up search results page

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,6 +17,7 @@
     "@backstage/plugin-badges": "^0.2.53",
     "@backstage/plugin-catalog": "^1.16.1",
     "@backstage/plugin-catalog-graph": "^0.3.3",
+    "@backstage/plugin-catalog-react": "^1.9.3",
     "@backstage/plugin-cost-insights": "^0.12.18",
     "@backstage/plugin-explore": "^0.4.15",
     "@backstage/plugin-github-actions": "^0.6.10",

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -48,7 +48,7 @@ const SearchPage = () => {
   const catalogApi = useApi(catalogApiRef);
   return (
     <Page themeId="home">
-      <Header title="Search" subtitle={<Lifecycle alpha />} />
+      <Header title="Search" />
       <Content>
         <Grid container direction="row">
           <Grid item xs={12}>

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -3,7 +3,6 @@ import {
   Content,
   DocsIcon,
   Header,
-  Lifecycle,
   Page,
 } from '@backstage/core-components';
 import { CatalogSearchResultListItem } from '@backstage/plugin-catalog';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11866,6 +11866,7 @@ __metadata:
     "@backstage/plugin-badges": ^0.2.53
     "@backstage/plugin-catalog": ^1.16.1
     "@backstage/plugin-catalog-graph": ^0.3.3
+    "@backstage/plugin-catalog-react": ^1.9.3
     "@backstage/plugin-cost-insights": ^0.12.18
     "@backstage/plugin-explore": ^0.4.15
     "@backstage/plugin-github-actions": ^0.6.10


### PR DESCRIPTION
Cleaned up the search results page. This more closely match what you get from `create-app` with just some minor adjustments to enable TechDocs and Explore search

|  Before | After  |  
|---|---|
| ![Screenshot 2024-01-20 at 10 55 10 AM](https://github.com/backstage/demo/assets/67169551/3846ebbd-dbeb-4967-a288-96009125e3ff)  |  ![Screenshot 2024-01-20 at 10 56 40 AM](https://github.com/backstage/demo/assets/67169551/e0b807c2-b7b0-4d80-8679-d3726b55b44d) |  


