### PR TITLE
v1.35.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 254c816a15098e2a0b414345caf9144409fbf6a63da7ec8ec8d3454aa1d2edfbbc32cd264d8c464b7ec4aca7809c690848a7c1191b5f8167dec81dbdf6107b01
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.35.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.35.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.35.0-next.1"
+  "version": "1.35.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3502,15 +3502,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@npm:^1.5.15":
-  version: 1.5.15
-  resolution: "@backstage/app-defaults@npm:1.5.15"
+"@backstage/app-defaults@npm:^1.5.16-next.0":
+  version: 1.5.16-next.0
+  resolution: "@backstage/app-defaults@npm:1.5.16-next.0"
   dependencies:
-    "@backstage/core-app-api": "npm:^1.15.3"
-    "@backstage/core-components": "npm:^0.16.2"
-    "@backstage/core-plugin-api": "npm:^1.10.2"
-    "@backstage/plugin-permission-react": "npm:^0.4.29"
-    "@backstage/theme": "npm:^0.6.3"
+    "@backstage/core-app-api": "npm:1.15.4-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.30-next.0"
+    "@backstage/theme": "npm:0.6.3"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -3521,22 +3521,22 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1302b723b7c93af590974268d92159fb822d936a8353f63f63e69e9d84fadcfb8bd21e9e9b86db098aa0d4c80d7dd6aac7172a201dff6db01f08945be0d6d238
+  checksum: 10/628e945704eac95a8bccbdf41fcc1eab7d9c137723e3fffbea80054e513a7f45056b88ef2d08223060e172d8b67e635e1526430226c1817de75c28efb480e24c
   languageName: node
   linkType: hard
 
-"@backstage/backend-app-api@npm:1.1.1-next.0":
-  version: 1.1.1-next.0
-  resolution: "@backstage/backend-app-api@npm:1.1.1-next.0"
+"@backstage/backend-app-api@npm:1.1.1-next.1":
+  version: 1.1.1-next.1
+  resolution: "@backstage/backend-app-api@npm:1.1.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
     "@backstage/cli-common": "npm:0.1.15"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/config-loader": "npm:1.9.5-next.0"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-permission-node": "npm:0.8.7-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/config-loader": "npm:1.9.5-next.1"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-permission-node": "npm:0.8.7-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@manypkg/get-packages": "npm:^1.1.3"
     compression: "npm:^1.7.4"
     cookie: "npm:^0.7.0"
@@ -3558,7 +3558,7 @@ __metadata:
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     winston-transport: "npm:^4.5.0"
-  checksum: 10/cb9ca85088875a5d1e045821811505ee75bf34ef4dd77f377a9cd69472b9091cb80022b4be8715d006a1e62094b87ad1676977a430bd392d86798c68c59a1885
+  checksum: 10/6b063ee7fda5fa01811cee265406b13192d1a1b9d2329958e764d2c2744e0a214af6dfbf8837f2ee2234f7f3f4d00cef3d9fc099909ecf317be5b2750e4de7dd
   languageName: node
   linkType: hard
 
@@ -3715,9 +3715,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:0.7.0-next.0, @backstage/backend-defaults@npm:^0.7.0-next.0":
-  version: 0.7.0-next.0
-  resolution: "@backstage/backend-defaults@npm:0.7.0-next.0"
+"@backstage/backend-defaults@npm:0.7.0-next.1, @backstage/backend-defaults@npm:^0.7.0-next.1":
+  version: 0.7.0-next.1
+  resolution: "@backstage/backend-defaults@npm:0.7.0-next.1"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -3726,20 +3726,20 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-app-api": "npm:1.1.1-next.0"
+    "@backstage/backend-app-api": "npm:1.1.1-next.1"
     "@backstage/backend-dev-utils": "npm:0.1.5"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
     "@backstage/cli-common": "npm:0.1.15"
-    "@backstage/cli-node": "npm:0.2.11"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/config-loader": "npm:1.9.5-next.0"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/integration-aws-node": "npm:0.1.14"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.7-next.0"
-    "@backstage/plugin-permission-node": "npm:0.8.7-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/cli-node": "npm:0.2.12-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/config-loader": "npm:1.9.5-next.1"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/integration-aws-node": "npm:0.1.15-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.7-next.1"
+    "@backstage/plugin-permission-node": "npm:0.8.7-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@google-cloud/storage": "npm:^7.0.0"
     "@keyv/memcache": "npm:^2.0.1"
     "@keyv/redis": "npm:^4.0.1"
@@ -3794,7 +3794,7 @@ __metadata:
   peerDependenciesMeta:
     "@google-cloud/cloud-sql-connector":
       optional: true
-  checksum: 10/9b56c090767a563632b298d86ec6fc96f972dde1f3d1bdca663eef7986dd00d311b5f279613f8f9b42f9eb074a1dab4469f1358043c6eb8476f435c824c0a5b2
+  checksum: 10/2c3a77d22953f61923427df86fd2aa942a694682462ae0872137356837e5d5b3806d77fa48beeb332a4072b02afbfd3c8105bd60c3bc658c2d1b0c3ac75391d5
   languageName: node
   linkType: hard
 
@@ -3805,14 +3805,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-openapi-utils@npm:0.4.1-next.0":
-  version: 0.4.1-next.0
-  resolution: "@backstage/backend-openapi-utils@npm:0.4.1-next.0"
+"@backstage/backend-openapi-utils@npm:0.4.1-next.1":
+  version: 0.4.1-next.1
+  resolution: "@backstage/backend-openapi-utils@npm:0.4.1-next.1"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@types/express": "npm:^4.17.6"
     "@types/express-serve-static-core": "npm:^4.17.5"
     ajv: "npm:^8.16.0"
@@ -3825,7 +3825,7 @@ __metadata:
     mockttp: "npm:^3.13.0"
     openapi-merge: "npm:^1.3.2"
     openapi3-ts: "npm:^3.1.2"
-  checksum: 10/8e3e02440c3d5657b35d6fa8b23b1f2bb4b720ea5e19794d4c5c3464c644bca38104772c2e7511792908655d6625654b11246e0cdf3fe68e1279df6066face56
+  checksum: 10/8165e4915fc29c4ca2d67c67fbf133ecda12defc053820d8860f4302449a0d158e0701b5cc3fdf43b0a3221ad88c7a219cf8aeb3fe5666b68db6d1bd1ff345d1
   languageName: node
   linkType: hard
 
@@ -3853,21 +3853,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:1.1.1-next.0, @backstage/backend-plugin-api@npm:^1.1.1-next.0":
-  version: 1.1.1-next.0
-  resolution: "@backstage/backend-plugin-api@npm:1.1.1-next.0"
+"@backstage/backend-plugin-api@npm:1.1.1-next.1, @backstage/backend-plugin-api@npm:^1.1.1-next.1":
+  version: 1.1.1-next.1
+  resolution: "@backstage/backend-plugin-api@npm:1.1.1-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.1.15"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@types/express": "npm:^4.17.6"
     "@types/luxon": "npm:^3.0.0"
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
-  checksum: 10/ddc1e720567970ff4a41729ff53cf7d52bc433132da2fcfc95f3fd45fe2121515912f7d3fe2cccf9aa7282adebbf0be8fbce9ae5050fc3c68d5f574eae0ae221
+  checksum: 10/a3313843dfba4cfea71f37a38dd2583102d425107eac9154ec8bf7cfeaf78b38d738e2ded1a8932eecbd33d53163e822dd18a732abada2f11fd081b3a2f42318
   languageName: node
   linkType: hard
 
@@ -3908,7 +3908,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:1.9.0, @backstage/catalog-client@npm:^1.6.5, @backstage/catalog-client@npm:^1.9.0":
+"@backstage/catalog-client@npm:1.9.1-next.0":
+  version: 1.9.1-next.0
+  resolution: "@backstage/catalog-client@npm:1.9.1-next.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    cross-fetch: "npm:^4.0.0"
+    uri-template: "npm:^2.0.0"
+  checksum: 10/7e6aed8340b025f64556f1ceb8f6b5f8b22320388dd98136b513c279b30c2cf547fcb6e28c439c529d7d2181573daf40f4326fe7ee6c1370f977eb1582f07dda
+  languageName: node
+  linkType: hard
+
+"@backstage/catalog-client@npm:^1.6.5, @backstage/catalog-client@npm:^1.9.0":
   version: 1.9.0
   resolution: "@backstage/catalog-client@npm:1.9.0"
   dependencies:
@@ -3920,7 +3932,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@npm:1.7.2, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.2":
+"@backstage/catalog-model@npm:1.7.3-next.0, @backstage/catalog-model@npm:^1.7.3-next.0":
+  version: 1.7.3-next.0
+  resolution: "@backstage/catalog-model@npm:1.7.3-next.0"
+  dependencies:
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+    ajv: "npm:^8.10.0"
+    lodash: "npm:^4.17.21"
+  checksum: 10/ed1439ab0ff8eaf8df43fcc88dd87a706d7a3df56d0dc5ad8bec022f938353aea485dc6b3cf2a3ed2df753be2281b8651eb5c01c82a5ad3ab5326e58ce20579d
+  languageName: node
+  linkType: hard
+
+"@backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.2":
   version: 1.7.2
   resolution: "@backstage/catalog-model@npm:1.7.2"
   dependencies:
@@ -3939,36 +3963,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-node@npm:0.2.11":
-  version: 0.2.11
-  resolution: "@backstage/cli-node@npm:0.2.11"
+"@backstage/cli-node@npm:0.2.12-next.0":
+  version: 0.2.12-next.0
+  resolution: "@backstage/cli-node@npm:0.2.12-next.0"
   dependencies:
-    "@backstage/cli-common": "npm:^0.1.15"
-    "@backstage/errors": "npm:^1.2.6"
-    "@backstage/types": "npm:^1.2.0"
+    "@backstage/cli-common": "npm:0.1.15"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@manypkg/get-packages": "npm:^1.1.3"
     "@yarnpkg/parsers": "npm:^3.0.0"
     fs-extra: "npm:^11.2.0"
     semver: "npm:^7.5.3"
     zod: "npm:^3.22.4"
-  checksum: 10/de1bed1204b97605624ab1ed65357138fe06201f775e1f4ea2a4fcf5d92c22931ab30a4813a0858365849058de2156311cb0eb7f253d9414019810d853402bd7
+  checksum: 10/a409f729a34e2482f55291d32c0c52c0f46b8a516b61d49b42c304fddc53f548789b941082270a6747e21a9b71be9b1eaa39e466c5094107d6d1b139fd082123
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:^0.29.5-next.0":
-  version: 0.29.5-next.0
-  resolution: "@backstage/cli@npm:0.29.5-next.0"
+"@backstage/cli@npm:^0.29.5-next.1":
+  version: 0.29.5-next.1
+  resolution: "@backstage/cli@npm:0.29.5-next.1"
   dependencies:
-    "@backstage/catalog-model": "npm:1.7.2"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
     "@backstage/cli-common": "npm:0.1.15"
-    "@backstage/cli-node": "npm:0.2.11"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/config-loader": "npm:1.9.5-next.0"
-    "@backstage/errors": "npm:1.2.6"
+    "@backstage/cli-node": "npm:0.2.12-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/config-loader": "npm:1.9.5-next.1"
+    "@backstage/errors": "npm:1.2.7-next.0"
     "@backstage/eslint-plugin": "npm:0.1.10"
-    "@backstage/integration": "npm:1.16.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
     "@backstage/release-manifests": "npm:0.0.12"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@manypkg/get-packages": "npm:^1.1.3"
     "@module-federation/enhanced": "npm:^0.8.0"
     "@octokit/graphql": "npm:^5.0.0"
@@ -4100,18 +4124,18 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/8ecf7c998a35c635d59fdd82440a0fdb91889aafb4a89da763c9ca429ffb6be5fc48136b5e79a7fc33adfcfb92f5668e696051714d65a9e135e934e9c5b13b62
+  checksum: 10/2e43f0552af0cad3b35124542e9a3265deeccfd4247b8308d33d2c19c5381e84e7653c2a062e3a1149486977b3888d4fecd36c76ca35963adbe77ab72338eef5
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:1.9.5-next.0":
-  version: 1.9.5-next.0
-  resolution: "@backstage/config-loader@npm:1.9.5-next.0"
+"@backstage/config-loader@npm:1.9.5-next.1":
+  version: 1.9.5-next.1
+  resolution: "@backstage/config-loader@npm:1.9.5-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.1.15"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@types/json-schema": "npm:^7.0.6"
     ajv: "npm:^8.10.0"
     chokidar: "npm:^3.5.2"
@@ -4123,7 +4147,7 @@ __metadata:
     minimist: "npm:^1.2.5"
     typescript-json-schema: "npm:^0.65.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/bf88aeee38459161de35db9e3c1da396bacf68eeb7245234e20f81aba63606ab13175798946c689ea12cd5306cfe9c1074c82f7e9b18b92281f05916cdf9661e
+  checksum: 10/6c4a7f5f9df57e58ef8a319cf488ce98df53d1f62ed06a01a7cb363b9456d6ee6e8c8c6e024b5de6ffed0da849d91cc739c08c46d0efa18d63aac170655559cf
   languageName: node
   linkType: hard
 
@@ -4150,7 +4174,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@npm:1.3.1, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.1":
+"@backstage/config@npm:1.3.2-next.0, @backstage/config@npm:^1.3.2-next.0":
+  version: 1.3.2-next.0
+  resolution: "@backstage/config@npm:1.3.2-next.0"
+  dependencies:
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+    ms: "npm:^2.1.3"
+  checksum: 10/8c4bf97c405b704a6c2b589fb2a3a4c7f5ba49d5e5e2e83768a8ecda374327e9d170858c2a391e6b56a71d8c5dd23fbddd6630e7c712e4bb8ef0997916775d26
+  languageName: node
+  linkType: hard
+
+"@backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.1":
   version: 1.3.1
   resolution: "@backstage/config@npm:1.3.1"
   dependencies:
