### PR TITLE
Refactor mermaid implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,9 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN pip3 install mkdocs-techdocs-core mkdocs-kroki-plugin
+RUN pip3 install mkdocs-techdocs-core markdown-inline-mermaid
+
+RUN yarn global add @mermaid-js/mermaid-cli
 
 RUN curl -o plantuml.jar -L https://github.com/plantuml/plantuml/releases/download/v1.2023.10/plantuml-1.2023.10.jar && echo "527d28af080ae91a455e7023e1a726c7714dc98e plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 RUN echo '#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml

--- a/README.md
+++ b/README.md
@@ -108,3 +108,25 @@ You can see our Renovate configuration in the [`renovate.json`](https://github.c
 > Note: you may not see any Pull Request as we very much like to stay on top of them, clicking on the "Closed" option will let you see examples that have been merged in the past.
 
 To learn how to get started with Renovate we recommend reading the [Installing and onboarding Renovate into repositories](https://docs.renovatebot.com/getting-started/installing-onboarding/) documentation.
+
+## Working With This Repo
+
+The following sections are to help those working with this repo to keep in maintained.
+
+### Local Docker
+
+The Dockerfile in this repo can be built locally using the following command:
+
+```bash
+docker image build .  -t demo --build-arg ENVIRONMENT_CONFIG=local
+```
+
+This will build the image with your `app-config.local.yaml` included this allows you to include any config you might want to have in place for local testing.
+
+Using `--progress=plain --no-cache` can also be helpful with testing changes.
+
+You can then run it with this command:
+
+```bash
+docker run -it -p 7007:7007 demo
+```

--- a/docs/examples/mermaid.md
+++ b/docs/examples/mermaid.md
@@ -12,25 +12,23 @@ To be able to use Mermaid diagrams with TechDocs you'll need to follow this guid
 
 Here is an example:
 
-```kroki-mermaid
+```mermaid
 sequenceDiagram
     Alice->>John: Hello John, how are you?
     John-->>Alice: Great!
     Alice-)John: See you later!
 ```
-
->Note: For this example we are using [Kroki.io](https://kroki.io/), but you may which to run your own server to protect TechDocs with sensitive content. More details on this topic are in the previously linked guide.
 
 ## Markdown
 
 Here is the Markdown:
 
 ```markdown
-kroki-mermaid
+mermaid
 sequenceDiagram
-    Alice->>John: Hello John, how are you?
-    John-->>Alice: Great!
-    Alice-)John: See you later!
+Alice->>John: Hello John, how are you?
+John-->>Alice: Great!
+Alice-)John: See you later!
 ```
 
->Note: in order to prevent Mermaid from rendering the diagram above the backticks (\`) have been removed. You'll want to add 3 backticks on line 1 before `kroki-mermaid` and then another 3 backticks on a new line below line 5.
+> Note: in order to prevent Mermaid from rendering the diagram above the backticks (\`) have been removed. You'll want to add 3 backticks on line 1 before `mermaid` and then another 3 backticks on a new line below line 5.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,4 +2,6 @@ site_name: 'Backstage Demo'
 
 plugins:
   - techdocs-core
-  - kroki
+
+markdown_extensions:
+  - markdown_inline_mermaid


### PR DESCRIPTION
This refactors the mermaid implementation to use `markdown-inline-mermaid` instead of `mkdocs-kroki-plugin`. This seems like a more straightforward pattern and also means you don't send you data externally or have to run the Kroki service internally.

Closes #290 and #500