### PR TITLE
Adjusted renovate `matchPackageNames`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     {
       "matchManagers": ["npm"],
       "enabled": false,
-      "matchPackageNames": ["/@backstage/"]
+      "matchPackageNames": ["@backstage/**"]
     }
   ],
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
I noticed we were not getting any Renovate PRs for the Community Plugins (`@backstage-community`) and have been manually updating them in the version bump PR. This should allow Renovate to start creating PRs for these as they release on an as needed basis.

I followed the "prefix match using Glob" example from here to help with this change: https://docs.renovatebot.com/configuration-options/#matchpackagenames