### PR TITLE
Added Backstage entity provider

### DIFF
--- a/app-config.heroku.yaml
+++ b/app-config.heroku.yaml
@@ -47,3 +47,11 @@ kubernetes:
           authProvider: 'serviceAccount'
           caData: ${K8S_CA_DATA}
           serviceAccountToken: ${KUBERNETES_SERVICE_ACCOUNT_TOKEN}
+
+catalog:
+  providers:
+    backstage:
+      enabled: false
+      schedule:
+        frequency: { minutes: 360 } # runs every 6 hours
+        timeout: { minutes: 5 }

--- a/app-config.heroku.yaml
+++ b/app-config.heroku.yaml
@@ -53,5 +53,5 @@ catalog:
     backstage:
       enabled: false
       schedule:
-        frequency: { minutes: 360 } # runs every 6 hours
-        timeout: { minutes: 5 }
+        frequency: { hours: 12 }
+        timeout: { minutes: 30 }

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -109,13 +109,13 @@ catalog:
     - type: file
       target: ../../demo-template/template/template.yaml
       rules:
-        - allow: ['Template']   
+        - allow: ['Template']
   providers:
     backstage:
       enabled: false
       schedule:
-        frequency: { minutes: 360 } # runs every 6 hours
-        timeout: { minutes: 5 }
+        frequency: { hours: 12 }
+        timeout: { minutes: 30 }
 
 costInsights:
   engineerCost: 200000

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -110,6 +110,12 @@ catalog:
       target: ../../demo-template/template/template.yaml
       rules:
         - allow: ['Template']   