@@ -4161,7 +4196,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@npm:1.15.3, @backstage/core-app-api@npm:^1.15.3":
+"@backstage/core-app-api@npm:1.15.4-next.0, @backstage/core-app-api@npm:^1.15.4-next.0":
+  version: 1.15.4-next.0
+  resolution: "@backstage/core-app-api@npm:1.15.4-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+    "@backstage/version-bridge": "npm:1.0.10"
+    "@types/prop-types": "npm:^15.7.3"
+    history: "npm:^5.0.0"
+    i18next: "npm:^22.4.15"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/deeaed739954a1e86a653372fe856fe1cdb94ef4fdb41d99a263c12b46fe95a9cc4666d439314fae4ef3992b833f7333ef45fb912787cda8990038c9939a4f2e
+  languageName: node
+  linkType: hard
+
+"@backstage/core-app-api@npm:^1.15.3":
   version: 1.15.3
   resolution: "@backstage/core-app-api@npm:1.15.3"
   dependencies:
@@ -4189,13 +4252,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@npm:0.3.4, @backstage/core-compat-api@npm:^0.3.4":
-  version: 0.3.4
-  resolution: "@backstage/core-compat-api@npm:0.3.4"
+"@backstage/core-compat-api@npm:0.3.5-next.0":
+  version: 0.3.5-next.0
+  resolution: "@backstage/core-compat-api@npm:0.3.5-next.0"
   dependencies:
-    "@backstage/core-plugin-api": "npm:^1.10.2"
-    "@backstage/frontend-plugin-api": "npm:^0.9.3"
-    "@backstage/version-bridge": "npm:^1.0.10"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/version-bridge": "npm:1.0.10"
     lodash: "npm:^4.17.21"
   peerDependencies:
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -4205,7 +4268,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8be0795cbaef25ab19259bc46085c4be60455de6c648ed58b7e6a86c5e5f66c061d1144936ecadf04cddc3feb35a5a921e737921daf9f15ffa8f8b1c1a0fa879
+  checksum: 10/46adc3b049070c5ac51cd284f81de74893b863cd2ddf9a67e6b09f05773c089ffff7da31d1e41ddfed9e55e5ae00b9b72e461ea2b1deaab82d515c0f47ec0b7f
   languageName: node
   linkType: hard
 
@@ -4225,15 +4288,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:0.16.2, @backstage/core-components@npm:^0.16.2":
-  version: 0.16.2
-  resolution: "@backstage/core-components@npm:0.16.2"
+"@backstage/core-compat-api@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "@backstage/core-compat-api@npm:0.3.4"
   dependencies:
-    "@backstage/config": "npm:^1.3.1"
     "@backstage/core-plugin-api": "npm:^1.10.2"
-    "@backstage/errors": "npm:^1.2.6"
-    "@backstage/theme": "npm:^0.6.3"
+    "@backstage/frontend-plugin-api": "npm:^0.9.3"
     "@backstage/version-bridge": "npm:^1.0.10"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/8be0795cbaef25ab19259bc46085c4be60455de6c648ed58b7e6a86c5e5f66c061d1144936ecadf04cddc3feb35a5a921e737921daf9f15ffa8f8b1c1a0fa879
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.16.3-next.0, @backstage/core-components@npm:^0.16.3-next.0":
+  version: 0.16.3-next.0
+  resolution: "@backstage/core-components@npm:0.16.3-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/theme": "npm:0.6.3"
+    "@backstage/version-bridge": "npm:1.0.10"
     "@date-io/core": "npm:^1.3.13"
     "@material-table/core": "npm:^3.1.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -4274,7 +4357,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/f42772aad10d07613b16d95fa4bab7cf5daca9854d00f9fd32b7a5c8d244f133bc5b97861e228282c86d091b813c1486c53807d457fe66cb7becc30914429a80
+  checksum: 10/9423aec5c66ee494a0de4eb47d69c432f9b6467d645cd01e1fcf60bc080ff1746aa37f83e5626c6888c6bb5f5c36e565f7b38812ee4c5e15c729b19d2c4f4f21
   languageName: node
   linkType: hard
 
@@ -4379,7 +4462,81 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@npm:1.10.2, @backstage/core-plugin-api@npm:^1.10.0, @backstage/core-plugin-api@npm:^1.10.2, @backstage/core-plugin-api@npm:^1.9.3":
+"@backstage/core-components@npm:^0.16.2":
+  version: 0.16.2
+  resolution: "@backstage/core-components@npm:0.16.2"
+  dependencies:
+    "@backstage/config": "npm:^1.3.1"
+    "@backstage/core-plugin-api": "npm:^1.10.2"
+    "@backstage/errors": "npm:^1.2.6"
+    "@backstage/theme": "npm:^0.6.3"
+    "@backstage/version-bridge": "npm:^1.0.10"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    dagre: "npm:^0.8.5"
+    linkify-react: "npm:4.1.3"
+    linkifyjs: "npm:4.1.3"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/f42772aad10d07613b16d95fa4bab7cf5daca9854d00f9fd32b7a5c8d244f133bc5b97861e228282c86d091b813c1486c53807d457fe66cb7becc30914429a80
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:1.10.3-next.0, @backstage/core-plugin-api@npm:^1.10.3-next.0":
+  version: 1.10.3-next.0
+  resolution: "@backstage/core-plugin-api@npm:1.10.3-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+    "@backstage/version-bridge": "npm:1.0.10"
+    history: "npm:^5.0.0"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/e8eed9b69a6c9adc41f54d43226cc625fe286f4d6ea4296831e17dbd033e5d174d60e32fd1234e8d2ad4d33f895b77d92a6c10a78c841d15ee24a9ff1c5d5e4f
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:^1.10.0, @backstage/core-plugin-api@npm:^1.10.2, @backstage/core-plugin-api@npm:^1.9.3":
   version: 1.10.2
   resolution: "@backstage/core-plugin-api@npm:1.10.2"
   dependencies:
@@ -4415,7 +4572,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/errors@npm:1.2.6, @backstage/errors@npm:^1.2.4, @backstage/errors@npm:^1.2.6":
+"@backstage/errors@npm:1.2.7-next.0":
+  version: 1.2.7-next.0
+  resolution: "@backstage/errors@npm:1.2.7-next.0"
+  dependencies:
+    "@backstage/types": "npm:1.2.1-next.0"
+    serialize-error: "npm:^8.0.1"
+  checksum: 10/069f30ff038f3480466d8ff23aa63f0058034f111f92f35e8b046636a553b79849eaf0d9f59e45fce48e646791b76164737ce8490427752fe05ffb54ab22e331
+  languageName: node
+  linkType: hard
+
+"@backstage/errors@npm:^1.2.4, @backstage/errors@npm:^1.2.6":
   version: 1.2.6
   resolution: "@backstage/errors@npm:1.2.6"
   dependencies:
@@ -4432,6 +4599,32 @@ __metadata:
     "@manypkg/get-packages": "npm:^1.1.3"
     minimatch: "npm:^9.0.0"
   checksum: 10/7983d7ff71d940e7aa761d1a5663844dcd23fc4754efd46423e2996a66ac63b39d44866f49dad6794827b738bc9dcbbc1bdee2b3934e2cee477733bcb5a27b2f
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-app-api@npm:0.10.4-next.0":
+  version: 0.10.4-next.0
+  resolution: "@backstage/frontend-app-api@npm:0.10.4-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/core-app-api": "npm:1.15.4-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/frontend-defaults": "npm:0.1.5-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+    "@backstage/version-bridge": "npm:1.0.10"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/fab9bf6fad5d7daeabc47a3483befca857d1c948011535c0d248cef4bd3894bf0f9d7d2f306878465f7ac2dc5cc79af67dbf52d15fca5138c593b5a182f976f5
   languageName: node
   linkType: hard
 
@@ -4461,6 +4654,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-defaults@npm:0.1.5-next.0":
+  version: 0.1.5-next.0
+  resolution: "@backstage/frontend-defaults@npm:0.1.5-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/frontend-app-api": "npm:0.10.4-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-app": "npm:0.1.5-next.0"
+    "@react-hookz/web": "npm:^24.0.0"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/db99f30ba317e1ae5311791268c2854b92be1c2348af3fa009f16a750c85b6bc147c5e11fd8d937e4c4362852cd5249dabb96fe642a9043438e8e00ea3371d6c
+  languageName: node
+  linkType: hard
+
 "@backstage/frontend-defaults@npm:^0.1.4":
   version: 0.1.4
   resolution: "@backstage/frontend-defaults@npm:0.1.4"
@@ -4483,14 +4698,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:0.9.3, @backstage/frontend-plugin-api@npm:^0.9.3":
-  version: 0.9.3
-  resolution: "@backstage/frontend-plugin-api@npm:0.9.3"
+"@backstage/frontend-plugin-api@npm:0.9.4-next.0":
+  version: 0.9.4-next.0
+  resolution: "@backstage/frontend-plugin-api@npm:0.9.4-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.16.2"
-    "@backstage/core-plugin-api": "npm:^1.10.2"
-    "@backstage/types": "npm:^1.2.0"
-    "@backstage/version-bridge": "npm:^1.0.10"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+    "@backstage/version-bridge": "npm:1.0.10"
     "@material-ui/core": "npm:^4.12.4"
     lodash: "npm:^4.17.21"
     zod: "npm:^3.22.4"
@@ -4503,7 +4718,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6e6a089ca4e684890f219f036291369ded8f43f1ef881806223f694e7895b77faa8b86a35b8c67914695f122e530a56f8d0fcc8feceadd3f172cf1a43d81199b
+  checksum: 10/e1b88f2b58a3b435af775cbf487e6fbe48601988607dcafa4d5c568a0d8f0ed99a1c8838449db5545c3441cb5fda9dbb65f3738183a52928844b676a14ef14e6
   languageName: node
   linkType: hard
 
@@ -4527,7 +4742,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-test-utils@npm:0.2.4, @backstage/frontend-test-utils@npm:^0.2.4":
+"@backstage/frontend-plugin-api@npm:^0.9.3":
+  version: 0.9.3
+  resolution: "@backstage/frontend-plugin-api@npm:0.9.3"
+  dependencies:
+    "@backstage/core-components": "npm:^0.16.2"
+    "@backstage/core-plugin-api": "npm:^1.10.2"
+    "@backstage/types": "npm:^1.2.0"
+    "@backstage/version-bridge": "npm:^1.0.10"
+    "@material-ui/core": "npm:^4.12.4"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.21.4"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/6e6a089ca4e684890f219f036291369ded8f43f1ef881806223f694e7895b77faa8b86a35b8c67914695f122e530a56f8d0fcc8feceadd3f172cf1a43d81199b
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-test-utils@npm:0.2.5-next.0":
+  version: 0.2.5-next.0
+  resolution: "@backstage/frontend-test-utils@npm:0.2.5-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/frontend-app-api": "npm:0.10.4-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-app": "npm:0.1.5-next.0"
+    "@backstage/test-utils": "npm:1.7.4-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+    "@backstage/version-bridge": "npm:1.0.10"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/d10cb5cd693d500243c5264912531fb30cc89fb47415a957196a9f58dd15608af97f248342a445842c6ef1249e22de9e5b51754f5b6cec2aee00772fd4276339
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-test-utils@npm:^0.2.4":
   version: 0.2.4
   resolution: "@backstage/frontend-test-utils@npm:0.2.4"
   dependencies:
@@ -4552,7 +4816,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-aws-node@npm:0.1.14, @backstage/integration-aws-node@npm:^0.1.12":
+"@backstage/integration-aws-node@npm:0.1.15-next.0":
+  version: 0.1.15-next.0
+  resolution: "@backstage/integration-aws-node@npm:0.1.15-next.0"
+  dependencies:
+    "@aws-sdk/client-sts": "npm:^3.350.0"
+    "@aws-sdk/credential-provider-node": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@aws-sdk/util-arn-parser": "npm:^3.310.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+  checksum: 10/7357701018ea1094e21d68cbe40760de5297f5d90af7ba0bcb608af94c9924418f2219217bdfc7d1cced21865e3108c4b0f7d23e7ff2a156b68d48629f75016d
+  languageName: node
+  linkType: hard
+
+"@backstage/integration-aws-node@npm:^0.1.12":
   version: 0.1.14
   resolution: "@backstage/integration-aws-node@npm:0.1.14"
   dependencies:
@@ -4567,7 +4846,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@npm:1.2.2, @backstage/integration-react@npm:^1.2.2":
+"@backstage/integration-react@npm:1.2.3-next.0, @backstage/integration-react@npm:^1.2.3-next.0":
+  version: 1.2.3-next.0
+  resolution: "@backstage/integration-react@npm:1.2.3-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/9fe7ff5d81f30e5c334c326d798a95a66965b79e36099b765916a15127f672cc538786e6c79fc91e9f057a11e455be309a858a4aeaa0145a9f40b4378de19235
+  languageName: node
+  linkType: hard
+
+"@backstage/integration-react@npm:^1.2.2":
   version: 1.2.2
   resolution: "@backstage/integration-react@npm:1.2.2"
   dependencies:
@@ -4588,7 +4888,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration@npm:1.16.0, @backstage/integration@npm:^1.13.0, @backstage/integration@npm:^1.15.0, @backstage/integration@npm:^1.16.0":
+"@backstage/integration@npm:1.16.1-next.0, @backstage/integration@npm:^1.16.1-next.0":
+  version: 1.16.1-next.0
+  resolution: "@backstage/integration@npm:1.16.1-next.0"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+  checksum: 10/f572dd119cf81ef43c605604081c5015fb980917f388f41b244b536e64608be7698b268025f6cd4e6a327ffa5c09f21a67c3958ca9962e5e37b3ee28dadde197
+  languageName: node
+  linkType: hard
+
+"@backstage/integration@npm:^1.13.0, @backstage/integration@npm:^1.15.0, @backstage/integration@npm:^1.16.0":
   version: 1.16.0
   resolution: "@backstage/integration@npm:1.16.0"
   dependencies:
