### PR TITLE
Fix img-src directive in CSP

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -32,7 +32,7 @@ backend:
         'https://img.shields.io/',
         'https://api.dicebear.com/',
         'https://kroki.io/',
-        'https://bestpractices.coreinfrastructure.org',
+        'https://www.bestpractices.dev/',
         'https://api.securityscorecards.dev',
       ]
     frame-src: ['https://www.youtube.com']


### PR DESCRIPTION
Looks like
https://bestpractices.coreinfrastructure.org/projects/7678/badge has started redirecting to
https://www.bestpractices.dev/projects/7678/badge, which means our CSP no longer does the right thing and the corresponding badge image doesn't load in
https://demo.backstage.io/catalog/default/component/backstage/docs