### PR TITLE
Included demo template in `catalog.locations`

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -106,8 +106,8 @@ catalog:
       target: https://github.com/mclarke47/dice-roller/blob/master/catalog-info.yaml
 
     # Demo Software Template
-    - type: file
-      target: ../../demo-template/template/template.yaml
+    - type: url
+      target: https://github.com/backstage/demo/blob/master/demo-template/template/template.yaml
       rules:
         - allow: ['Template']
   providers:

--- a/demo-template/template/template.yaml
+++ b/demo-template/template/template.yaml
@@ -19,8 +19,8 @@ metadata:
     GitHub credentials as well. 
     2. Now using the inputs provided it will take the following actions:
         1. It will then create a GitHub repository using the provided GitHub credentials
-        2. Populate the repository with a [basic HTML landing page](https://github.com/backstage/demo/blob/topic/demo-template/demo-template/template/skeleton/index.html) and a [GitHub Action](https://github.com/backstage/demo/blob/topic/demo-template/demo-template/template/skeleton/.github/workflows/pages.yml). 
-        3. Then it will [enable GitHub Pages](https://github.com/awanlin/demo/blob/topic/demo-template/plugins/scaffolder-backend-module-github-pages/src/actions/pages/createGithubPagesAction.ts) on this new repository 
+        2. Populate the repository with a [basic HTML landing page](https://github.com/backstage/demo/blob/master/demo-template/template/skeleton/index.html) and a [GitHub Action](https://github.com/backstage/demo/blob/master/demo-template/template/skeleton/.github/workflows/pages.yml). 
+        3. Then it will [enable GitHub Pages](https://github.com/awanlin/demo/blob/master/plugins/scaffolder-backend-module-github-pages/src/actions/pages/createGithubPagesAction.ts) on this new repository 
         4. Using the included GitHub Action deploy the landing page to GitHub Pages.
     3. Once completed it will output a link to the new repository and the GitHub Action workflow that was triggered. As well as a text reminder to delete the resulting repository.
 


### PR DESCRIPTION
This adds the demo template to the `catalog.location` and also fixes a few broken links in the template itself.