@@ -4606,20 +4924,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@npm:^0.12.3-next.0":
-  version: 0.12.3-next.0
-  resolution: "@backstage/plugin-api-docs@npm:0.12.3-next.0"
+"@backstage/plugin-api-docs@npm:^0.12.3-next.1":
+  version: 0.12.3-next.1
+  resolution: "@backstage/plugin-api-docs@npm:0.12.3-next.1"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/plugin-catalog": "npm:1.26.1-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.29"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-catalog": "npm:1.26.1-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.30-next.0"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4638,21 +4956,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2c8a0b3a5dfff8002d808910ef117888bdc0fa5071c7b56496d48b1b61b7f8f0595894fb541b829211a0415aa8cb562157a5fe8b23c604a57b354b82f4cd01b8
+  checksum: 10/a7290da3ba485316948369a8e92d38ded443b74535404a6f1cce0dec6cd84ac2f037b64801c8ed45fb8a0507a1d121ca09314f85932471be6298ce87d0dc1253
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@npm:^0.4.4-next.0":
-  version: 0.4.4-next.0
-  resolution: "@backstage/plugin-app-backend@npm:0.4.4-next.0"
+"@backstage/plugin-app-backend@npm:^0.4.4-next.1":
+  version: 0.4.4-next.1
+  resolution: "@backstage/plugin-app-backend@npm:0.4.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/config-loader": "npm:1.9.5-next.0"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-app-node": "npm:0.1.29-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/config-loader": "npm:1.9.5-next.1"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-app-node": "npm:0.1.29-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -4663,20 +4981,46 @@ __metadata:
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     yn: "npm:^4.0.0"
-  checksum: 10/bdc9bf4929b2a8faa7937528a047a3eb5e839be411cc510b047837f8608e00842021013c83102a24de89793b7df70fddb5336b01f05bb39a7508bb282bac2f60
+  checksum: 10/745c43b65f8adf76f0be40c83e1739e51efe095d5056f2839d61f6904f2cdee8f6eef36cfeb2013eb9f595c66d4895833b04d46df4dc58d3c39a87b4c3acefe2
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-node@npm:0.1.29-next.0":
-  version: 0.1.29-next.0
-  resolution: "@backstage/plugin-app-node@npm:0.1.29-next.0"
+"@backstage/plugin-app-node@npm:0.1.29-next.1":
+  version: 0.1.29-next.1
+  resolution: "@backstage/plugin-app-node@npm:0.1.29-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config-loader": "npm:1.9.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config-loader": "npm:1.9.5-next.1"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     fs-extra: "npm:^11.2.0"
-  checksum: 10/2d7a0489271884451a8b9294f6ed89eee88cfa45aab58a3ed7a76af9b8f54c2d8e364c413a56685361c34b54811d0175ce464017cd20ee6fb907e76d824308a6
+  checksum: 10/07a68e08b42e52e50e2c4c86dde81294558d7cbe7069905cff07e5fdc59d0a7c2655a9cd298f47ecd7fad23e62a89c7e33c549ae2bbaa223d21fe790859ccba8
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-app@npm:0.1.5-next.0":
+  version: 0.1.5-next.0
+  resolution: "@backstage/plugin-app@npm:0.1.5-next.0"
+  dependencies:
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/integration-react": "npm:1.2.3-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.30-next.0"
+    "@backstage/theme": "npm:0.6.3"
+    "@material-ui/core": "npm:^4.9.13"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/9e768e9bc0d5b1001e004b4ee0e5b0b15e9cbc2a344f5b8ebe30f1ff3f8cb349714c330a0231eca59873326c8a8b71887e903d1561d9616a9cfa6f9c13bf1d28
   languageName: node
   linkType: hard
 
@@ -4706,270 +5050,270 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-atlassian-provider@npm:0.3.4-next.0":
-  version: 0.3.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-atlassian-provider@npm:0.3.4-next.0"
+"@backstage/plugin-auth-backend-module-atlassian-provider@npm:0.3.4-next.1":
+  version: 0.3.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-atlassian-provider@npm:0.3.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
     passport-atlassian-oauth2: "npm:^2.1.0"
-  checksum: 10/8262ad8e72b82d166d9ba0859dbbbd442228e80588ea3b2605280896afa659435a3ea68ccfebea0c3b85f1df650a795b1a611b1271b9f70aec291b1a203b1d03
+  checksum: 10/9596b3773f323e02638f52e7ca696ec0fe363892fa7d7fa93c077b8ae00b31db96d9b1c38e779bb1b41b68c7af85cd12bfcf4a7dc42b7afa2f446703dfbde3ec
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-auth0-provider@npm:0.1.4-next.0":
-  version: 0.1.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-auth0-provider@npm:0.1.4-next.0"
+"@backstage/plugin-auth-backend-module-auth0-provider@npm:0.1.4-next.1":
+  version: 0.1.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-auth0-provider@npm:0.1.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     express: "npm:^4.17.1"
     passport-auth0: "npm:^1.4.3"
     passport-oauth2: "npm:^1.6.1"
-  checksum: 10/2b921a3cc27669ab75fb99eb1392cc50454f69329780bb658cf866f95c8a0c9b310a12fd751776a80e2b4772e1da50e525b953a3fbb682a8fe50bf5dbae18a2b
+  checksum: 10/db8441c3ce402d637d0887ea42e2e5ec22c80be05ea5f50a5b8b897c7f3c99c3c734a153775cf50103f86988b92ff212d997c52e1acc97773879c4959066f3a6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.3.2-next.0":
-  version: 0.3.2-next.0
-  resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.3.2-next.0"
+"@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.3.2-next.1":
+  version: 0.3.2-next.1
+  resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.3.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-backend": "npm:0.24.2-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-backend": "npm:0.24.2-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     jose: "npm:^5.0.0"
     node-cache: "npm:^5.1.2"
-  checksum: 10/f9d5048939d31e6e04ca180dc3747ba28f9cad34dfd3fdf634f2c837d68342f4ab9e973ee06591d7e720160f5b4238e3763a763537e53e2fc5d9902f11a31fb0
+  checksum: 10/064ea87a05a6e2893c9ec3301cf3d4aad751272cc79f631f62fd21d9882843c8fbd794ffb555f32abafe04efab5420b433a4483a693f1dfeb1b56f4ea8b3c020
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:0.2.4-next.0"
+"@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     "@types/passport": "npm:^1.0.16"
     express: "npm:^4.19.2"
     jose: "npm:^5.0.0"
     passport: "npm:^0.7.0"
-  checksum: 10/0322d056be7d836871662cb544a709ec7dce5f5c38501089911557fb9a33e3af1e8bf5c2b3e4b6ef4df84d3a550ca8396ac01540ef80c2b69f2b6ca506a89b9e
+  checksum: 10/e55dd215b1d61ad731a2ab484fe1f9bc4577cdc4a69ac98bf3bb5860235975578e4b4362f06f06f32a26a90d4915e96d440c68782bd281ef583b97b302e76c72
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.2.4-next.0"
+"@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
     passport-bitbucket-oauth2: "npm:^0.1.2"
-  checksum: 10/0cfd75d6bd168e2421f943012a7e128b81907644038d1e78ab23abcc8da7d2028ee51e65cef19f7f65c1ee238b117f761ba223a08be571075bc1074cb7b1a3ae
+  checksum: 10/27d0469aeeb91c3a617dec8847d600ccd204c0255bc7d751afa2f0b868a834e8f427da0dce8a71efa6eb7c47798697a1af53ada24171238ba3954b3390fc7116
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-bitbucket-server-provider@npm:0.1.4-next.0":
-  version: 0.1.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-bitbucket-server-provider@npm:0.1.4-next.0"
+"@backstage/plugin-auth-backend-module-bitbucket-server-provider@npm:0.1.4-next.1":
+  version: 0.1.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-bitbucket-server-provider@npm:0.1.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     passport: "npm:^0.7.0"
     passport-oauth2: "npm:^1.6.1"
-  checksum: 10/ad78b7906948c5b1a32a24b6a1d8906d7c2d2dc6526efabae33f6b1a0e09965fe3b701eb6fa1969bf6d7bd219e6e4b4386ccd463cd558129cdd0cd393dad298d
+  checksum: 10/6d87ac0ed5649978f48fbd7e0a4ed1a0f1741ed23483349b78aaafaed0e98da79e8a422418079b7162fc8ce62c7af5a6f08899a8a67ae8a8a187e4ed8004da04
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:0.3.4-next.0":
-  version: 0.3.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:0.3.4-next.0"
+"@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:0.3.4-next.1":
+  version: 0.3.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:0.3.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     express: "npm:^4.18.2"
     jose: "npm:^5.0.0"
-  checksum: 10/02143fc8d4f33e0a0871890d06ec9a4e8f88e34615fd96d8ebe66f7deb409abd3e9e79f639b05a5f320cab7f1739b73cf02819bc6a50baad36fbbc7872780a7f
+  checksum: 10/f00a633f74b758df68406d3a146bb3f5c87e6016fcb771d6ce950f0cabf13e53ffa1545b18032fe8d74b4841e33f53fabafb004f044fea708711e42f020b61fd
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:0.3.4-next.0":
-  version: 0.3.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:0.3.4-next.0"
+"@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:0.3.4-next.1":
+  version: 0.3.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:0.3.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     google-auth-library: "npm:^9.0.0"
-  checksum: 10/86e610f2463e6e54def039b4775a1a1b45d87606f04f0d72c2f0f3f479cf3710a0726f6dbc245b4da6dd1addad7ba8a03d4773b34166d538c6c03c22f0401781
+  checksum: 10/222bbe0972fc54848a9709aad983c138f65c5823285f15ab823685cb04cf9c4b7cf5a1fa0db299d4e1da86faafa847343229521de6fe268f2c1b71e4d4e9b1e4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@npm:0.2.4-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.2.4-next.0"
+"@backstage/plugin-auth-backend-module-github-provider@npm:0.2.4-next.1, @backstage/plugin-auth-backend-module-github-provider@npm:^0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     passport-github2: "npm:^0.1.12"
-  checksum: 10/feba2fa1e4a3b9e9b4f062f53702f3e26f4654cd0a249f07c48f46605353b1e82e2fdd88fb1ff97477fc640a016071ed075b9f3d411dda1b1e40fc562394b609
+  checksum: 10/0c288f3452bd35fb5f66d81d99fc01a7e5008fa49fb91c289e5e9c1d473475e8037f300c71256b1405db80abd2c7fbbfdf8e4a966e23849cd28321d08bd4457f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-gitlab-provider@npm:0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-gitlab-provider@npm:0.2.4-next.0"
+"@backstage/plugin-auth-backend-module-gitlab-provider@npm:0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-gitlab-provider@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
     passport-gitlab2: "npm:^5.0.0"
-  checksum: 10/f1606d12ac9bafaccce2bf882b30868807e91d08cf5702396cf144749f69fa0ad85f1bd748adfd61ceb382b0be860a7f2ff903bb73e0efaf95304b543fe4c709
+  checksum: 10/e13161b4735af75fc81c44e154fc62654600fbee6d6fb64307cdb533602d3163dc92ba8f6738d752456640121ab031294d542af0d7ba2b54f29a87235f705637
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-google-provider@npm:0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-google-provider@npm:0.2.4-next.0"
+"@backstage/plugin-auth-backend-module-google-provider@npm:0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-google-provider@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     google-auth-library: "npm:^9.0.0"
     passport-google-oauth20: "npm:^2.0.0"
-  checksum: 10/73a6776190dcca7091ead72fbb2132ca7a67de7d669cfdc5fd069e90155f9e9443842f9c6d9f8fa6e5fe3be72811a743f4cb00cc887e3b31456850f66ae182c8
+  checksum: 10/7bd335ad2a81927068bdfccb1f8a99eccadba27ddbb3aaa31c190259c84ba9a447cf2bc30f82337f0e549035690579ef00fb037cfe12aa8e9229cec1c66b069b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.4-next.0"
+"@backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     passport-oauth2: "npm:^1.7.0"
-  checksum: 10/98a1c50f60381d676cb2da6e37374e71ee1cabbf6cd45c137b3d46e903ff119c4d5bb4168f3595726c0b5b40fdd81cec10c6bb27ffde8f1888dc82b586d8ac7e
+  checksum: 10/bfc77f9c5fda6534988417396acc571955badb8314e7d9fd9cf49c403010eb82d75bbc7f444fcf1df91857eecd8ed27a60421fd4b040831a52c9df1bc680c34d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-microsoft-provider@npm:0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-microsoft-provider@npm:0.2.4-next.0"
+"@backstage/plugin-auth-backend-module-microsoft-provider@npm:0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-microsoft-provider@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     express: "npm:^4.18.2"
     jose: "npm:^5.0.0"
     passport-microsoft: "npm:^1.0.0"
-  checksum: 10/9a8cb4cf987972434ac1721d3860eb4caaaf5d32b89297c24bbdb2491d9f45343bfca1a83b0fa5ed8e19337281cc02bd6472f98159ed52f07aa1a76934c9999a
+  checksum: 10/f1e56feb6e38dadfdfb8dc04eb396ac5b56630f060d7d88180b9c97703443d8904e8c42e12eb3e66d9da37cf9b17b60dc9517919c6257b258f252c2501cd2159
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-oauth2-provider@npm:0.3.4-next.0":
-  version: 0.3.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-oauth2-provider@npm:0.3.4-next.0"
+"@backstage/plugin-auth-backend-module-oauth2-provider@npm:0.3.4-next.1":
+  version: 0.3.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-oauth2-provider@npm:0.3.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     passport: "npm:^0.7.0"
     passport-oauth2: "npm:^1.6.1"
-  checksum: 10/eb2c3f77b5735dcda87c1dc8aa497ffa9fef0d9fff8ec0f72820c4b6f95ccacd056696d91e4cb5e08165a0d1c270f5eecd402d6eeae55eb8a862ba3b28c01e4d
+  checksum: 10/589151ec39f897f67bfe914ab10b35d80d744c8932fb50678d1eeb9d6817fe71bbdbf7173be79a4f60fd307959d670e07cbd21efa222b44c837282e8c99a25ce
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:0.2.4-next.0"
+"@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     jose: "npm:^5.0.0"
-  checksum: 10/37734fb8a4d00edc9fd97c2bfc56a1e8f295c345c99eac9dbe6a7d814b408d45f4d7ca866b9455810263b70f6f70e56329bb21ebd397531265e76e14b95e158c
+  checksum: 10/27672e5f76683d6fd68095ec83fb50d4f954d544e20c86b9c1356b1c1f01676a376b82304ba610fa7027bae1a62fcc8b4eb5a2756d79bfde866d63ac66a20fd4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-oidc-provider@npm:0.3.4-next.0":
-  version: 0.3.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.3.4-next.0"
+"@backstage/plugin-auth-backend-module-oidc-provider@npm:0.3.4-next.1":
+  version: 0.3.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.3.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-backend": "npm:0.24.2-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-backend": "npm:0.24.2-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     express: "npm:^4.18.2"
     openid-client: "npm:^5.5.0"
     passport: "npm:^0.7.0"
