### PR TITLE
Add installing Heroku CLI to release workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -52,6 +52,9 @@ jobs:
       - name: build
         run: yarn build:all
 
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
       - name: Login to Heroku Container registry
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
@@ -68,11 +71,11 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: heroku container:release -a ${{ secrets.HEROKU_APP_NAME }} web
 
-      # Post notification to Discord Announcements channel  
+      # Post notification to Discord Announcements channel
       - name: 'Check if last commit is a release'
         id: check_if_release
-        run: node scripts/check-if-release.js ${{ github.sha }} 
-      
+        run: node scripts/check-if-release.js ${{ github.sha }}
+
       - name: Discord notification
         uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # 0.3.2
         if: steps.check_if_release.outputs.is_release == 'true'
@@ -80,4 +83,4 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
           CURRENT_VERSION: ${{ steps.check_if_release.outputs.current_version }}
         with:
-          args: 'The Backstage Demo site has been upgraded to release {{CURRENT_VERSION}} go check it out: https://demo.backstage.io'  
+          args: 'The Backstage Demo site has been upgraded to release {{CURRENT_VERSION}} go check it out: https://demo.backstage.io'


### PR DESCRIPTION
This should fix the errors we are seeing here: https://github.com/backstage/demo/actions/runs/12356075289/job/34481131949#step:12:2

This fix is based on this issue: https://github.com/actions/runner-images/issues/10786

I'm not able to test this so it's a bit of YOLO, we do have a few PRs pending that we can use to validate quickly once this is merged.