+  providers:
+    backstage:
+      enabled: false
+      schedule:
+        frequency: { minutes: 360 } # runs every 6 hours
+        timeout: { minutes: 5 }
 
 costInsights:
   engineerCost: 200000

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@3/schema.json",
-  "ignore": ["**/setupTests.ts", "**/.eslintrc.js"],
+  "ignore": ["**/setupTests.ts", "**/.eslintrc.js", "**/config.d.ts"],
   "ignoreDependencies": [
     "better-sqlite3",
     "app",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -47,7 +47,6 @@ import { HomepageCompositionRoot, VisitListener } from '@backstage/plugin-home';
 import { HomePage } from './components/home/HomePage';
 import { CustomizableHomePage } from './components/home/CustomizableHomePage';
 import { ScaffolderPage, scaffolderPlugin } from '@backstage/plugin-scaffolder';
-import { DefaultFilters } from '@backstage/plugin-catalog-react';
 
 const app = createApp({
   apis,
@@ -121,14 +120,8 @@ const routes = (
       path="/catalog"
       element={
         <CatalogIndexPage
-          filters={
-            <>
-              <DefaultFilters
-                initiallySelectedFilter="all"
-                initiallySelectedNamespaces={['default']}
-              />
-            </>
-          }
+          initiallySelectedFilter="all"
+          initiallySelectedNamespaces={['default']}
         />
       }
     />

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -47,6 +47,7 @@ import { HomepageCompositionRoot, VisitListener } from '@backstage/plugin-home';
 import { HomePage } from './components/home/HomePage';
 import { CustomizableHomePage } from './components/home/CustomizableHomePage';
 import { ScaffolderPage, scaffolderPlugin } from '@backstage/plugin-scaffolder';
+import { DefaultFilters } from '@backstage/plugin-catalog-react';
 
 const app = createApp({
   apis,
@@ -118,7 +119,18 @@ const routes = (
     <Route path="/api-docs" element={<ApiExplorerPage />} />
     <Route
       path="/catalog"
-      element={<CatalogIndexPage initiallySelectedFilter="all" />}
+      element={
+        <CatalogIndexPage
+          filters={
+            <>
+              <DefaultFilters
+                initiallySelectedFilter="all"
+                initiallySelectedNamespaces={['default']}
+              />
+            </>
+          }
+        />
+      }
     />
     <Route
       path="/catalog/:namespace/:kind/:name"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -38,8 +38,8 @@
     "@backstage/plugin-todo-backend": "^0.3.16-next.1",
     "@frontside/backstage-plugin-graphql-backend": "^0.1.2",
     "@frontside/backstage-plugin-graphql-backend-module-catalog": "^0.3.0",
-    "@internal/backstage-plugin-scaffolder-backend-module-github-pages": "workspace:^",
-    "@internal/plugin-catalog-backend-module-backstage": "^0.1.0",
+    "@internal/plugin-catalog-backend-module-backstage": "workspace:^",
+    "@internal/plugin-scaffolder-backend-module-github-pages": "workspace:^",
     "app": "^0.0.0",
     "better-sqlite3": "^9.0.0"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -39,6 +39,7 @@
     "@frontside/backstage-plugin-graphql-backend": "^0.1.2",
     "@frontside/backstage-plugin-graphql-backend-module-catalog": "^0.3.0",
     "@internal/backstage-plugin-scaffolder-backend-module-github-pages": "workspace:^",
+    "@internal/plugin-catalog-backend-module-backstage": "^0.1.0",
     "app": "^0.0.0",
     "better-sqlite3": "^9.0.0"
   },

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -8,7 +8,7 @@ backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
 backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
 backend.add(import('@backstage/plugin-badges-backend'));
 backend.add(import('@backstage/plugin-catalog-backend/alpha'));
-backend.add(import('@internal/plugin-catalog-backend-module-backstage'))
+backend.add(import('@internal/plugin-catalog-backend-module-backstage'));
 backend.add(
   import('@backstage/plugin-catalog-backend-module-scaffolder-entity-model'),
 );
@@ -21,12 +21,13 @@ backend.add(import('@backstage/plugin-kubernetes-backend/alpha'));
 backend.add(import('@backstage/plugin-proxy-backend/alpha'));
 backend.add(import('@backstage/plugin-scaffolder-backend/alpha'));
 backend.add(import('@backstage/plugin-scaffolder-backend-module-github'));
-backend.add(import('@internal/backstage-plugin-scaffolder-backend-module-github-pages'));
+backend.add(import('@internal/plugin-scaffolder-backend-module-github-pages'));
 backend.add(import('@backstage/plugin-search-backend/alpha'));
 backend.add(import('@backstage/plugin-search-backend-module-catalog/alpha'));
 backend.add(import('@backstage/plugin-search-backend-module-explore/alpha'));
 
 // TODO:(awanlin) enable when issue causing crashes is resolved
+// https://github.com/backstage/backstage/issues/23047
 // backend.add(import('@backstage/plugin-search-backend-module-techdocs/alpha'));
 
 backend.add(import('@backstage/plugin-techdocs-backend/alpha'));

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -8,6 +8,7 @@ backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
 backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
 backend.add(import('@backstage/plugin-badges-backend'));
 backend.add(import('@backstage/plugin-catalog-backend/alpha'));
+backend.add(import('@internal/plugin-catalog-backend-module-backstage'))
 backend.add(
   import('@backstage/plugin-catalog-backend-module-scaffolder-entity-model'),
 );

--- a/plugins/catalog-backend-module-backstage/.eslintrc.js
+++ b/plugins/catalog-backend-module-backstage/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/catalog-backend-module-backstage/README.md
+++ b/plugins/catalog-backend-module-backstage/README.md
@@ -1,0 +1,3 @@
+# @internal/plugin-catalog-backend-module-backstage
+
+This is the entity provider plugin that pulls in all the `catalog-info.yaml` files from the various repos in the Backstage GitHub Org

--- a/plugins/catalog-backend-module-backstage/config.d.ts
+++ b/plugins/catalog-backend-module-backstage/config.d.ts
@@ -1,0 +1,24 @@
+import { TaskScheduleDefinitionConfig } from '@backstage/backend-tasks';
+
+export interface Config {
+  catalog?: {
+    /**
+     * List of provider-specific options and attributes
+     */
+    providers?: {
+      /**
+       * BackstageEntityProvider configuration
+       */
+      backstage?: {
+        /**
+         * Flag to enable or disable the provider
+         */
+        enabled: boolean;
+        /**
+         * TaskScheduleDefinition for the refresh.
+         */
+        schedule: TaskScheduleDefinitionConfig;
+      };
+    };
+  };
+}

--- a/plugins/catalog-backend-module-backstage/package.json
+++ b/plugins/catalog-backend-module-backstage/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@internal/plugin-catalog-backend-module-backstage",
+  "description": "The backstage backend module for the catalog plugin.",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin-module"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/backend-common": "^0.21.7-next.0",
+    "@backstage/backend-plugin-api": "^0.6.17-next.0",
+    "@backstage/backend-tasks": "^0.5.22-next.0",
+    "@backstage/catalog-model": "^1.4.5",
+    "@backstage/config": "^1.2.0",
+    "@backstage/integration": "^1.10.0-next.0",
+    "@backstage/plugin-catalog-node": "^1.11.1-next.0",
+    "fs-extra": "^11.2.0",
+    "glob": "^10.3.10",
+    "lodash": "^4.17.21",
+    "node-fetch": "^2.6.7",
+    "uuid": "^8.0.0",
+    "winston": "^3.2.1",
+    "yaml": "^2.3.4"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.26.3-next.0",
+    "@types/fs-extra": "^11.0.4",
+    "@types/glob": "^8.1.0",
+    "@types/uuid": "^9.0.7"
+  },
+  "files": [
+    "dist",
+    "config.d.ts"
+  ],
+  "configSchema": "config.d.ts"
+}

--- a/plugins/catalog-backend-module-backstage/package.json
+++ b/plugins/catalog-backend-module-backstage/package.json
@@ -36,7 +36,6 @@
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
     "uuid": "^8.0.0",
-    "winston": "^3.2.1",
     "yaml": "^2.3.4"
   },
   "devDependencies": {

--- a/plugins/catalog-backend-module-backstage/package.json
+++ b/plugins/catalog-backend-module-backstage/package.json
@@ -24,13 +24,13 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/backend-common": "^0.21.7-next.0",
-    "@backstage/backend-plugin-api": "^0.6.17-next.0",
-    "@backstage/backend-tasks": "^0.5.22-next.0",
+    "@backstage/backend-common": "^0.21.7-next.1",
+    "@backstage/backend-plugin-api": "^0.6.17-next.1",
+    "@backstage/backend-tasks": "^0.5.22-next.1",
     "@backstage/catalog-model": "^1.4.5",
     "@backstage/config": "^1.2.0",
     "@backstage/integration": "^1.10.0-next.0",
-    "@backstage/plugin-catalog-node": "^1.11.1-next.0",
+    "@backstage/plugin-catalog-node": "^1.11.1-next.1",
     "fs-extra": "^11.2.0",
     "glob": "^10.3.10",
     "lodash": "^4.17.21",
@@ -40,7 +40,7 @@
     "yaml": "^2.3.4"
   },
   "devDependencies": {
-    "@backstage/cli": "^0.26.3-next.0",
+    "@backstage/cli": "^0.26.3-next.1",
     "@types/fs-extra": "^11.0.4",
     "@types/glob": "^8.1.0",
     "@types/uuid": "^9.0.7"

--- a/plugins/catalog-backend-module-backstage/src/constants.ts
+++ b/plugins/catalog-backend-module-backstage/src/constants.ts
@@ -1,0 +1,5 @@
+export const defaults = {
+  organization: 'backstage',
+  host: 'github.com',
+  namespace: 'backstage',
+} as const;

--- a/plugins/catalog-backend-module-backstage/src/index.ts
+++ b/plugins/catalog-backend-module-backstage/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * The backstage entity provider backend module for the catalog plugin.
+ *
+ * @packageDocumentation
+ */
+
+export { catalogModuleBackstageEntityProvider as default } from './module';
+export { BackstageEntityProvider } from './provider';

--- a/plugins/catalog-backend-module-backstage/src/module.ts
+++ b/plugins/catalog-backend-module-backstage/src/module.ts
@@ -2,7 +2,6 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
-import { loggerToWinstonLogger } from '@backstage/backend-common';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
 import { BackstageEntityProvider } from './provider/BackstageEntityProvider';
 
@@ -21,7 +20,7 @@ export const catalogModuleBackstageEntityProvider = createBackendModule({
       async init({ catalog, config, logger, scheduler, urlReader }) {
         catalog.addEntityProvider(
           BackstageEntityProvider.fromConfig(config, {
-            logger: loggerToWinstonLogger(logger),
+            logger: logger,
             urlReader,
             scheduler,
           }),

--- a/plugins/catalog-backend-module-backstage/src/module.ts
+++ b/plugins/catalog-backend-module-backstage/src/module.ts
@@ -1,0 +1,32 @@
+import {
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import { loggerToWinstonLogger } from '@backstage/backend-common';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import { BackstageEntityProvider } from './provider/BackstageEntityProvider';
+
+export const catalogModuleBackstageEntityProvider = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'backstage-entity-provider',
+  register(env) {
+    env.registerInit({
+      deps: {
+        catalog: catalogProcessingExtensionPoint,
+        config: coreServices.rootConfig,
+        logger: coreServices.logger,
+        scheduler: coreServices.scheduler,
+        urlReader: coreServices.urlReader,
+      },
+      async init({ catalog, config, logger, scheduler, urlReader }) {
+        catalog.addEntityProvider(
+          BackstageEntityProvider.fromConfig(config, {
+            logger: loggerToWinstonLogger(logger),
+            urlReader,
+            scheduler,
+          }),
+        );
+      },
+    });
+  },
+});

--- a/plugins/catalog-backend-module-backstage/src/provider/BackstageEntityProvider.ts
+++ b/plugins/catalog-backend-module-backstage/src/provider/BackstageEntityProvider.ts
@@ -1,0 +1,354 @@
+import {
+  PluginTaskScheduler,
+  TaskRunner,
+  readTaskScheduleDefinitionFromConfig,
+} from '@backstage/backend-tasks';
+import { Config } from '@backstage/config';
+import {
+  GithubCredentialsProvider,
+  ScmIntegrations,
+  GithubIntegrationConfig,
+  GithubIntegration,
+  SingleInstanceGithubCredentialsProvider,
+} from '@backstage/integration';
+import {
+  EntityProvider,
+  EntityProviderConnection,
+} from '@backstage/plugin-catalog-node';
+import lodash from 'lodash';
+import yaml from 'yaml';
+import fetch from 'node-fetch';
+import * as uuid from 'uuid';
+import { Logger } from 'winston';
+import { GithubRepository, PackageJson } from '../types';
+import { ComponentEntity, Entity } from '@backstage/catalog-model';
+import { UrlReader } from '@backstage/backend-common';
+import { sync as globSync } from 'glob';
+import fs from 'fs-extra';
+import path from 'path';
+import { defaults } from '../constants';
+
+export class BackstageEntityProvider implements EntityProvider {
+  private readonly logger: Logger;
+  private readonly integration: GithubIntegrationConfig;
+  private readonly urlReader: UrlReader;
+  private readonly scheduleFn: () => Promise<void>;
+  private connection?: EntityProviderConnection;
+  private readonly githubCredentialsProvider: GithubCredentialsProvider;
+  private readonly config: Config;
+
+  static fromConfig(
+    config: Config,
+    options: {
+      logger: Logger;
+      urlReader: UrlReader;
+      scheduler: PluginTaskScheduler;
+    },
+  ): BackstageEntityProvider {
+    const integrations = ScmIntegrations.fromConfig(config);
+    const integration = integrations.github.byHost(defaults.host);
+
+    if (!integration) {
+      throw new Error(
+        `There is no GitHub config that matches host ${defaults.host}. Please add a configuration entry for it under 'integrations.github'`,
+      );
+    }
+
+    const configSchedule = readTaskScheduleDefinitionFromConfig(
+      config.getConfig('catalog.providers.backstage.schedule'),
+    );
+
+    const taskRunner =
+      options.scheduler!.createScheduledTaskRunner(configSchedule);
+
+    return new BackstageEntityProvider(
+      integration,
+      options.logger,
+      taskRunner,
+      options.urlReader,
+      config,
+    );
+  }
+
+  private constructor(
+    integration: GithubIntegration,
+    logger: Logger,
+    taskRunner: TaskRunner,
+    urlReader: UrlReader,
+    config: Config,
+  ) {
+    this.integration = integration.config;
+    this.logger = logger.child({
+      target: this.getProviderName(),
+    });
+    this.urlReader = urlReader;
+    this.scheduleFn = this.createScheduleFn(taskRunner);
+    this.githubCredentialsProvider =
+      SingleInstanceGithubCredentialsProvider.create(integration.config);
+    this.config = config;
+  }
+
+  getProviderName(): string {
+    return `BackstageEntityProvider`;
+  }
+
+  async connect(connection: EntityProviderConnection): Promise<void> {
+    this.connection = connection;
+    return await this.scheduleFn();
+  }
+
+  private createScheduleFn(taskRunner: TaskRunner): () => Promise<void> {
+    return async () => {
+      const taskId = `${this.getProviderName()}:refresh`;
+      return taskRunner.run({
+        id: taskId,
+        fn: async () => {
+          const logger = this.logger.child({
+            class: BackstageEntityProvider.prototype.constructor.name,
+            taskId,
+            taskInstanceId: uuid.v4(),
+          });
+          try {
+            await this.refresh(logger);
+          } catch (error) {
+            logger.error(
+              `${this.getProviderName()} refresh failed, ${error}`,
+              error,
+            );
+          }
+        },
+      });
+    };
+  }
+
+  async refresh(logger: Logger) {
+    if (!this.connection) {
+      throw new Error('Not initialized');
+    }
+    const enabled = this.config.getBoolean(
+      'catalog.providers.backstage.enabled',
+    );
+    if (!enabled) {
+      logger.warn(
+        'Backstage entity provider is currently disabled via config, exiting',
+      );
+      return;
+    }
+
+    const entities: Entity[] = [];
+
+    const repositories = await this.getAllRepositories();
+
+    for (const repository of repositories) {
+      const readTreeResponse = await this.urlReader.readTree(
+        `https://github.com/backstage/${repository.name}`,
+      );
+
+      const fileDir = await readTreeResponse.dir();
+      const catalogInfoFiles = globSync(
+        [
+          'catalog-info.yaml',
+          'packages/*/catalog-info.yaml',
+          'plugins/*/catalog-info.yaml',
+        ],
+        { cwd: fileDir },
+      );
+
+      logger.info(
+        `Found ${catalogInfoFiles.length} catalog-info.yaml files in the '${repository.name}' repository`,
+      );
+
+      if (!catalogInfoFiles) {
+        // No catalog info files found, continue
+        logger.warn(
+          `No catalog-info.yaml file found in the '${repository.name}' repository, continuing`,
+        );
+        continue;
+      }
+
+      for (const catalogInfoFile of catalogInfoFiles) {
+        const catalogInfoDir = path.join(fileDir, catalogInfoFile);
+        const rawEntities = await this.parseEntityYaml(catalogInfoDir);
+        const cleanEntities = this.cleanUpRawEntities(
+          rawEntities,
+          repository,
+          catalogInfoFile,
+        );
+
+        const mappedEntities: Entity[] = [];
+        for (const cleanEntity of cleanEntities) {
+          switch (cleanEntity.kind) {
+            case 'Component': {
+              const mappedComponent = await this.componentMapper(
+                cleanEntity,
+                repository,
+                catalogInfoDir,
+              );
+              mappedEntities.push(mappedComponent);
+              break;
+            }
+
+            default:
+              mappedEntities.push(cleanEntity);
+          }
+        }
+
+        entities.push(...mappedEntities);
+      }
+
+      await fs.remove(fileDir);
+    }
+
+    if (entities.length > 0) {
+      logger.info(
+        `Attempting to apply mutations on ${
+          entities.length
+        } entities from the ${this.getProviderName()} provider`,
+      );
+      await this.connection.applyMutation({
+        type: 'full',
+        entities: entities.map(entity => ({
+          entity,
+          locationKey: this.getProviderName(),
+        })),
+      });
+    } else {
+      logger.warn(
+        'No Backstage entities discovered, mutation not being attempted this run',
+      );
+    }
+
+    logger.info(
+      `Completed refreshing entities for the ${this.getProviderName()} provider`,
+    );
+  }
+
+  private async getAllRepositories(): Promise<GithubRepository[]> {
+    const host = this.integration.host;
+    const orgUrl = `https://${host}/${defaults.organization}`;
+
+    const credentials = await this.githubCredentialsProvider.getCredentials({
+      url: orgUrl,
+    });
+
+    // TODO: (awanlin) - Default page size is 30, there are 22 repos ast of December 9, 2023
+    const ghApiUrl = `https://api.github.com/orgs/${defaults.organization}/repos`;
+    const response = await fetch(ghApiUrl, {
+      headers: {
+        ...credentials?.headers,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Unable to retrieve list of repositories from: '${ghApiUrl}'`,
+      );
+    }
+
+    const repositories = (await response.json()) as GithubRepository[];
+    return repositories;
+  }
+
+  private async parseEntityYaml(catalogInfoDir: string): Promise<Entity[]> {
+    let documents: yaml.Document.Parsed[];
+    const entities: Entity[] = [];
+    try {
+      const data = await fs.readFile(catalogInfoDir);
+      documents = yaml.parseAllDocuments(data.toString('utf8')).filter(d => d);
+    } catch (e) {
+      throw Error(`Failed to parse YAML at ${catalogInfoDir}, ${e}`);
+    }
+
+    for (const document of documents) {
+      if (document.errors?.length) {
+        throw Error(`YAML error at ${catalogInfoDir}, ${document.errors[0]}`);
+      } else {
+        const json = document.toJSON();
+        if (lodash.isPlainObject(json)) {
+          entities.push(json as Entity);
+        } else if (json === null) {
+          // Ignore null values, these happen if there is an empty document in the
+          // YAML file, for example if --- is added to the end of the file.
+        } else {
+          throw Error(`Expected object at root, got ${typeof json}`);
+        }
+      }
+    }
+
+    return entities;
+  }
+
+  private cleanUpRawEntities(
+    rawEntities: Entity[],
+    repository: GithubRepository,
+    catalogInfoFilePath: string,
+  ) {
+    const cleanEntities: Entity[] = [];
+    const baseUrl = `https://github.com/backstage/${repository.name}`;
+    const subPath =
+      catalogInfoFilePath === 'catalog-info.yaml'
+        ? ''
+        : catalogInfoFilePath.replace('catalog-info.yaml', '').trim();
+
+    for (const rawEntity of rawEntities) {
+      const annotations: Record<string, string> =
+        (rawEntity.metadata.annotations ??= {});
+
+      annotations['backstage.io/managed-by-location'] =
+        `url:${baseUrl}/blob/${repository.default_branch}/${catalogInfoFilePath}`;
+      annotations['backstage.io/managed-by-origin-location'] =
+        `url:${baseUrl}/blob/${repository.default_branch}/${catalogInfoFilePath}`;
+      annotations['backstage.io/edit-url'] =
+        `${baseUrl}/edit/${repository.default_branch}/${catalogInfoFilePath}`;
+      annotations['backstage.io/view-url'] =
+        `${baseUrl}/blob/${repository.default_branch}/${catalogInfoFilePath}`;
+      annotations['backstage.io/source-location'] =
+        `url:${baseUrl}/blob/${repository.default_branch}/${subPath}`;
+
+      rawEntity.metadata.namespace = defaults.namespace;
+      cleanEntities.push(rawEntity);
+    }
+
+    return cleanEntities;
+  }
+
+  private async componentMapper(
+    entity: Entity,
+    repository: GithubRepository,
+    catalogInfoDir: string,
+  ) {
+    const componentEntity = entity as ComponentEntity;
+
+    const dependsOn: string[] = [];
+    switch (repository.language) {
+      case 'TypeScript':
+      case 'JavaScript': {
+        const packageJsonDir = catalogInfoDir.replace(
+          'catalog-info.yaml',
+          'package.json',
+        );
+        const data = await fs.readFile(packageJsonDir);
+        const packageJson = JSON.parse(data.toString('utf8')) as PackageJson;
+        if (packageJson.dependencies) {
+          const dependencies = Object.keys(packageJson.dependencies).filter(d =>
+            d.startsWith('@backstage'),
+          );
+          dependencies.forEach((dep, index) => {
+            dependencies[index] =
+              `component:${defaults.namespace}/${dep.replace(
+                '@backstage/',
+                'backstage-',
+              )}`;
+          });
+          dependsOn.push(...dependencies);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    componentEntity.spec.dependsOn = dependsOn;
+    return componentEntity;
+  }
+}

--- a/plugins/catalog-backend-module-backstage/src/provider/index.ts
+++ b/plugins/catalog-backend-module-backstage/src/provider/index.ts
@@ -1,0 +1,1 @@
+export { BackstageEntityProvider } from './BackstageEntityProvider';

--- a/plugins/catalog-backend-module-backstage/src/types.ts
+++ b/plugins/catalog-backend-module-backstage/src/types.ts
@@ -1,0 +1,17 @@
+export type GithubRepository = {
+  id: string;
+  name: string;
+  description: string;
+  default_branch: string;
+  language: string;
+  archived: boolean;
+};
+
+export type PackageJson = {
+  name: string;
+  version: string;
+  backstage?: {
+    role: string;
+  };
+  dependencies?: Record<string, string>;
+};

--- a/plugins/scaffolder-backend-module-github-pages/package.json
+++ b/plugins/scaffolder-backend-module-github-pages/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@internal/backstage-plugin-scaffolder-backend-module-github-pages",
+  "name": "@internal/plugin-scaffolder-backend-module-github-pages",
   "description": "The github-pages module for @backstage/plugin-scaffolder-backend",
   "version": "0.1.0",
   "main": "src/index.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7440,14 +7440,14 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@internal/plugin-catalog-backend-module-backstage@workspace:plugins/catalog-backend-module-backstage"
   dependencies:
-    "@backstage/backend-common": ^0.21.7-next.0
-    "@backstage/backend-plugin-api": ^0.6.17-next.0
-    "@backstage/backend-tasks": ^0.5.22-next.0
+    "@backstage/backend-common": ^0.21.7-next.1
+    "@backstage/backend-plugin-api": ^0.6.17-next.1
+    "@backstage/backend-tasks": ^0.5.22-next.1
     "@backstage/catalog-model": ^1.4.5
-    "@backstage/cli": ^0.26.3-next.0
+    "@backstage/cli": ^0.26.3-next.1
     "@backstage/config": ^1.2.0
     "@backstage/integration": ^1.10.0-next.0
-    "@backstage/plugin-catalog-node": ^1.11.1-next.0
+    "@backstage/plugin-catalog-node": ^1.11.1-next.1
     "@types/fs-extra": ^11.0.4
     "@types/glob": ^8.1.0
     "@types/uuid": ^9.0.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -3381,7 +3381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-common@npm:^0.21.7-next.1":
+"@backstage/backend-common@npm:^0.21.7-next.0, @backstage/backend-common@npm:^0.21.7-next.1":
   version: 0.21.7-next.1
   resolution: "@backstage/backend-common@npm:0.21.7-next.1"
   dependencies:
@@ -3503,7 +3503,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^0.6.17-next.1":
+"@backstage/backend-plugin-api@npm:^0.6.17-next.0, @backstage/backend-plugin-api@npm:^0.6.17-next.1":
   version: 0.6.17-next.1
   resolution: "@backstage/backend-plugin-api@npm:0.6.17-next.1"
   dependencies:
@@ -3540,7 +3540,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-tasks@npm:^0.5.22-next.1":
+"@backstage/backend-tasks@npm:^0.5.22-next.0, @backstage/backend-tasks@npm:^0.5.22-next.1":
   version: 0.5.22-next.1
   resolution: "@backstage/backend-tasks@npm:0.5.22-next.1"
   dependencies:
@@ -3620,7 +3620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:^0.26.3-next.1":
+"@backstage/cli@npm:^0.26.3-next.0, @backstage/cli@npm:^0.26.3-next.1":
   version: 0.26.3-next.1
   resolution: "@backstage/cli@npm:0.26.3-next.1"
   dependencies:
@@ -4548,7 +4548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^1.11.1-next.1":
+"@backstage/plugin-catalog-node@npm:^1.11.1-next.0, @backstage/plugin-catalog-node@npm:^1.11.1-next.1":
   version: 1.11.1-next.1
   resolution: "@backstage/plugin-catalog-node@npm:1.11.1-next.1"
   dependencies:
@@ -7433,6 +7433,31 @@ __metadata:
     "@backstage/plugin-scaffolder-node": ^0.4.3-next.1
     octokit: ^3.1.2
     yaml: ^2.0.0
+  languageName: unknown
+  linkType: soft
+
+"@internal/plugin-catalog-backend-module-backstage@^0.1.0, @internal/plugin-catalog-backend-module-backstage@workspace:plugins/catalog-backend-module-backstage":
+  version: 0.0.0-use.local
+  resolution: "@internal/plugin-catalog-backend-module-backstage@workspace:plugins/catalog-backend-module-backstage"
+  dependencies:
+    "@backstage/backend-common": ^0.21.7-next.0
+    "@backstage/backend-plugin-api": ^0.6.17-next.0
+    "@backstage/backend-tasks": ^0.5.22-next.0
+    "@backstage/catalog-model": ^1.4.5
+    "@backstage/cli": ^0.26.3-next.0
+    "@backstage/config": ^1.2.0
+    "@backstage/integration": ^1.10.0-next.0
+    "@backstage/plugin-catalog-node": ^1.11.1-next.0
+    "@types/fs-extra": ^11.0.4
+    "@types/glob": ^8.1.0
+    "@types/uuid": ^9.0.7
+    fs-extra: ^11.2.0
+    glob: ^10.3.10
+    lodash: ^4.17.21
+    node-fetch: ^2.6.7
+    uuid: ^8.0.0
+    winston: ^3.2.1
+    yaml: ^2.3.4
   languageName: unknown
   linkType: soft
 
@@ -12706,6 +12731,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/fs-extra@npm:^11.0.4":
+  version: 11.0.4
+  resolution: "@types/fs-extra@npm:11.0.4"
+  dependencies:
+    "@types/jsonfile": "*"
+    "@types/node": "*"
+  checksum: 242cb84157631f057f76495c8220707541882c00a00195b603d937fb55e471afecebcb089bab50233ed3a59c69fd68bf65c1f69dd7fafe2347e139cc15b9b0e5
+  languageName: node
+  linkType: hard
+
+"@types/glob@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "@types/glob@npm:8.1.0"
+  dependencies:
+    "@types/minimatch": ^5.1.2
+    "@types/node": "*"
+  checksum: 9101f3a9061e40137190f70626aa0e202369b5ec4012c3fabe6f5d229cce04772db9a94fa5a0eb39655e2e4ad105c38afbb4af56a56c0996a8c7d4fc72350e3d
+  languageName: node
+  linkType: hard
+
 "@types/graceful-fs@npm:^4.1.3":
   version: 4.1.9
   resolution: "@types/graceful-fs@npm:4.1.9"
@@ -12849,6 +12894,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jsonfile@npm:*":
+  version: 6.1.4
+  resolution: "@types/jsonfile@npm:6.1.4"
+  dependencies:
+    "@types/node": "*"
+  checksum: 309fda20eb5f1cf68f2df28931afdf189c5e7e6bec64ac783ce737bb98908d57f6f58757ad5da9be37b815645a6f914e2d4f3ac66c574b8fe1ba6616284d0e97
+  languageName: node
+  linkType: hard
+
 "@types/jsonwebtoken@npm:^9.0.0":
   version: 9.0.5
   resolution: "@types/jsonwebtoken@npm:9.0.5"
@@ -12908,6 +12962,13 @@ __metadata:
   version: 1.3.5
   resolution: "@types/mime@npm:1.3.5"
   checksum: e29a5f9c4776f5229d84e525b7cd7dd960b51c30a0fb9a028c0821790b82fca9f672dab56561e2acd9e8eed51d431bde52eafdfef30f643586c4162f1aecfc78
+  languageName: node
+  linkType: hard
+
+"@types/minimatch@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@types/minimatch@npm:5.1.2"
+  checksum: 0391a282860c7cb6fe262c12b99564732401bdaa5e395bee9ca323c312c1a0f45efbf34dce974682036e857db59a5c9b1da522f3d6055aeead7097264c8705a8
   languageName: node
   linkType: hard
 
@@ -13319,7 +13380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^9.0.0":
+"@types/uuid@npm:^9.0.0, @types/uuid@npm:^9.0.7":
   version: 9.0.8
   resolution: "@types/uuid@npm:9.0.8"
   checksum: b8c60b7ba8250356b5088302583d1704a4e1a13558d143c549c408bf8920535602ffc12394ede77f8a8083511b023704bc66d1345792714002bfa261b17c5275
@@ -15034,6 +15095,7 @@ __metadata:
     "@frontside/backstage-plugin-graphql-backend": ^0.1.2
     "@frontside/backstage-plugin-graphql-backend-module-catalog": ^0.3.0
     "@internal/backstage-plugin-scaffolder-backend-module-github-pages": "workspace:^"
+    "@internal/plugin-catalog-backend-module-backstage": ^0.1.0
     app: ^0.0.0
     better-sqlite3: ^9.0.0
   languageName: unknown
@@ -33302,7 +33364,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0, yaml@npm:^2.0.0-10, yaml@npm:^2.2.1, yaml@npm:^2.2.2":
+"yaml@npm:^2.0.0, yaml@npm:^2.0.0-10, yaml@npm:^2.2.1, yaml@npm:^2.2.2, yaml@npm:^2.3.4":
   version: 2.4.1
   resolution: "yaml@npm:2.4.1"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7421,22 +7421,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@internal/backstage-plugin-scaffolder-backend-module-github-pages@workspace:^, @internal/backstage-plugin-scaffolder-backend-module-github-pages@workspace:plugins/scaffolder-backend-module-github-pages":
-  version: 0.0.0-use.local
-  resolution: "@internal/backstage-plugin-scaffolder-backend-module-github-pages@workspace:plugins/scaffolder-backend-module-github-pages"
-  dependencies:
-    "@backstage/backend-plugin-api": ^0.6.17-next.1
-    "@backstage/cli": ^0.26.3-next.1
-    "@backstage/errors": ^1.2.4
-    "@backstage/integration": ^1.10.0-next.0
-    "@backstage/plugin-scaffolder-backend-module-github": ^0.2.7-next.1
-    "@backstage/plugin-scaffolder-node": ^0.4.3-next.1
-    octokit: ^3.1.2
-    yaml: ^2.0.0
-  languageName: unknown
-  linkType: soft
-
-"@internal/plugin-catalog-backend-module-backstage@^0.1.0, @internal/plugin-catalog-backend-module-backstage@workspace:plugins/catalog-backend-module-backstage":
+"@internal/plugin-catalog-backend-module-backstage@workspace:^, @internal/plugin-catalog-backend-module-backstage@workspace:plugins/catalog-backend-module-backstage":
   version: 0.0.0-use.local
   resolution: "@internal/plugin-catalog-backend-module-backstage@workspace:plugins/catalog-backend-module-backstage"
   dependencies:
@@ -7456,8 +7441,22 @@ __metadata:
     lodash: ^4.17.21
     node-fetch: ^2.6.7
     uuid: ^8.0.0
-    winston: ^3.2.1
     yaml: ^2.3.4
+  languageName: unknown
+  linkType: soft
+
+"@internal/plugin-scaffolder-backend-module-github-pages@workspace:^, @internal/plugin-scaffolder-backend-module-github-pages@workspace:plugins/scaffolder-backend-module-github-pages":
+  version: 0.0.0-use.local
+  resolution: "@internal/plugin-scaffolder-backend-module-github-pages@workspace:plugins/scaffolder-backend-module-github-pages"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.6.17-next.1
+    "@backstage/cli": ^0.26.3-next.1
+    "@backstage/errors": ^1.2.4
+    "@backstage/integration": ^1.10.0-next.0
+    "@backstage/plugin-scaffolder-backend-module-github": ^0.2.7-next.1
+    "@backstage/plugin-scaffolder-node": ^0.4.3-next.1
+    octokit: ^3.1.2
+    yaml: ^2.0.0
   languageName: unknown
   linkType: soft
 
@@ -15094,8 +15093,8 @@ __metadata:
     "@backstage/plugin-todo-backend": ^0.3.16-next.1
     "@frontside/backstage-plugin-graphql-backend": ^0.1.2
     "@frontside/backstage-plugin-graphql-backend-module-catalog": ^0.3.0
-    "@internal/backstage-plugin-scaffolder-backend-module-github-pages": "workspace:^"
-    "@internal/plugin-catalog-backend-module-backstage": ^0.1.0
+    "@internal/plugin-catalog-backend-module-backstage": "workspace:^"
+    "@internal/plugin-scaffolder-backend-module-github-pages": "workspace:^"
     app: ^0.0.0
     better-sqlite3: ^9.0.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -3381,7 +3381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-common@npm:^0.21.7-next.0, @backstage/backend-common@npm:^0.21.7-next.1":
+"@backstage/backend-common@npm:^0.21.7-next.1":
   version: 0.21.7-next.1
   resolution: "@backstage/backend-common@npm:0.21.7-next.1"
   dependencies:
@@ -3503,7 +3503,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^0.6.17-next.0, @backstage/backend-plugin-api@npm:^0.6.17-next.1":
+"@backstage/backend-plugin-api@npm:^0.6.17-next.1":
   version: 0.6.17-next.1
   resolution: "@backstage/backend-plugin-api@npm:0.6.17-next.1"
   dependencies:
@@ -3540,7 +3540,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-tasks@npm:^0.5.22-next.0, @backstage/backend-tasks@npm:^0.5.22-next.1":
+"@backstage/backend-tasks@npm:^0.5.22-next.1":
   version: 0.5.22-next.1
   resolution: "@backstage/backend-tasks@npm:0.5.22-next.1"
   dependencies:
@@ -3620,7 +3620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:^0.26.3-next.0, @backstage/cli@npm:^0.26.3-next.1":
+"@backstage/cli@npm:^0.26.3-next.1":
   version: 0.26.3-next.1
   resolution: "@backstage/cli@npm:0.26.3-next.1"
   dependencies:
@@ -4548,7 +4548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^1.11.1-next.0, @backstage/plugin-catalog-node@npm:^1.11.1-next.1":
+"@backstage/plugin-catalog-node@npm:^1.11.1-next.1":
   version: 1.11.1-next.1
   resolution: "@backstage/plugin-catalog-node@npm:1.11.1-next.1"
   dependencies:


### PR DESCRIPTION
This adds a Backstage entity provider that scans all the repos in the Backstage GitHub org looking for `catalog-info.yaml` files and ingesting them. It will also look for related `package.json` files to be able to build up dependency relationships.

# Screenshot

![Screenshot 2024-02-10 at 5 51 21 PM](https://github.com/backstage/demo/assets/67169551/c563dc6f-946a-4df1-b494-0d66848a9f26)

# Demo Video

https://github.com/backstage/demo/assets/67169551/0ca1f03e-e988-4878-a01a-33f931cf85aa