-  checksum: 10/aa3e22ad657990f95f70ede8a4a0dfd4120ef4be12f07454150751909e6705072c4e1e40e732a72d236c8686f36fa48f18559cb4b66f756610fb37456adfe948
+  checksum: 10/58bacb062e13c71791d652dd3dbcc75a6dbf947cecac9d26ded24b526c9f93c875ccf26b102e417be28da7ebdfbc136b3d42df442f88ab51272fe5925de60319
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-okta-provider@npm:0.1.4-next.0":
-  version: 0.1.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-okta-provider@npm:0.1.4-next.0"
+"@backstage/plugin-auth-backend-module-okta-provider@npm:0.1.4-next.1":
+  version: 0.1.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-okta-provider@npm:0.1.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     "@davidzemon/passport-okta-oauth": "npm:^0.0.5"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
-  checksum: 10/badd2129f63ec2ed42c3aec0928b0d31184c4edb882e0ad929da807a2fc19305c9c590195ce2ccf049703d549ec59240c3c7d4699314942ac95a5a588f7d4b7c
+  checksum: 10/1ae7f244accf6549752c3efe05586602a8b5e8b7928a1412637aa0e73bfcaa219afce71d117d6e4c7f0605149fd127e5e4147d7143d0b389fe43cc0d388ced69
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-onelogin-provider@npm:0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-auth-backend-module-onelogin-provider@npm:0.2.4-next.0"
+"@backstage/plugin-auth-backend-module-onelogin-provider@npm:0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-auth-backend-module-onelogin-provider@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
     passport-onelogin-oauth: "npm:^0.0.1"
-  checksum: 10/3692a0d2bce142bf00d4f4bd6d15600b03b28b39d5ba44ffc25d03a3a0e6d05879e31ff1d66ec15adbedcd52f94ed0dba0a7ae23c7277c0bff7ea5a0933168c4
+  checksum: 10/dfff5732906be4ccf0f40aff0a6f22a7a41f721217e0eaecf5d0999b462013c45a07b91234f1ee27ba481fec5ba6d6c6450f0d1040f78c2f4f2f93eb148061f7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@npm:0.24.2-next.0, @backstage/plugin-auth-backend@npm:^0.24.2-next.0":
-  version: 0.24.2-next.0
-  resolution: "@backstage/plugin-auth-backend@npm:0.24.2-next.0"
+"@backstage/plugin-auth-backend@npm:0.24.2-next.1, @backstage/plugin-auth-backend@npm:^0.24.2-next.1":
+  version: 0.24.2-next.1
+  resolution: "@backstage/plugin-auth-backend@npm:0.24.2-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-backend-module-atlassian-provider": "npm:0.3.4-next.0"
-    "@backstage/plugin-auth-backend-module-auth0-provider": "npm:0.1.4-next.0"
-    "@backstage/plugin-auth-backend-module-aws-alb-provider": "npm:0.3.2-next.0"
-    "@backstage/plugin-auth-backend-module-azure-easyauth-provider": "npm:0.2.4-next.0"
-    "@backstage/plugin-auth-backend-module-bitbucket-provider": "npm:0.2.4-next.0"
-    "@backstage/plugin-auth-backend-module-bitbucket-server-provider": "npm:0.1.4-next.0"
-    "@backstage/plugin-auth-backend-module-cloudflare-access-provider": "npm:0.3.4-next.0"
-    "@backstage/plugin-auth-backend-module-gcp-iap-provider": "npm:0.3.4-next.0"
-    "@backstage/plugin-auth-backend-module-github-provider": "npm:0.2.4-next.0"
-    "@backstage/plugin-auth-backend-module-gitlab-provider": "npm:0.2.4-next.0"
-    "@backstage/plugin-auth-backend-module-google-provider": "npm:0.2.4-next.0"
-    "@backstage/plugin-auth-backend-module-microsoft-provider": "npm:0.2.4-next.0"
-    "@backstage/plugin-auth-backend-module-oauth2-provider": "npm:0.3.4-next.0"
-    "@backstage/plugin-auth-backend-module-oauth2-proxy-provider": "npm:0.2.4-next.0"
-    "@backstage/plugin-auth-backend-module-oidc-provider": "npm:0.3.4-next.0"
-    "@backstage/plugin-auth-backend-module-okta-provider": "npm:0.1.4-next.0"
-    "@backstage/plugin-auth-backend-module-onelogin-provider": "npm:0.2.4-next.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.15.1-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-backend-module-atlassian-provider": "npm:0.3.4-next.1"
+    "@backstage/plugin-auth-backend-module-auth0-provider": "npm:0.1.4-next.1"
+    "@backstage/plugin-auth-backend-module-aws-alb-provider": "npm:0.3.2-next.1"
+    "@backstage/plugin-auth-backend-module-azure-easyauth-provider": "npm:0.2.4-next.1"
+    "@backstage/plugin-auth-backend-module-bitbucket-provider": "npm:0.2.4-next.1"
+    "@backstage/plugin-auth-backend-module-bitbucket-server-provider": "npm:0.1.4-next.1"
+    "@backstage/plugin-auth-backend-module-cloudflare-access-provider": "npm:0.3.4-next.1"
+    "@backstage/plugin-auth-backend-module-gcp-iap-provider": "npm:0.3.4-next.1"
+    "@backstage/plugin-auth-backend-module-github-provider": "npm:0.2.4-next.1"
+    "@backstage/plugin-auth-backend-module-gitlab-provider": "npm:0.2.4-next.1"
+    "@backstage/plugin-auth-backend-module-google-provider": "npm:0.2.4-next.1"
+    "@backstage/plugin-auth-backend-module-microsoft-provider": "npm:0.2.4-next.1"
+    "@backstage/plugin-auth-backend-module-oauth2-provider": "npm:0.3.4-next.1"
+    "@backstage/plugin-auth-backend-module-oauth2-proxy-provider": "npm:0.2.4-next.1"
+    "@backstage/plugin-auth-backend-module-oidc-provider": "npm:0.3.4-next.1"
+    "@backstage/plugin-auth-backend-module-okta-provider": "npm:0.1.4-next.1"
+    "@backstage/plugin-auth-backend-module-onelogin-provider": "npm:0.2.4-next.1"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.15.1-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@google-cloud/firestore": "npm:^7.0.0"
     "@node-saml/passport-saml": "npm:^5.0.0"
     "@types/express": "npm:^4.17.6"
@@ -5001,21 +5345,21 @@ __metadata:
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/11456fa759d5b51fcd4187d97b997a997301152cb8192b0052384efb70c3d9d4600bb63a4cd4e2660bc663cf191dfd2e51234a08959d78f80b6fca08105ba2e2
+  checksum: 10/ff9f118c63d0805aebdd12cbbb51b3ab288473709cd198897b4d7fe6959821b27919ec8ec0b9d399c3b137fced2be330c37a60902da53565d6a7d65135983cf5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:0.5.6-next.0":
-  version: 0.5.6-next.0
-  resolution: "@backstage/plugin-auth-node@npm:0.5.6-next.0"
+"@backstage/plugin-auth-node@npm:0.5.6-next.1":
+  version: 0.5.6-next.1
+  resolution: "@backstage/plugin-auth-node@npm:0.5.6-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@types/express": "npm:^4.17.6"
     "@types/passport": "npm:^1.0.3"
     express: "npm:^4.17.1"
@@ -5026,7 +5370,7 @@ __metadata:
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.21.4"
     zod-validation-error: "npm:^3.4.0"
-  checksum: 10/9228022ba0dae320ab7fed698255bc4b0b61c89809e608383e474ee7e8f8bbbd258e80080071ad3c89d4a78b8f366aacf3556c873ddb56a0181e66a921581cb2
+  checksum: 10/5e7602742481278e79626a9b11bec583bd0c38d7be1342f0e04342e8917eff76c36c4d29d70574ec3e5eac7bf295a0d071483b8336e0d2f4abb913a117d43663
   languageName: node
   linkType: hard
 
@@ -5080,13 +5424,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-react@npm:0.1.10":
-  version: 0.1.10
-  resolution: "@backstage/plugin-auth-react@npm:0.1.10"
+"@backstage/plugin-auth-react@npm:0.1.11-next.0":
+  version: 0.1.11-next.0
+  resolution: "@backstage/plugin-auth-react@npm:0.1.11-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.16.2"
-    "@backstage/core-plugin-api": "npm:^1.10.2"
-    "@backstage/errors": "npm:^1.2.6"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
     "@material-ui/core": "npm:^4.9.13"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
@@ -5097,63 +5441,63 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/90179fb0c50bbfa814af1280862881b544067b22c4a7c66c7de3f48c8dc30f56ba713b72c739ee5825e18cfb36f7e19d5c75c21597933ab6017b93a5c6b2e78e
+  checksum: 10/a0a07ddb130d9f4df02c2dc8988fa1938934ff74dec4a8645f291b46fb0df1f7af41db1bb97cea7e43ea9f1dd5bbc175828955048fda4ccc6a50931e1988ad8f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-bitbucket-cloud-common@npm:0.2.26":
-  version: 0.2.26
-  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.2.26"
+"@backstage/plugin-bitbucket-cloud-common@npm:0.2.27-next.0":
+  version: 0.2.27-next.0
+  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.2.27-next.0"
   dependencies:
-    "@backstage/integration": "npm:^1.16.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
     cross-fetch: "npm:^4.0.0"
-  checksum: 10/8e50aba3ab5ac0def28acac11ece042f55fe6306557ff0c01a98c192db42d8412e92babd44f022ff89f7a95df127dea4ac2b176f7c1585698c5a95a66b489d24
+  checksum: 10/ac4e4767e9167ae340d4eb1647bab3cbdd1bc83a6466589cd391d1257785e4ae47ae6e905fe4ecc8354bfe1820ff9a568de7621fc000712f62ba4b32699cb12b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@npm:^0.1.6-next.0":
-  version: 0.1.6-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.6-next.0"
+"@backstage/plugin-catalog-backend-module-logs@npm:^0.1.6-next.1":
+  version: 0.1.6-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.6-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/plugin-catalog-backend": "npm:1.30.0-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.7-next.0"
-  checksum: 10/771a87b505ef7a429cf9ea6ee44066dec0e653bc6d1dcce9903c695f54a34bb6e66d96f348135e8f2174bd1dea6a151e6877267f9dc82d9361d1dfdb4e0a6aea
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/plugin-catalog-backend": "npm:1.30.0-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.7-next.1"
+  checksum: 10/dffee8e8e6cbcabfcc88a83ea236fa9253e82f96cf3172f0fb00e90229026f1b1704214bce20b96417873c3edd7a680bb6e617c9d21b1264334108e28ccde839
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.4-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.4-next.0"
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.4-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-catalog-node": "npm:1.15.1-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.8"
-  checksum: 10/78879cf2584123ea4eb95a48524865b93bae9c2f4850686b049f71e1d6bf967cb5711d4b75f3bfe6c054638d011ab3896a35cce837da4dc386728713d1042734
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.15.1-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.9-next.0"
+  checksum: 10/47d5e3267ffe1d9981725f127b386e0646308849306159db2cb6022eb7fb2ca61a6b1a1a5549ccfa66b161e09437ad4d32e0e7ee3a004b33d40b8725af04972c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@npm:1.30.0-next.0, @backstage/plugin-catalog-backend@npm:^1.30.0-next.0":
-  version: 1.30.0-next.0
-  resolution: "@backstage/plugin-catalog-backend@npm:1.30.0-next.0"
+"@backstage/plugin-catalog-backend@npm:1.30.0-next.1, @backstage/plugin-catalog-backend@npm:^1.30.0-next.1":
+  version: 1.30.0-next.1
+  resolution: "@backstage/plugin-catalog-backend@npm:1.30.0-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-openapi-utils": "npm:0.4.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-catalog-node": "npm:1.15.1-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.7-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-permission-node": "npm:0.8.7-next.0"
-    "@backstage/plugin-search-backend-module-catalog": "npm:0.3.0-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-openapi-utils": "npm:0.4.1-next.1"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.15.1-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.7-next.1"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-permission-node": "npm:0.8.7-next.1"
+    "@backstage/plugin-search-backend-module-catalog": "npm:0.3.0-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/express": "npm:^4.17.6"
     codeowners-utils: "npm:^1.0.2"
@@ -5173,11 +5517,22 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/1a12d17526f26cb7409277c5553e993a27624208b0f5437f5706dc569ed26fc5e6d11abd1cfde38ffa25fd89277ffdea60969c152688d159fcb31b0274e2015f
+  checksum: 10/c9969bfc4b30053b25a17c44ceccceaf77613930194dc6420dd2313a14a3ea7249dbce5ea2ddc39c7d6b32a338b066fb237c58d685a8f884e72d05077bd86f3e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@npm:1.1.2, @backstage/plugin-catalog-common@npm:^1.1.2":
+"@backstage/plugin-catalog-common@npm:1.1.3-next.0":
+  version: 1.1.3-next.0
+  resolution: "@backstage/plugin-catalog-common@npm:1.1.3-next.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
+  checksum: 10/9c939068a9fc6d68fa37c31b83b53ab085d33273fec29d00bb4c8ad178688ed229a9558ffaa197f28ef97239e557d3a931403bc2ca9248f5c94a402580e0a912
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-common@npm:^1.1.2":
   version: 1.1.2
   resolution: "@backstage/plugin-catalog-common@npm:1.1.2"
   dependencies:
@@ -5188,18 +5543,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@npm:^0.4.15-next.0":
-  version: 0.4.15-next.0
-  resolution: "@backstage/plugin-catalog-graph@npm:0.4.15-next.0"
+"@backstage/plugin-catalog-graph@npm:^0.4.15-next.1":
+  version: 0.4.15-next.1
+  resolution: "@backstage/plugin-catalog-graph@npm:0.4.15-next.1"
   dependencies:
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5216,23 +5571,23 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c824c811c64116475a012d46ca1bc1181063ce541ad8cef45371bb2272d1a9b893b201b2ce8791db18bacb64bba50d54b0fba4367219888331370db25de47f4c
+  checksum: 10/ef67b2bb208c13144faaaacf7ab18f4f5dddf75acabb817c4a6873f59b67ed269f88750bd882f51be0b29e7da218ad25e4c8a4307c7a9403a8761b702cc9dbfe
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:1.15.1-next.0, @backstage/plugin-catalog-node@npm:^1.15.1-next.0":
-  version: 1.15.1-next.0
-  resolution: "@backstage/plugin-catalog-node@npm:1.15.1-next.0"
+"@backstage/plugin-catalog-node@npm:1.15.1-next.1, @backstage/plugin-catalog-node@npm:^1.15.1-next.1":
+  version: 1.15.1-next.1
+  resolution: "@backstage/plugin-catalog-node@npm:1.15.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-permission-node": "npm:0.8.7-next.0"
-    "@backstage/types": "npm:1.2.0"
-  checksum: 10/121cff3ac46fa6473fddb2aaa54ee0944b466be87bc4afd454784826e54c4ee618accbc71b60bbabb6e130960fb7282870a09d62d5dac8cb87eb8d351d310dad
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-permission-node": "npm:0.8.7-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
+  checksum: 10/f090345ea4ae44875d7de24006be5f70fcda23153fe970f130487f4a9c5ad96016190f69fa70e697d93fb1e07d0954d0e428a472560c5c05ce3ab2e431bc926e
   languageName: node
   linkType: hard
 
@@ -5252,23 +5607,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@npm:1.15.1-next.0, @backstage/plugin-catalog-react@npm:^1.15.1-next.0":
-  version: 1.15.1-next.0
-  resolution: "@backstage/plugin-catalog-react@npm:1.15.1-next.0"
+"@backstage/plugin-catalog-react@npm:1.15.1-next.1, @backstage/plugin-catalog-react@npm:^1.15.1-next.1":
+  version: 1.15.1-next.1
+  resolution: "@backstage/plugin-catalog-react@npm:1.15.1-next.1"
   dependencies:
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/frontend-test-utils": "npm:0.2.4"
-    "@backstage/integration-react": "npm:1.2.2"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-permission-react": "npm:0.4.29"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/frontend-test-utils": "npm:0.2.5-next.0"
+    "@backstage/integration-react": "npm:1.2.3-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.30-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@backstage/version-bridge": "npm:1.0.10"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5289,7 +5644,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/446efc96b4760d528db77d1184d384aa51930d0c4a1e654ad1a5fca5ef82a8574578b8a02f639c18357ede9a8f6e4510d9788da062b0f26363bad7f068c09258
+  checksum: 10/2548d7f86e5ebc73290a5d11b8dfd1708bd58f85bfedcf964181d5bdd4417b17885b9b90117dc71ca60212ce1d4eb14b71f5cbd1c5e48acdfc857ca8879acb51
   languageName: node
   linkType: hard
 
@@ -5334,25 +5689,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@npm:1.26.1-next.0, @backstage/plugin-catalog@npm:^1.26.1-next.0":
-  version: 1.26.1-next.0
-  resolution: "@backstage/plugin-catalog@npm:1.26.1-next.0"
+"@backstage/plugin-catalog@npm:1.26.1-next.1, @backstage/plugin-catalog@npm:^1.26.1-next.1":
+  version: 1.26.1-next.1
+  resolution: "@backstage/plugin-catalog@npm:1.26.1-next.1"
   dependencies:
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/integration-react": "npm:1.2.2"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.29"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.8"
-    "@backstage/plugin-search-common": "npm:1.2.16"
-    "@backstage/plugin-search-react": "npm:1.8.4"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/integration-react": "npm:1.2.3-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.30-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.9-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
+    "@backstage/plugin-search-react": "npm:1.8.5-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5372,50 +5727,50 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1ebf03ba155f5c858c270e7e55212738c7c55e583c510f652db60172c5695f9681bfab0c43ca82042ef7c37923e28e39f1c5b95952026bae01bbc12f55df2b6e
+  checksum: 10/e60e4b37c6170e6e29175f7ee597a524d6f17fcbc45a0b8ecd5f367ce6233450cc3801614ef78573b04d2e3859f961f3410920564092d19c583a91c01a2803df
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@npm:^0.4.1-next.0":
-  version: 0.4.1-next.0
-  resolution: "@backstage/plugin-events-backend@npm:0.4.1-next.0"
+"@backstage/plugin-events-backend@npm:^0.4.1-next.1":
+  version: 0.4.1-next.1
+  resolution: "@backstage/plugin-events-backend@npm:0.4.1-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-openapi-utils": "npm:0.4.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-events-node": "npm:0.4.7-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-openapi-utils": "npm:0.4.1-next.1"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.7-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@types/express": "npm:^4.17.6"
     content-type: "npm:^1.0.5"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     winston: "npm:^3.2.1"
-  checksum: 10/33987ec032442d7e007970aa443dbaecb6afc7af97427e7467071307662664289cd8ab230445c13d801a2f4b6b0e8c42bb2f8636b7200709c19894eb6b3269d9
+  checksum: 10/e6d04bfa02e75ed46fb0cf938e3e1494549fc0d2d847df933ac7a1281bec66a5d1b94f8042cc328d72a0190d34459dfea24b6604d3ac39e7162aeaf9523f122d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-node@npm:0.4.7-next.0":
-  version: 0.4.7-next.0
-  resolution: "@backstage/plugin-events-node@npm:0.4.7-next.0"
+"@backstage/plugin-events-node@npm:0.4.7-next.1":
+  version: 0.4.7-next.1
+  resolution: "@backstage/plugin-events-node@npm:0.4.7-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     cross-fetch: "npm:^4.0.0"
     uri-template: "npm:^2.0.0"
-  checksum: 10/0a7889f590a2e8ea7a5d0839d5a09587f1c49319f7c5ab8178d978887f3495ebd967b42d426cf3106018a19db7c1314af86aa11161bfb7582dfc2191c68f1c7b
+  checksum: 10/f9aa247993c1690b0793a0ea2d1f8def62edb259cd69e2c606c31cb148e3490191a7cc1d4417562172b377b71cc0967ea8248c96e495d4a2fc1831b036a5e378
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@npm:0.1.22-next.0":
-  version: 0.1.22-next.0
-  resolution: "@backstage/plugin-home-react@npm:0.1.22-next.0"
+"@backstage/plugin-home-react@npm:0.1.22-next.1":
+  version: 0.1.22-next.1
+  resolution: "@backstage/plugin-home-react@npm:0.1.22-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@rjsf/utils": "npm:5.23.2"
@@ -5427,24 +5782,24 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/592f0893f2f7d97f97f9eddc291993cc1306db69e9a6110bd70fa307d894765b1eeb15fb9f20cec8930a2e6c391a93dac9e54bb800006fdd8ce2967404cb9185
+  checksum: 10/56015e5ca3fc42974b083a31aeaeb9c8379ad655bea76c39572f6a3ae4507e821b4e5a1f5d46cc5f6f7b34e477f116b7d5a2a7f9f421c9f759c45d308718e42e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@npm:^0.8.4-next.1":
-  version: 0.8.4-next.1
-  resolution: "@backstage/plugin-home@npm:0.8.4-next.1"
+"@backstage/plugin-home@npm:^0.8.4-next.2":
+  version: 0.8.4-next.2
+  resolution: "@backstage/plugin-home@npm:0.8.4-next.2"
   dependencies:
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/core-app-api": "npm:1.15.3"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/plugin-home-react": "npm:0.1.22-next.0"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/core-app-api": "npm:1.15.4-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/plugin-home-react": "npm:0.1.22-next.1"
     "@backstage/theme": "npm:0.6.3"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5467,32 +5822,32 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b37397ee8a7482253bc88334066fd7c488a4f1a5dbcefaa0510a0ad0f307b798e11faf4ec2e2e95fe46a0ab680d045c4a32240f5fa0d4d61ead4d7932b4a8d42
+  checksum: 10/06eff9124ec0cf7e364e1aad4fd87f5ba0248b7d9834821b6beddd0464bcad93fea5bc8489d9f7c61e441071ce51b502a4786c0ffae39a60625352ed5ca1995e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@npm:^0.19.2-next.0":
-  version: 0.19.2-next.0
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.2-next.0"
+"@backstage/plugin-kubernetes-backend@npm:^0.19.2-next.1":
+  version: 0.19.2-next.1
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.2-next.1"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@aws-sdk/signature-v4": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration-aws-node": "npm:0.1.14"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.15.1-next.0"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.1"
-    "@backstage/plugin-kubernetes-node": "npm:0.2.2-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-permission-node": "npm:0.8.7-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration-aws-node": "npm:0.1.15-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.15.1-next.1"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.2-next.0"
+    "@backstage/plugin-kubernetes-node": "npm:0.2.2-next.1"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-permission-node": "npm:0.8.7-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@google-cloud/container": "npm:^5.0.0"
     "@jest-mock/express": "npm:^2.0.1"
     "@kubernetes/client-node": "npm:1.0.0-rc7"
@@ -5513,50 +5868,50 @@ __metadata:
     stream-buffers: "npm:^3.0.2"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/7823be223aaaee0bdaea463667bdee76c32ac2024cdc2d18aac4fcb34d0ac209da535ba732002f2437b3f0c116edf4b6b65ea5949ae6472598e51ebd71c80227
+  checksum: 10/5d288a9fb5182d93bc0f287a129afd3d8bf3a748911e46a20e47e2950489ae9d9cd1ceeb2e1e7aa002d07552142ab1967b55a247a680cf4a259d3ff07e4bd47a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-common@npm:0.9.1, @backstage/plugin-kubernetes-common@npm:^0.9.1":
-  version: 0.9.1
-  resolution: "@backstage/plugin-kubernetes-common@npm:0.9.1"
+"@backstage/plugin-kubernetes-common@npm:0.9.2-next.0":
+  version: 0.9.2-next.0
+  resolution: "@backstage/plugin-kubernetes-common@npm:0.9.2-next.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.2"
-    "@backstage/plugin-permission-common": "npm:^0.8.3"
-    "@backstage/types": "npm:^1.2.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@kubernetes/client-node": "npm:1.0.0-rc7"
     kubernetes-models: "npm:^4.3.1"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-  checksum: 10/6853d8fdf731d9521674e307f0c2c99c38bc6da1ad13acbf0104a202eb7bfb07c2e90f0166bf2238fd8cbdbc758065d03ba78d98d5474b4c1bcd5a59f9c5a654
+  checksum: 10/c8f9e934a4723e12d4a6425ca70fa3ee8568ffa1d8255d29a47019092f09933ab1dc6eba9934a7f133d46e0e509fcbd4e2c1bdc8d4a3a784a1c84ecfa705b073
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-node@npm:0.2.2-next.0":
-  version: 0.2.2-next.0
-  resolution: "@backstage/plugin-kubernetes-node@npm:0.2.2-next.0"
+"@backstage/plugin-kubernetes-node@npm:0.2.2-next.1":
+  version: 0.2.2-next.1
+  resolution: "@backstage/plugin-kubernetes-node@npm:0.2.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.1"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.2-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@kubernetes/client-node": "npm:1.0.0-rc7"
     node-fetch: "npm:^2.7.0"
     winston: "npm:^3.2.1"
-  checksum: 10/a88d179675d1207734974fdb6f3a56a217003513dc82a6dee7698ee5809268b714a325f02c036c02d3828d186d470570eca365e40666f83bf05de1dbc580748b
+  checksum: 10/b006a8c34d0ed676044875e7338c69cd00eb9fb3e8d34d0d96ae7176d8fd420421d5b48e3cfe1e1ecfa8b92f5d81577214d9378946bc3ba388a6360a3a16ae71
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-react@npm:0.5.2":
-  version: 0.5.2
-  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.2"
+"@backstage/plugin-kubernetes-react@npm:0.5.3-next.0":
+  version: 0.5.3-next.0
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.3-next.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.2"
-    "@backstage/core-components": "npm:^0.16.2"
-    "@backstage/core-plugin-api": "npm:^1.10.2"
-    "@backstage/errors": "npm:^1.2.6"
-    "@backstage/plugin-kubernetes-common": "npm:^0.9.1"
-    "@backstage/types": "npm:^1.2.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.2-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
     "@kubernetes/client-node": "npm:1.0.0-rc7"
@@ -5580,22 +5935,22 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/848a98b8faa3975e8c39f1742c4952d9339725757c2efa093011282f25674e5f40dcc7707af8d6ce92bf0f1ff5893cf2c93dade6ae76b9eb22245f55546e8b1c
+  checksum: 10/b554177c702565b0360e765c3e7c83a4a037cc02ce531c1b76545fbbb7b0f75da941a470d7cb2627bba7980365ea31e76997b6c2fcf2ad04866af584f1d11f39
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@npm:^0.12.3-next.0":
-  version: 0.12.3-next.0
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.3-next.0"
+"@backstage/plugin-kubernetes@npm:^0.12.3-next.1":
+  version: 0.12.3-next.1
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.3-next.1"
   dependencies:
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.1"
-    "@backstage/plugin-kubernetes-react": "npm:0.5.2"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.2-next.0"
+    "@backstage/plugin-kubernetes-react": "npm:0.5.3-next.0"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
     "@kubernetes/client-node": "npm:1.0.0-rc7"
@@ -5616,71 +5971,71 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fd3d2459e4a64b78e70c813d62c8a40e7d0d7bbeee5c4ba684a2fb4b4d61efb8f328b14867bbf0247b6968733f967eec09670b61cf6bf7f498621a3746339ac7
+  checksum: 10/0702ead464366a509bbba5216f73be72e6614565800475676bff4d851d74339ea2d14ff3cb26562bbc3acf224bdb68d9198020273e46153a4d44c1563b01ef5f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@npm:^0.5.1-next.0":
-  version: 0.5.1-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.5.1-next.0"
+"@backstage/plugin-notifications-backend@npm:^0.5.1-next.1":
+  version: 0.5.1-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.5.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.15.1-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.7-next.0"
-    "@backstage/plugin-notifications-common": "npm:0.0.7"
-    "@backstage/plugin-notifications-node": "npm:0.2.11-next.0"
-    "@backstage/plugin-signals-node": "npm:0.1.16-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.15.1-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.7-next.1"
+    "@backstage/plugin-notifications-common": "npm:0.0.8-next.0"
+    "@backstage/plugin-notifications-node": "npm:0.2.11-next.1"
+    "@backstage/plugin-signals-node": "npm:0.1.16-next.1"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/7a30bba28cc91a34c49a0544ab37f951d24dc4b351e2598bfd06d7195e06d9afeb3d1b718f93b06e45e319a306e5ed9a8ec15d60eb89e10322d394e1263e9dcb
+  checksum: 10/bce463bdcca8e17baf0db4160913b997e5bfffd97744450d9aba67872b95e0bfd3572705a685a5318fdd4d0d3dda9e4c175e9d6814ad5f30fc6fccee6096b414
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-common@npm:0.0.7, @backstage/plugin-notifications-common@npm:^0.0.7":
-  version: 0.0.7
-  resolution: "@backstage/plugin-notifications-common@npm:0.0.7"
+"@backstage/plugin-notifications-common@npm:0.0.8-next.0":
+  version: 0.0.8-next.0
+  resolution: "@backstage/plugin-notifications-common@npm:0.0.8-next.0"
   dependencies:
-    "@backstage/config": "npm:^1.3.1"
+    "@backstage/config": "npm:1.3.2-next.0"
     "@material-ui/icons": "npm:^4.9.1"
-  checksum: 10/784575670e37db1494d5ab381044ff4fb1bdf85d5061d093c0253451b04bc2700bb35ee75ac160f3cba17e38fddaf3eaa3502a2fafdd7d78499c7c2c94992006
+  checksum: 10/2041eb50a84ce476534e689dfaf96f1865cb7932110b72aff49923211c0ab2d336a6ff70fe41170da1105e33d6a57a226bf134eee6ba9eed52cf0577ff95ebb1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@npm:0.2.11-next.0":
-  version: 0.2.11-next.0
-  resolution: "@backstage/plugin-notifications-node@npm:0.2.11-next.0"
+"@backstage/plugin-notifications-node@npm:0.2.11-next.1":
+  version: 0.2.11-next.1
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.11-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/plugin-notifications-common": "npm:0.0.7"
-    "@backstage/plugin-signals-node": "npm:0.1.16-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/plugin-notifications-common": "npm:0.0.8-next.0"
+    "@backstage/plugin-signals-node": "npm:0.1.16-next.1"
     knex: "npm:^3.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/7950f9e535efdd72df241ec0ccc23628d1060dd57d042112986179478f2e32eee1fa91d45117bbdd218c33c65911c8e1cfc1faf3735d422b6403007bdda1d2e0
+  checksum: 10/4870da6050d823c68a4b5ed4636e22e511798bd2a220a512bc82b42a89b01c56db1a39bff4940bd626b39aa85e207e40e960389d47138667caff42d77bf81a39
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@backstage/plugin-notifications@npm:0.5.0"
+"@backstage/plugin-notifications@npm:^0.5.1-next.0":
+  version: 0.5.1-next.0
+  resolution: "@backstage/plugin-notifications@npm:0.5.1-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.16.2"
-    "@backstage/core-plugin-api": "npm:^1.10.2"
-    "@backstage/errors": "npm:^1.2.6"
-    "@backstage/plugin-notifications-common": "npm:^0.0.7"
-    "@backstage/plugin-signals-react": "npm:^0.0.8"
-    "@backstage/theme": "npm:^0.6.3"
-    "@backstage/types": "npm:^1.2.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-notifications-common": "npm:0.0.8-next.0"
+    "@backstage/plugin-signals-react": "npm:0.0.9-next.0"
+    "@backstage/theme": "npm:0.6.3"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
@@ -5697,21 +6052,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8d4d3f668622607d95827d2c4b67a668bb2f0d2d152e70c4ca622d01efecb2f340cbe31f869cdcb2028af1078094343ff6fb62cf7f3ea1dfbb6f05f34b9ced0f
+  checksum: 10/a3d9e16bd235c8eeee6350b273068eb52f5a53eb82da0a2df33e4097d1c06ba707f7512a8bb593429881bfd62f8490e8b75e922a2675fd9b358ee1edec3ddc81
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@npm:^0.6.35-next.0":
-  version: 0.6.35-next.0
-  resolution: "@backstage/plugin-org@npm:0.6.35-next.0"
+"@backstage/plugin-org@npm:^0.6.35-next.1":
+  version: 0.6.35-next.1
+  resolution: "@backstage/plugin-org@npm:0.6.35-next.1"
   dependencies:
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5728,11 +6083,26 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/96a0ca6991e1a6682d9f28fa920075e502267f4bff0d5dc293302e88cda10d22b5f0910ceb26eefbc2823108ebfc3c5b2d16d3f0f56b10fd5448e75a79c3cc5a
+  checksum: 10/9a6dcba7e46d07b90e96b0d3b1f1ee07aa80bbc23d2114b3b2371ee698606b97758d29a7620fef87c4d1c762118e685ed7305f217202dad5911779bff0f2fa05
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-common@npm:0.8.3, @backstage/plugin-permission-common@npm:^0.8.0, @backstage/plugin-permission-common@npm:^0.8.3":
+"@backstage/plugin-permission-common@npm:0.8.4-next.0":
+  version: 0.8.4-next.0
+  resolution: "@backstage/plugin-permission-common@npm:0.8.4-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+    cross-fetch: "npm:^4.0.0"
+    uuid: "npm:^11.0.0"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.20.4"
+  checksum: 10/e4fa9b944a44fe118e9e974562566989c2fe7d01b2bc19e07862d28d48f2cda359a3e4c0a8492c75259247d9a2c628e47ed32d921b72b734012abe4759d4ace5
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-common@npm:^0.8.0, @backstage/plugin-permission-common@npm:^0.8.3":
   version: 0.8.3
   resolution: "@backstage/plugin-permission-common@npm:0.8.3"
   dependencies:
@@ -5747,22 +6117,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:0.8.7-next.0":
-  version: 0.8.7-next.0
-  resolution: "@backstage/plugin-permission-node@npm:0.8.7-next.0"
+"@backstage/plugin-permission-node@npm:0.8.7-next.1":
+  version: 0.8.7-next.1
+  resolution: "@backstage/plugin-permission-node@npm:0.8.7-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/bbbc6d8d3d8e53cb207e528f3c2bfcffa288df550181bcdacfa614acaf85234d31c172359c011b166d075ee01e03bc83a469f217bdf5de9a2bd2d37106c68109
+  checksum: 10/f3239897202d67ceedd2160d6318941d9eb4fd3f477bf8322ab23846a590fe0444d6b0d319eb8b8b6b3976bfc6d45fa20c2e525f64c82778e5a809a5d20d0cd0
   languageName: node
   linkType: hard
 
@@ -5785,7 +6155,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-react@npm:0.4.29, @backstage/plugin-permission-react@npm:^0.4.29":
+"@backstage/plugin-permission-react@npm:0.4.30-next.0":
+  version: 0.4.30-next.0
+  resolution: "@backstage/plugin-permission-react@npm:0.4.30-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    swr: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/4589b44b795a9c6ea9c698d1b20e073cd38f92f1bdb164bcd24d4c7eb5259a88e6f21625cdbc63a9bce82660e5a06910f49db39520fc6a867405d17e3e0f17c4
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-react@npm:^0.4.29":
   version: 0.4.29
   resolution: "@backstage/plugin-permission-react@npm:0.4.29"
   dependencies:
@@ -5805,14 +6195,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@npm:^0.5.10-next.0":
-  version: 0.5.10-next.0
-  resolution: "@backstage/plugin-proxy-backend@npm:0.5.10-next.0"
+"@backstage/plugin-proxy-backend@npm:^0.5.10-next.1":
+  version: 0.5.10-next.1
+  resolution: "@backstage/plugin-proxy-backend@npm:0.5.10-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -5823,171 +6213,171 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     yup: "npm:^1.0.0"
-  checksum: 10/b5302d1f16621ac8cf7e0f8925725ac2ec030fb4aef3b14aecbb7402d9d5c5fd359976aab1e422cf03473b008a0b8b2d33e7057a8a1d15b34c4183bf4ae5db9e
+  checksum: 10/d0cb16bb992e065c7de140eca6927f6c46492d34ab92def4ef2d820969981763ab6afcd946b418e900f412d145ba4e9be23cce804ecb7cee7ef070eefb13a15c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.5-next.0":
-  version: 0.2.5-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.5-next.0"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.5-next.1":
+  version: 0.2.5-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.5-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.1"
     azure-devops-node-api: "npm:^14.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/47ed18f67586e509c41a616ae30e40448b382e1bba4aa0f9eca1b25e1588786f39810867f0c328b2f57ab7e75d99c1eebae7de8d290667a305b922a4bc396dba
+  checksum: 10/9ad4671b34f235a9ac19783661795a2d97fc9a2316dc9206e705ad44bd541881b8e36fe0cd479952510219c08507818b614fea9719975ccfad55a24388e5e8f7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.5-next.0":
-  version: 0.2.5-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.5-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.5-next.1":
+  version: 0.2.5-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.5-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.26"
-    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.27-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/6b4b62231e1a71b239323e1d115ed924897c59a30833c9107ee9a519567ffab911cc8647ba80d8f4fce96f82f0660c397e1502de80cad109c88840a674c46ad0
+  checksum: 10/4f996033a933ed73c0f49796619a0ff258efc42dc578217c21fd7f9d15b7ad0b17cddc788d33d42b9f3a8f66ea3a3826c049cd0ecb025be5f6ea483ca1d46c6b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.5-next.0":
-  version: 0.2.5-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.5-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.5-next.1":
+  version: 0.2.5-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.5-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/923c5932baa50561083ac45e66661f6691204fc943efe4368cfa696bbf178a99c0c42d21781200ff132e4a023ab59b420aa43e11f1975a39a1f2e0f85a975726
+  checksum: 10/58147bcba3ed99d8a482c3cb3a8194ef7e2ad732d8d2d332ff602714fa17b5132d14061ec0ab98713be901d2ecfe0ad2d5bb4364a14cf477db57737c92ef19af
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.6-next.0":
-  version: 0.3.6-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.6-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.6-next.1":
+  version: 0.3.6-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.6-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.5-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.5-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.5-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.5-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/7d3e2b82206b8b28373e4776c09c4407c03cb9bd327620cd83aaacdf8d041718a73c94fcc8e12939f4a34599e568dc9665459c1c9f99a44b8a8af7039aa95782
+  checksum: 10/29fdfc39fb9a47afb394e079aed87326b72d07193e354c9b3cc889953684c9addd06a8abf50b5aa886b64fc2204106d394f99740a6097d62e82d50deec4c8b51
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.5-next.0":
-  version: 0.2.5-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.5-next.0"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.5-next.1":
+  version: 0.2.5-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.5-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/4290693c06ab0671e9209f13fd1f8260ce807815a23b717bffc59cbc10f495f30a52aee3110944586432e093c7a79db63bf8dcb19102fbce12439bfdd276e33e
+  checksum: 10/ba85747ea860bee7f64cac53e474fd2d2abbe0054b1f2a07358307a9a53a8014fafb7351d0f347718276a2cf6edf88c237db81f406ddc441b385110878f2a4c5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.5-next.0":
-  version: 0.2.5-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.5-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.5-next.1":
+  version: 0.2.5-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.5-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/d2704b18415d17c821fb68be0ab4bf357cda37446b5319b4249e65847030246b1ce02ee81b73d5a5215578402d7f357fc0ec350002f90596d50ca6a2d66bac62
+  checksum: 10/6f55d57a370cbea46582d03be24dbf1dbe8416a44f975eb4b44e4162a79e58303511e95749518e120ed31cb5d783677095f69a0e219f8ec362be3d87719cbf97
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@npm:0.5.5-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.5.5-next.1":
-  version: 0.5.5-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.5.5-next.1"
+"@backstage/plugin-scaffolder-backend-module-github@npm:0.5.5-next.2, @backstage/plugin-scaffolder-backend-module-github@npm:^0.5.5-next.2":
+  version: 0.5.5-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.5.5-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.1"
     "@octokit/webhooks": "npm:^10.9.2"
     libsodium-wrappers: "npm:^0.7.11"
     octokit: "npm:^3.0.0"
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/e458701b3f4e9af95526f633ae5f060d324c0b98c7ca5df274267ddac57baa0328eaae1314be769d6181e84c4b61bd56266ef3645b28ca3d4f3dae562b7194ab
+  checksum: 10/6572264ddce580a29eafe34cb1d092ca363555faf7e39200963cd0db592b01d7052b66a723b166bffe00f356e6ef67773c1614fb09768857129e1194e4b41e9f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.7.1-next.0":
-  version: 0.7.1-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.7.1-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.7.1-next.1":
+  version: 0.7.1-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.7.1-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.1"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     winston: "npm:^3.2.1"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/e2684459e828e9f6e006788c5318b114a6784baf33696074954a00624b9da9e3a3d4e62ebc9cdea1f3b84e5ece1bb29186f7198e2acec8f4bb8556dfdd98a606
+  checksum: 10/fea28deaf94873ddd6010dd45fd4af2bfb19f21377b2bd83b7e9e1169b9931d62cc9fc531ee74d339f1e81878041a4e00867353287e79838f5ee7597e34c6c47
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@npm:^1.29.0-next.1":
-  version: 1.29.0-next.1
-  resolution: "@backstage/plugin-scaffolder-backend@npm:1.29.0-next.1"
+"@backstage/plugin-scaffolder-backend@npm:^1.29.0-next.2":
+  version: 1.29.0-next.2
+  resolution: "@backstage/plugin-scaffolder-backend@npm:1.29.0-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-defaults": "npm:0.7.0-next.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.26"
-    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.4-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.15.1-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.7-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-permission-node": "npm:0.8.7-next.0"
-    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.5-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.6-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.5-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.5-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.5-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.5-next.0"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.5.5-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.7.1-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.8"
-    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-defaults": "npm:0.7.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.27-next.0"
+    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.4-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.15.1-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.7-next.1"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-permission-node": "npm:0.8.7-next.1"
+    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.5-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.6-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.5-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.5-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.5-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.5-next.1"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.5.5-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.7.1-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.9-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.6.3-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/express": "npm:^4.17.6"
     "@types/luxon": "npm:^3.0.0"
@@ -6015,32 +6405,32 @@ __metadata:
     yaml: "npm:^2.0.0"
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
-  checksum: 10/5d3466af55b32731a2d432ced6f2727698ba089aea90cafc3a5d8bf7be886ff8f22b7b45e042185ab26ebb0430c34358d72f4376dd992039286b3a41e76899b7
+  checksum: 10/af7527a73d43b420a2b337a04af41bd6687aa19f0030bb0fc87b67a7aad657d64d61320e1635fdc8932c16bc1ee22177da0b716494c62c4ad4a841ac357c7145
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-common@npm:1.5.8":
-  version: 1.5.8
-  resolution: "@backstage/plugin-scaffolder-common@npm:1.5.8"
+"@backstage/plugin-scaffolder-common@npm:1.5.9-next.0":
+  version: 1.5.9-next.0
+  resolution: "@backstage/plugin-scaffolder-common@npm:1.5.9-next.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.2"
-    "@backstage/plugin-permission-common": "npm:^0.8.3"
-    "@backstage/types": "npm:^1.2.0"
-  checksum: 10/6ad9a6dc339d15e6345d5ad7b3a6a6a8634b5e9e164970a7546e823f718ad6ce435912466c6d7842751d0796536694cdf74dad904cf14b87557adb5b939d10fc
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+  checksum: 10/ee31f94feed5eae9730f369d55b8d8a13e41413547df32e695dd662e524a6d8a44ebe83202a242abc03ec5e811bb17086069c43490cc18934b218253ba1f72be
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:0.6.3-next.0":
-  version: 0.6.3-next.0
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.6.3-next.0"
+"@backstage/plugin-scaffolder-node@npm:0.6.3-next.1":
+  version: 0.6.3-next.1
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.6.3-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.8"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.9-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     concat-stream: "npm:^2.0.0"
     fs-extra: "npm:^11.2.0"
     globby: "npm:^11.0.0"
@@ -6051,24 +6441,24 @@ __metadata:
     winston: "npm:^3.2.1"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/9c84ee07d34ba0d03ce0e601ad7f28b4524fd64273843e23d4929fd67c9e9b34dfa69059650f6debd31f80013c194d9c2d489b80bbb1b0da93b419281985d30e
+  checksum: 10/7eda10ce71eb45af13a5a756647935be48d55cef718b5780b82fa6f96ed817e28a8cb20b3352ddae3470a6cc1e16b01824fee832c84e2ba4cbd184e82ef55d5d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.14.3-next.1":
-  version: 1.14.3-next.1
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.14.3-next.1"
+"@backstage/plugin-scaffolder-react@npm:1.14.3-next.2":
+  version: 1.14.3-next.2
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.14.3-next.2"
   dependencies:
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.29"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.8"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.30-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.9-next.0"
     "@backstage/theme": "npm:0.6.3"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@backstage/version-bridge": "npm:1.0.10"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6101,29 +6491,29 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/04bf15760dbe0fe207236b0a9c123b487e0689da47e3068137dd1681becd8d9d1eaa7db66ccbd47705fa95b08851ccde46ca992f677a912855acca6aad882170
+  checksum: 10/6ec751423b739a86bf93cb4c28bab4df263d2fe7b4529304d247b3a9e9d82723543a8c2344e296abffd888e64ed0ee7e7670028bca1a82914d5b093f78056bdd
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@npm:^1.27.4-next.1":
-  version: 1.27.4-next.1
-  resolution: "@backstage/plugin-scaffolder@npm:1.27.4-next.1"
+"@backstage/plugin-scaffolder@npm:^1.27.4-next.2":
+  version: 1.27.4-next.2
+  resolution: "@backstage/plugin-scaffolder@npm:1.27.4-next.2"
   dependencies:
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/integration-react": "npm:1.2.2"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.29"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.8"
-    "@backstage/plugin-scaffolder-react": "npm:1.14.3-next.1"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/integration-react": "npm:1.2.3-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.30-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.9-next.0"
+    "@backstage/plugin-scaffolder-react": "npm:1.14.3-next.2"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
     "@codemirror/view": "npm:^6.0.0"
@@ -6162,96 +6552,96 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3dc4d19658a568a9de2e48ecd7901511d64fd1721bce0099483e029800f5041d3b2ee536aeab51d21f1e78456fcfa38390d2c70b60550f18d6080b6028e4e719
+  checksum: 10/138df13c86b843c58048c0b7e2d6bf6404ab357c949ef9a138dffdd7e7dcfbeb9d9236f2b84b278e045a908412ba1f45085e1d7256441664d81c41aed62b7a34
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@npm:0.3.0-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.0-next.0":
-  version: 0.3.0-next.0
-  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.0-next.0"
+"@backstage/plugin-search-backend-module-catalog@npm:0.3.0-next.1, @backstage/plugin-search-backend-module-catalog@npm:^0.3.0-next.1":
+  version: 0.3.0-next.1
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-catalog-node": "npm:1.15.1-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-search-backend-node": "npm:1.3.7-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.16"
-  checksum: 10/69c256e4c0642c082d28a80c66b136212d8eb44eed6756058ddfe7ab0bf11e7650f446c65f1b8af4e2ac71e5decc913c6477b518adec903955c7f167ed49507f
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.15.1-next.1"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-search-backend-node": "npm:1.3.7-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
+  checksum: 10/999492e554dd275188a43882613f8b8ef8ddd613d89ccde0793ddf1e7bcebc35956bc06cf67b3c10bd08714e4314809fc11eef9c52ae2302b703bfcd0b39fe17
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-explore@npm:^0.2.7-next.0":
-  version: 0.2.7-next.0
-  resolution: "@backstage/plugin-search-backend-module-explore@npm:0.2.7-next.0"
+"@backstage/plugin-search-backend-module-explore@npm:^0.2.7-next.1":
+  version: 0.2.7-next.1
+  resolution: "@backstage/plugin-search-backend-module-explore@npm:0.2.7-next.1"
   dependencies:
     "@backstage-community/plugin-explore-common": "npm:^0.0.7"
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/plugin-search-backend-node": "npm:1.3.7-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.16"
-  checksum: 10/cdf680b2216fd8a4a20b379ff6cbab9a2b6c2f62f2e2aa52263e428cfd56a61796ab01161bd8889255a85937e89a79b2904a2660894609eedc707d188e1450f1
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/plugin-search-backend-node": "npm:1.3.7-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
+  checksum: 10/32bb111e359931c2a093b107c6a8b0cb72b895818c20e033bd774fca93a2ba66b5f93018a51bbb7e1c05f36f733dadb99b087cbc16d94f6749dae00142bd6ae9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-techdocs@npm:0.3.5-next.0":
-  version: 0.3.5-next.0
-  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.3.5-next.0"
+"@backstage/plugin-search-backend-module-techdocs@npm:0.3.5-next.1":
+  version: 0.3.5-next.1
+  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.3.5-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-catalog-node": "npm:1.15.1-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-search-backend-node": "npm:1.3.7-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.16"
-    "@backstage/plugin-techdocs-node": "npm:1.12.16-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.15.1-next.1"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-search-backend-node": "npm:1.3.7-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
+    "@backstage/plugin-techdocs-node": "npm:1.12.16-next.1"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/503b31cdc13dffeb475b6a407948723ae6c85c1baae1cc4fb4484fa577d5aba94f020c021e4824e71783fad6ec34f355c416d1092d4fc4a2ad9bbcf48406e8cd
+  checksum: 10/15bc3fea3c536ee49682b33617df092e387aedfcc1487fa8a4adc02fe2ba9acda3733e908ba13dd5a63ea9a5675a56ee099fbf91b518cc3c7b64f18175ea5777
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-node@npm:1.3.7-next.0":
-  version: 1.3.7-next.0
-  resolution: "@backstage/plugin-search-backend-node@npm:1.3.7-next.0"
+"@backstage/plugin-search-backend-node@npm:1.3.7-next.1":
+  version: 1.3.7-next.1
+  resolution: "@backstage/plugin-search-backend-node@npm:1.3.7-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-search-common": "npm:1.2.16"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
     "@types/lunr": "npm:^2.3.3"
     lodash: "npm:^4.17.21"
     lunr: "npm:^2.3.9"
     ndjson: "npm:^2.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/27cc4d24e0813ceecb7bc313e5f91d00443db1af32c62b25b5fd9c692228308c5b8597803d1bea918c77559f8bb253a824ca0cf195c7199348793a4cf3a313e9
+  checksum: 10/2898bc1e25ef6a67060065fae8076bb225d2e8fa7844e6ecf38c906f67326d45467ecd7c9d6489d888689cfdf3a9ff983ceb9c15791dfd4d797262d8d02c3b09
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@npm:^1.8.1-next.0":
-  version: 1.8.1-next.0
-  resolution: "@backstage/plugin-search-backend@npm:1.8.1-next.0"
+"@backstage/plugin-search-backend@npm:^1.8.1-next.1":
+  version: 1.8.1-next.1
+  resolution: "@backstage/plugin-search-backend@npm:1.8.1-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-defaults": "npm:0.7.0-next.0"
-    "@backstage/backend-openapi-utils": "npm:0.4.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-permission-node": "npm:0.8.7-next.0"
-    "@backstage/plugin-search-backend-node": "npm:1.3.7-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.16"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-defaults": "npm:0.7.0-next.1"
+    "@backstage/backend-openapi-utils": "npm:0.4.1-next.1"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-permission-node": "npm:0.8.7-next.1"
+    "@backstage/plugin-search-backend-node": "npm:1.3.7-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@types/express": "npm:^4.17.6"
     dataloader: "npm:^2.0.0"
     express: "npm:^4.17.1"
@@ -6259,11 +6649,21 @@ __metadata:
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/0c3a9bfc85897bbc5f7d7ab066d5b535d952624c8a1afb9c369a50abc2c7dc8e3c997ccf66cd3fc315af1453ca4c143b41be9c5407d39e358292b87c9767af03
+  checksum: 10/feb5a0df734cf5b0c09164eee7bdab5cf9fed4743bc5373a7976adcd5bce9dee5dbcf845538dfd146b4ee1033430719083f61460ad12a2f11dffb7c70b054bd0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-common@npm:1.2.16, @backstage/plugin-search-common@npm:^1.2.16":
+"@backstage/plugin-search-common@npm:1.2.17-next.0":
+  version: 1.2.17-next.0
+  resolution: "@backstage/plugin-search-common@npm:1.2.17-next.0"
+  dependencies:
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
+  checksum: 10/fb2e0da6595190d1cabf685b2f2b1e6835bb092020c527e3686806a6b9460b5fd257b5f180c7cbb016bd01d01705125425a0c0ad8478fa85a2d59a732fd94847
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-common@npm:^1.2.16":
   version: 1.2.16
   resolution: "@backstage/plugin-search-common@npm:1.2.16"
   dependencies:
@@ -6273,7 +6673,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@npm:1.8.4, @backstage/plugin-search-react@npm:^1.8.4":
+"@backstage/plugin-search-react@npm:1.8.5-next.0, @backstage/plugin-search-react@npm:^1.8.5-next.0":
+  version: 1.8.5-next.0
+  resolution: "@backstage/plugin-search-react@npm:1.8.5-next.0"
+  dependencies:
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
+    "@backstage/theme": "npm:0.6.3"
+    "@backstage/types": "npm:1.2.1-next.0"
+    "@backstage/version-bridge": "npm:1.0.10"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    lodash: "npm:^4.17.21"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.3.2"
+    uuid: "npm:^11.0.2"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/c12183c6b7152c1e63042b9ebeaeb14ee3fb8d3359cedca3f99f09c5cef0e5cf6e8bb0cbcaa3b8cd98548dd9ce6b98a2dbc86b2655419d594e9b55efc67c151b
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-react@npm:^1.8.4":
   version: 1.8.4
   resolution: "@backstage/plugin-search-react@npm:1.8.4"
   dependencies:
@@ -6303,19 +6733,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@npm:^1.4.22-next.0":
-  version: 1.4.22-next.0
-  resolution: "@backstage/plugin-search@npm:1.4.22-next.0"
+"@backstage/plugin-search@npm:^1.4.22-next.1":
+  version: 1.4.22-next.1
+  resolution: "@backstage/plugin-search@npm:1.4.22-next.1"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.16"
-    "@backstage/plugin-search-react": "npm:1.8.4"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
+    "@backstage/plugin-search-react": "npm:1.8.5-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@backstage/version-bridge": "npm:1.0.10"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6329,20 +6759,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ce0872bb78dd40b9d6a4f471e4f12911af5d4d204ab5192d717fa42fd8912549d6dd33976c3686505b4788fd5e7a69d67129d364b2d949f417ce4caac3bd0d32
+  checksum: 10/5df3d4d713b8cc92eecc0751d204a349b7779396be607040671c0d684f18be8554a8090d1b8b84bcb5eafd1fa0163f3d33cd202582029bb7c22623df9d280f9e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@npm:^0.3.0-next.1":
-  version: 0.3.0-next.1
-  resolution: "@backstage/plugin-signals-backend@npm:0.3.0-next.1"
+"@backstage/plugin-signals-backend@npm:^0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/plugin-signals-backend@npm:0.3.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.7-next.0"
-    "@backstage/plugin-signals-node": "npm:0.1.16-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.7-next.1"
+    "@backstage/plugin-signals-node": "npm:0.1.16-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     http-proxy-middleware: "npm:^2.0.0"
@@ -6350,32 +6780,32 @@ __metadata:
     winston: "npm:^3.2.1"
     ws: "npm:^8.18.0"
     yn: "npm:^4.0.0"
-  checksum: 10/d4631aaf9eac26db2e2d5804ffab895e045074e6b81061b67586328a92524560cafb54e791be53dfa5f0d19d613271517b4bf07318b20d0ee31cddef4e925470
+  checksum: 10/8e648c692203284a4c44f5eeeffd3563956e252db1fc9853989f22f2971b877cf82849a9e1fb5b73ac2a4de5721f5e70b197701c92b6ae54f336eab19ca0b431
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-node@npm:0.1.16-next.0":
-  version: 0.1.16-next.0
-  resolution: "@backstage/plugin-signals-node@npm:0.1.16-next.0"
+"@backstage/plugin-signals-node@npm:0.1.16-next.1":
+  version: 0.1.16-next.1
+  resolution: "@backstage/plugin-signals-node@npm:0.1.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/plugin-auth-node": "npm:0.5.6-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.7-next.0"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/plugin-auth-node": "npm:0.5.6-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.7-next.1"
+    "@backstage/types": "npm:1.2.1-next.0"
     express: "npm:^4.17.1"
     uuid: "npm:^11.0.0"
     ws: "npm:^8.18.0"
-  checksum: 10/444a34ece19be5ad6f6438383b155b7682d0874c98c3a4769af643a582c397a838e0e96fa47535318716d1fbd815c60cd917a373386b6c5d9db7d1f17e624247
+  checksum: 10/eb0b74ee4afed8ef4156f9146246311eea3d5a7d89716923819deca56c48de188b0144847d388b004fe173f10baf11a9b81ab767116ee399ab1884c53050a1e5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-react@npm:0.0.8, @backstage/plugin-signals-react@npm:^0.0.8":
-  version: 0.0.8
-  resolution: "@backstage/plugin-signals-react@npm:0.0.8"
+"@backstage/plugin-signals-react@npm:0.0.9-next.0":
+  version: 0.0.9-next.0
+  resolution: "@backstage/plugin-signals-react@npm:0.0.9-next.0"
   dependencies:
-    "@backstage/core-plugin-api": "npm:^1.10.2"
-    "@backstage/types": "npm:^1.2.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@material-ui/core": "npm:^4.12.4"
   peerDependencies:
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -6385,19 +6815,19 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/17f7163f3f1b27db352a121c527a2c22fb033cd69116d39c66b8a88c7f4334b5953a080845e32f0a4a946fb2e2c27bd35471839013102c0643f25416f819f0ba
+  checksum: 10/e3945d91f4d774e4db9d875f92979ba2bf7e555ca1aaf00f6ce15b8f03c17068d4f7eaaa25b8e6d54f9249821106dda9432207c63fc41ec2ccfb5d926f0b98e5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@npm:^0.0.14":
-  version: 0.0.14
-  resolution: "@backstage/plugin-signals@npm:0.0.14"
+"@backstage/plugin-signals@npm:^0.0.15-next.0":
+  version: 0.0.15-next.0
+  resolution: "@backstage/plugin-signals@npm:0.0.15-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.16.2"
-    "@backstage/core-plugin-api": "npm:^1.10.2"
-    "@backstage/plugin-signals-react": "npm:^0.0.8"
-    "@backstage/theme": "npm:^0.6.3"
-    "@backstage/types": "npm:^1.2.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/plugin-signals-react": "npm:0.0.9-next.0"
+    "@backstage/theme": "npm:0.6.3"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
@@ -6411,27 +6841,27 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/864ada125f177b3f1414facd4a33fc29269ebd49b7035de1650822e71610eca22cd0fadea79fce051fe07f2327d1e8fc9a9c6769691d59d0e122fa780337a72d
+  checksum: 10/446cc89bf0c816ca5a9a43b41a249b12ac9627a7db00bdf65602292a24df851aca27dcf055bc909c99952cabd2417bc85404dd2c46a797476e9cd2f71f150390
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@npm:^1.11.5-next.1":
-  version: 1.11.5-next.1
-  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.5-next.1"
+"@backstage/plugin-techdocs-backend@npm:^1.11.5-next.2":
+  version: 1.11.5-next.2
+  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.5-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-client": "npm:1.9.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.2"
-    "@backstage/plugin-catalog-node": "npm:1.15.1-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.3"
-    "@backstage/plugin-search-backend-module-techdocs": "npm:0.3.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-client": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.15.1-next.1"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-search-backend-module-techdocs": "npm:0.3.5-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-node": "npm:1.12.16-next.0"
+    "@backstage/plugin-techdocs-node": "npm:1.12.16-next.1"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -6440,7 +6870,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/bf08574dd6999205772b72c31252ac64f4282e3625f90300e718c4c05773fd3faa291a4711aecbba43653eee2791be356e2d96e536b17b82d11b59a8bb5fc9b9
+  checksum: 10/34a16b7804e461972fbba4c6ead9608cdacc139c05930e4f44951e7042c067b9a2f52e8a723f0e92e72df4f57c367530b0a46c5aeffea00f8149202b6bb8e011
   languageName: node
   linkType: hard
 
@@ -6451,15 +6881,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.20-next.0":
-  version: 1.1.20-next.0
-  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.20-next.0"
+"@backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.20-next.1":
+  version: 1.1.20-next.1
+  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.20-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/integration-react": "npm:1.2.2"
-    "@backstage/plugin-techdocs-react": "npm:1.2.12"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/integration-react": "npm:1.2.3-next.0"
+    "@backstage/plugin-techdocs-react": "npm:1.2.13-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@react-hookz/web": "npm:^24.0.0"
@@ -6473,13 +6903,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9dbc9315fffa4fe84f5205d368bbd2454eb82a50f33bdfffceb35284c0fcbb9c3a54db74ac00a63df1fce514128f4b6c0946e16393c305e1f3693c883b980bb1
+  checksum: 10/64da3dbb6807551bb4bd276c39f54811f886421cc4cf147c2ef39c5f4dbbd5598719b41846761bd2198b36d164691899dd636f4a378bab283b622afd7d2a4c41
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@npm:1.12.16-next.0, @backstage/plugin-techdocs-node@npm:^1.12.16-next.0":
-  version: 1.12.16-next.0
-  resolution: "@backstage/plugin-techdocs-node@npm:1.12.16-next.0"
+"@backstage/plugin-techdocs-node@npm:1.12.16-next.1, @backstage/plugin-techdocs-node@npm:^1.12.16-next.1":
+  version: 1.12.16-next.1
+  resolution: "@backstage/plugin-techdocs-node@npm:1.12.16-next.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -6487,13 +6917,13 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-plugin-api": "npm:1.1.1-next.0"
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/integration-aws-node": "npm:0.1.14"
-    "@backstage/plugin-search-common": "npm:1.2.16"
+    "@backstage/backend-plugin-api": "npm:1.1.1-next.1"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/integration-aws-node": "npm:0.1.15-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
     "@google-cloud/storage": "npm:^7.0.0"
     "@smithy/node-http-handler": "npm:^3.0.0"
@@ -6510,11 +6940,38 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/7c2f337ef6f2b932974c8b2db4173e40a8a7f72f453934a77e2d3f31c1de0e418279839b737ce9814fb49a7eb1f06674c07ada7d0d03a4abac07566461099728
+  checksum: 10/ecfb8026cff51e5982dff916a673cb7d4d1388cac0287b5c276080d578046fc7fef0dc18a3c1895f8a4acea68beffd67711fd883d30abb8164657984c5e97d8c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@npm:1.2.12, @backstage/plugin-techdocs-react@npm:^1.2.12, @backstage/plugin-techdocs-react@npm:^1.2.9":
+"@backstage/plugin-techdocs-react@npm:1.2.13-next.0, @backstage/plugin-techdocs-react@npm:^1.2.13-next.0":
+  version: 1.2.13-next.0
+  resolution: "@backstage/plugin-techdocs-react@npm:1.2.13-next.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/version-bridge": "npm:1.0.10"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/styles": "npm:^4.11.0"
+    jss: "npm:~10.10.0"
+    lodash: "npm:^4.17.21"
+    react-helmet: "npm:6.1.0"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/3cdbed3733eef6c9be491ba6fa2bb07914a9f961f66891c975a495d07af761888f1fe8703aefff13bf019c29dedfc0b8ca59efab57897d393d4b880c17b625b8
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs-react@npm:^1.2.9":
   version: 1.2.12
   resolution: "@backstage/plugin-techdocs-react@npm:1.2.12"
   dependencies:
@@ -6541,25 +6998,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@npm:^1.12.1-next.0":
-  version: 1.12.1-next.0
-  resolution: "@backstage/plugin-techdocs@npm:1.12.1-next.0"
+"@backstage/plugin-techdocs@npm:^1.12.1-next.1":
+  version: 1.12.1-next.1
+  resolution: "@backstage/plugin-techdocs@npm:1.12.1-next.1"
   dependencies:
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/config": "npm:1.3.1"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/integration": "npm:1.16.0"
-    "@backstage/integration-react": "npm:1.2.2"
-    "@backstage/plugin-auth-react": "npm:0.1.10"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.16"
-    "@backstage/plugin-search-react": "npm:1.8.4"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/integration": "npm:1.16.1-next.0"
+    "@backstage/integration-react": "npm:1.2.3-next.0"
+    "@backstage/plugin-auth-react": "npm:0.1.11-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.17-next.0"
+    "@backstage/plugin-search-react": "npm:1.8.5-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-react": "npm:1.2.12"
+    "@backstage/plugin-techdocs-react": "npm:1.2.13-next.0"
     "@backstage/theme": "npm:0.6.3"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6580,7 +7037,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1ad8404e14cbad03d78b5b3a82147b8b7080de7c9cb93646abd9e1f384751a202107fd9f366fa6898ecafad3a855fcc5247acb32a468c045b715af021c04f562
+  checksum: 10/d56d355d5043ea21f6eef48cffa91188a47563e954dbf74129e449170b1ad90094784f8c699df3ae6ad7e275f2f99fcb94d45346540a0b55494ad22c23351fd2
   languageName: node
   linkType: hard
 
@@ -6591,22 +7048,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@npm:^0.8.18-next.0":
-  version: 0.8.18-next.0
-  resolution: "@backstage/plugin-user-settings@npm:0.8.18-next.0"
+"@backstage/plugin-user-settings@npm:^0.8.18-next.1":
+  version: 0.8.18-next.1
+  resolution: "@backstage/plugin-user-settings@npm:0.8.18-next.1"
   dependencies:
-    "@backstage/catalog-model": "npm:1.7.2"
-    "@backstage/core-app-api": "npm:1.15.3"
-    "@backstage/core-compat-api": "npm:0.3.4"
-    "@backstage/core-components": "npm:0.16.2"
-    "@backstage/core-plugin-api": "npm:1.10.2"
-    "@backstage/errors": "npm:1.2.6"
-    "@backstage/frontend-plugin-api": "npm:0.9.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.1-next.0"
-    "@backstage/plugin-signals-react": "npm:0.0.8"
+    "@backstage/catalog-model": "npm:1.7.3-next.0"
+    "@backstage/core-app-api": "npm:1.15.4-next.0"
+    "@backstage/core-compat-api": "npm:0.3.5-next.0"
+    "@backstage/core-components": "npm:0.16.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/errors": "npm:1.2.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.9.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.15.1-next.1"
+    "@backstage/plugin-signals-react": "npm:0.0.9-next.0"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
     "@backstage/theme": "npm:0.6.3"
-    "@backstage/types": "npm:1.2.0"
+    "@backstage/types": "npm:1.2.1-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -6620,7 +7077,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/54fd9622d2f8080c5f6601d0ae6fcf00c99a077e91ac04269f52d675c2c3f0dc6e12acd99110baca4d9e8bc7d8240b4dcf05c947551a165b43d4477727b17f9b
+  checksum: 10/c7ea23562d253e5b127feba1fea71a1d5dabb90752eee5399d1112812b6a32e66fb3b4d2307261f560246e4ae35590ca75c8d5f58851e2783b9b9cf1c0d5f3f8
   languageName: node
   linkType: hard
 
@@ -6628,6 +7085,38 @@ __metadata:
   version: 0.0.12
   resolution: "@backstage/release-manifests@npm:0.0.12"
   checksum: 10/482108faf39bd4095dfda34d00007065bff54a5aff836ef7c935a7a583baa6ae9d25e9d0c58a419e4d7d65eeb4f50357da47ab4d9cbd2d79da331fa426f64a3c
+  languageName: node
+  linkType: hard
+
+"@backstage/test-utils@npm:1.7.4-next.0":
+  version: 1.7.4-next.0
+  resolution: "@backstage/test-utils@npm:1.7.4-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2-next.0"
+    "@backstage/core-app-api": "npm:1.15.4-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.30-next.0"
+    "@backstage/theme": "npm:0.6.3"
+    "@backstage/types": "npm:1.2.1-next.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    cross-fetch: "npm:^4.0.0"
+    i18next: "npm:^22.4.15"
+    zen-observable: "npm:^0.10.0"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/jest": "*"
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/jest":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/abfccce403f757d684c761f29bbbbd749e28a1b4e0568b47c13670e0bd850ed10395f5ade9447698a720f5beeb39800662db4e5ee9b96cd6b6e2f8e90a3e7a99
   languageName: node
   linkType: hard
 
@@ -6699,7 +7188,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/types@npm:1.2.0, @backstage/types@npm:^1.1.1, @backstage/types@npm:^1.2.0":
+"@backstage/types@npm:1.2.1-next.0":
+  version: 1.2.1-next.0
+  resolution: "@backstage/types@npm:1.2.1-next.0"
+  checksum: 10/4c94ba81eb38a6c0fee3455e9ddac6982ba6cb5089412ac9afaeb0f50849b4bbcce6adc3f7614e3034cb38858c4b4b324d0a5ed314ca8d4b7fb77b67fcae2dc1
+  languageName: node
+  linkType: hard
+
+"@backstage/types@npm:^1.1.1, @backstage/types@npm:^1.2.0":
   version: 1.2.0
   resolution: "@backstage/types@npm:1.2.0"
   checksum: 10/7e7b35ed04d055153854d7dd9b2c03097ca4abba12d42d07a3444e2c8474e63c951bad4fb08e95936e2e6a6362d0ea2faa70adebaf19afceadf8e6a765a7ee01


### PR DESCRIPTION
Backstage release v1.35.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.35.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.35.0-next.2-changelog.md)
- Upgrade Helper: [From 1.35.0-next.1 to 1.35.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.35.0-next.1&to=1.35.0-next.2)
 
Created by [Version Bump 12668334749](https://github.com/backstage/demo/actions/runs/12668334749)
 