### PR TITLE
v1.36.0-next.3 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 254c816a15098e2a0b414345caf9144409fbf6a63da7ec8ec8d3454aa1d2edfbbc32cd264d8c464b7ec4aca7809c690848a7c1191b5f8167dec81dbdf6107b01
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.36.0-next.2/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.36.0-next.3/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -66,6 +66,9 @@ auth:
 
 catalog:
   readonly: true
+  # Experimental: Always use the search method in UrlReaderProcessor.
+  # New adopters are encouraged to enable it as this behavior will be the default in a future release.
+  useUrlReadersSearch: true
   rules:
     - allow: [Component, API, System, Domain, Resource, Location, User, Group]
   locations:

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.36.0-next.2"
+  "version": "1.36.0-next.3"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "backstage-cli repo lint --since origin/master",
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
-    "new": "backstage-cli new --scope internal",
+    "new": "backstage-cli new",
     "knip": "knip",
     "prepare": "husky",
     "postinstall": "husky || true"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,17 +3525,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-app-api@npm:1.2.0-next.2":
-  version: 1.2.0-next.2
-  resolution: "@backstage/backend-app-api@npm:1.2.0-next.2"
+"@backstage/backend-app-api@npm:1.2.0-next.3":
+  version: 1.2.0-next.3
+  resolution: "@backstage/backend-app-api@npm:1.2.0-next.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/cli-common": "npm:0.1.15"
     "@backstage/config": "npm:1.3.2"
     "@backstage/config-loader": "npm:1.9.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
-    "@backstage/plugin-permission-node": "npm:0.8.8-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
+    "@backstage/plugin-permission-node": "npm:0.8.8-next.2"
     "@backstage/types": "npm:1.2.1"
     "@manypkg/get-packages": "npm:^1.1.3"
     compression: "npm:^1.7.4"
@@ -3558,7 +3558,7 @@ __metadata:
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     winston-transport: "npm:^4.5.0"
-  checksum: 10/3f4058e9f09526696f33637816d975c30692c9c8c4c07e6210483bf1179677f25f8e36c5e88d99aa30ed663fb7d95069294fa03333e31ab02cb66ecc13ae9dcd
+  checksum: 10/0a7f0e41f53f8700887443a3c3ba336e6a066b6b26f43e66a48aa8af6a676126fed0ed311e103a51802f55d1f5d935ae9ae76e7e742170210c92b0b8c32eeac5
   languageName: node
   linkType: hard
 
@@ -3715,9 +3715,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:0.8.0-next.2, @backstage/backend-defaults@npm:^0.8.0-next.2":
-  version: 0.8.0-next.2
-  resolution: "@backstage/backend-defaults@npm:0.8.0-next.2"
+"@backstage/backend-defaults@npm:0.8.0-next.3, @backstage/backend-defaults@npm:^0.8.0-next.3":
+  version: 0.8.0-next.3
+  resolution: "@backstage/backend-defaults@npm:0.8.0-next.3"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -3726,9 +3726,9 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-app-api": "npm:1.2.0-next.2"
+    "@backstage/backend-app-api": "npm:1.2.0-next.3"
     "@backstage/backend-dev-utils": "npm:0.1.5"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/cli-common": "npm:0.1.15"
     "@backstage/cli-node": "npm:0.2.13-next.1"
     "@backstage/config": "npm:1.3.2"
@@ -3736,9 +3736,9 @@ __metadata:
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
     "@backstage/integration-aws-node": "npm:0.1.15"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
-    "@backstage/plugin-events-node": "npm:0.4.8-next.1"
-    "@backstage/plugin-permission-node": "npm:0.8.8-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
+    "@backstage/plugin-events-node": "npm:0.4.8-next.2"
+    "@backstage/plugin-permission-node": "npm:0.8.8-next.2"
     "@backstage/types": "npm:1.2.1"
     "@google-cloud/storage": "npm:^7.0.0"
     "@keyv/memcache": "npm:^2.0.1"
@@ -3794,7 +3794,7 @@ __metadata:
   peerDependenciesMeta:
     "@google-cloud/cloud-sql-connector":
       optional: true
-  checksum: 10/c9bdf6aa58671944989c5d5524c9085eb66edbf3761887d0dc9bf05a4ed64c008c90831ad163e6c81d289e785bded139499442f003fbc044826c3370c757619f
+  checksum: 10/f79a89825551adcbca37abe6145859044b802b05a686bd3ec449446879b0285cbf1b922013c39339ea9edec6e3a0eff0371116d8db0b83c5ca0f7623e40f80cb
   languageName: node
   linkType: hard
 
@@ -3805,12 +3805,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-openapi-utils@npm:0.5.0-next.2":
-  version: 0.5.0-next.2
-  resolution: "@backstage/backend-openapi-utils@npm:0.5.0-next.2"
+"@backstage/backend-openapi-utils@npm:0.5.0-next.3":
+  version: 0.5.0-next.3
+  resolution: "@backstage/backend-openapi-utils@npm:0.5.0-next.3"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/types": "npm:1.2.1"
     "@types/express": "npm:^4.17.6"
@@ -3825,7 +3825,7 @@ __metadata:
     mockttp: "npm:^3.13.0"
     openapi-merge: "npm:^1.3.2"
     openapi3-ts: "npm:^3.1.2"
-  checksum: 10/925948737bfd968ecc29a505d4955d549eed730187e453ee932d25b1677af8717a1a00ba7d92bf6c92dfd2141e401ccb47e78adc00e3902be8623d943effd299
+  checksum: 10/3ca96dc129f970ba572725390204128c5fc0e1a7071672246b7e91bedaaa2b97fe365cb98d90c845b35c67d6a4c0dcc23314ce649c99eed4b7f0f387847974e2
   languageName: node
   linkType: hard
 
@@ -3853,22 +3853,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:1.2.0-next.1, @backstage/backend-plugin-api@npm:^1.2.0-next.1":
-  version: 1.2.0-next.1
-  resolution: "@backstage/backend-plugin-api@npm:1.2.0-next.1"
+"@backstage/backend-plugin-api@npm:1.2.0-next.2, @backstage/backend-plugin-api@npm:^1.2.0-next.2":
+  version: 1.2.0-next.2
+  resolution: "@backstage/backend-plugin-api@npm:1.2.0-next.2"
   dependencies:
     "@backstage/cli-common": "npm:0.1.15"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.8.8-next.1"
+    "@backstage/plugin-permission-node": "npm:0.8.8-next.2"
     "@backstage/types": "npm:1.2.1"
     "@types/express": "npm:^4.17.6"
     "@types/luxon": "npm:^3.0.0"
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
-  checksum: 10/1e6f687281198b22cc29c5e759219cfa4b50b963459382d11342fd34a855d3062875160f906ba191e36e6969c7a6919b0a5823978bc3ae2f3e774642969547b3
+  checksum: 10/8fb3ff4a3902d6f55d7a41729b91023a4b6a018d9bf19e362ae63b4fb6ba5bcdca3e73329c4113a177954eff2ae6b91ff7a8020ed97ffe8a569cccba466f6c57
   languageName: node
   linkType: hard
 
@@ -3956,9 +3956,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:^0.30.0-next.2":
-  version: 0.30.0-next.2
-  resolution: "@backstage/cli@npm:0.30.0-next.2"
+"@backstage/cli@npm:^0.30.0-next.3":
+  version: 0.30.0-next.3
+  resolution: "@backstage/cli@npm:0.30.0-next.3"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/cli-common": "npm:0.1.15"
@@ -4073,6 +4073,7 @@ __metadata:
     yml-loader: "npm:^2.1.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
+    zod-validation-error: "npm:^3.4.0"
   peerDependencies:
     "@rspack/core": ^1.0.10
     "@rspack/dev-server": ^1.0.9
@@ -4086,7 +4087,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/501cc7493e79ab7c5d8795e1970e824276dcb195fd8edae9071ea2315c8b844aca902f57d00bd9d1dd4dd1f9d426100ec0b80a36d758f6cb4c23997ce850b76d
+  checksum: 10/5280126a2ce2b095cc8eafb9c7275ae48a3bcdc44bf0d3701aa924e3a0f3e6711ff10ee39bbdc7dd86ba40cc2f6dc3fbaa1a631e0182758e03e1263b3ae76a75
   languageName: node
   linkType: hard
 
@@ -4203,12 +4204,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@npm:0.3.6-next.2":
-  version: 0.3.6-next.2
-  resolution: "@backstage/core-compat-api@npm:0.3.6-next.2"
+"@backstage/core-compat-api@npm:0.3.6-next.3":
+  version: 0.3.6-next.3
+  resolution: "@backstage/core-compat-api@npm:0.3.6-next.3"
   dependencies:
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
     "@backstage/version-bridge": "npm:1.0.11-next.0"
     lodash: "npm:^4.17.21"
   peerDependencies:
@@ -4219,7 +4220,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8ab14e1f605891cdb3b500e1cf7be723947ffba161e60af742b4b6e48cbef15dbf3c056fe3ad979b5c48b7f4f01f9445615f16ed3fe0eb0218e2f8ddce93ba81
+  checksum: 10/31a3d3354b48b5b714dbc8bcfa95836169a4c29bb94977beaae9e06d40ca1859e32aad44eb53db68e1e85152885269d24287b06763cb608a6e2af020e93552b3
   languageName: node
   linkType: hard
 
@@ -4544,16 +4545,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-app-api@npm:0.10.5-next.2":
-  version: 0.10.5-next.2
-  resolution: "@backstage/frontend-app-api@npm:0.10.5-next.2"
+"@backstage/frontend-app-api@npm:0.10.5-next.3":
+  version: 0.10.5-next.3
+  resolution: "@backstage/frontend-app-api@npm:0.10.5-next.3"
   dependencies:
     "@backstage/config": "npm:1.3.2"
     "@backstage/core-app-api": "npm:1.15.5-next.0"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-defaults": "npm:0.1.6-next.2"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
+    "@backstage/frontend-defaults": "npm:0.1.6-next.3"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11-next.0"
     lodash: "npm:^4.17.21"
@@ -4566,7 +4567,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fcd61d4fe2eb47f76b01d321d91aaa045d89d2a72def94b975f2ed28cbe225fc38dfad3c066ad1f7c43ef313da04e5360e8297b67066812ea3b2efb77138cf50
+  checksum: 10/cf7e97916564a63860169251f7317d6f6dbfefbc4e1c5db33ce2393e15152706641460670d3fe07695c54af57c96de24fa5702b0211c231adbbb4bc18253a815
   languageName: node
   linkType: hard
 
@@ -4596,15 +4597,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@npm:0.1.6-next.2":
-  version: 0.1.6-next.2
-  resolution: "@backstage/frontend-defaults@npm:0.1.6-next.2"
+"@backstage/frontend-defaults@npm:0.1.6-next.3":
+  version: 0.1.6-next.3
+  resolution: "@backstage/frontend-defaults@npm:0.1.6-next.3"
   dependencies:
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-app-api": "npm:0.10.5-next.2"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/plugin-app": "npm:0.1.6-next.2"
+    "@backstage/frontend-app-api": "npm:0.10.5-next.3"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/plugin-app": "npm:0.1.6-next.3"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -4614,7 +4615,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3edb32d406601233f7f0c5cfc5f37e7017af3264331938e38c415873e901fc833989c2430a1b06bd707354fd4a203f69fb01efcdac9501ea7e42dcad4100c6c4
+  checksum: 10/ed369cdc73f4a776b6997c257aeaeddcbb688cade94df8a2ae54451840bb1f9c3087462639f50237c033cc60bb903b6cf65d213d3faf107738ef50b8eb4dafc3
   languageName: node
   linkType: hard
 
@@ -4640,9 +4641,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:0.9.5-next.2":
-  version: 0.9.5-next.2
-  resolution: "@backstage/frontend-plugin-api@npm:0.9.5-next.2"
+"@backstage/frontend-plugin-api@npm:0.9.5-next.3":
+  version: 0.9.5-next.3
+  resolution: "@backstage/frontend-plugin-api@npm:0.9.5-next.3"
   dependencies:
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
@@ -4660,7 +4661,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c500c3f2c2c765d5fb0bb92b1a1bfc4d4612ec4ce89bec67f208deb30f14caa1957a0f7acd8eae2cc57dec9e28d850fe38161761717733b4f6b9181b26fa6563
+  checksum: 10/97626101797209ed79abe6940d3fca07c4085b73144ed8c411b33dc922e9dcbd174674ab3e0413bc711eedad6b82542a2d40baf59a6ff22c018536e23ac91a63
   languageName: node
   linkType: hard
 
@@ -4708,14 +4709,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-test-utils@npm:0.2.6-next.2":
-  version: 0.2.6-next.2
-  resolution: "@backstage/frontend-test-utils@npm:0.2.6-next.2"
+"@backstage/frontend-test-utils@npm:0.2.6-next.3":
+  version: 0.2.6-next.3
+  resolution: "@backstage/frontend-test-utils@npm:0.2.6-next.3"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/frontend-app-api": "npm:0.10.5-next.2"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/plugin-app": "npm:0.1.6-next.2"
+    "@backstage/frontend-app-api": "npm:0.10.5-next.3"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/plugin-app": "npm:0.1.6-next.3"
     "@backstage/test-utils": "npm:1.7.5-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11-next.0"
@@ -4729,7 +4730,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c5c437ec146e55d216e8b91a6ae26765d7ccd0c020b3e3e2d5e7ef2d926c46157e5321e15af3f2a2dca86e742943822117434fcd09e31db6421670b87ff90a4a
+  checksum: 10/010064c7bdc7cbb787920fea11e0362accdc18bf8e2efd4b1ff2442cccef057cfba19079fe55bd667244a5a1c0bc58b9a71df428bc4afb383e3027e7772e450c
   languageName: node
   linkType: hard
 
@@ -4833,19 +4834,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@npm:^0.12.4-next.2":
-  version: 0.12.4-next.2
-  resolution: "@backstage/plugin-api-docs@npm:0.12.4-next.2"
+"@backstage/plugin-api-docs@npm:^0.12.4-next.3":
+  version: 0.12.4-next.3
+  resolution: "@backstage/plugin-api-docs@npm:0.12.4-next.3"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/plugin-catalog": "npm:1.27.0-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/plugin-catalog": "npm:1.27.0-next.3"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/plugin-permission-react": "npm:0.4.31-next.0"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -4865,20 +4866,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5608f5ba859e3218132fc7d5d0210050d9dc1ba87bdbe2b74c9651588001dd91390ed5f53251f37ec829ad5b89cef5ab03c131f4910181ef0813dcbc123fcb39
+  checksum: 10/208687aa766499ec1254dcaf063c97d37359a80937aba94e4aebf7b3759c3b53e3c3414bac4b9e98b973428957185e7b8d1eee01fa570395a290845347435293
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@npm:^0.4.5-next.1":
-  version: 0.4.5-next.1
-  resolution: "@backstage/plugin-app-backend@npm:0.4.5-next.1"
+"@backstage/plugin-app-backend@npm:^0.4.5-next.2":
+  version: 0.4.5-next.2
+  resolution: "@backstage/plugin-app-backend@npm:0.4.5-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/config-loader": "npm:1.9.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-app-node": "npm:0.1.30-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-app-node": "npm:0.1.30-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
@@ -4890,30 +4891,30 @@ __metadata:
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     yn: "npm:^4.0.0"
-  checksum: 10/02359e51465a87c0383df72292ac855e54b6615e9a20850679f0e217b40f2c2be4544944b0371c896040b4e52a2de82217e7f00b26c67dc5cc1b00c04844f692
+  checksum: 10/78b74af5f266f4f6f01cc875b4e7933aa3d58497b3695c71db94fd9a86c59f46eb0ed1e45ffb947a570af546ddf0539f065ba474d77138f7c311bb2d82a4727a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-node@npm:0.1.30-next.1":
-  version: 0.1.30-next.1
-  resolution: "@backstage/plugin-app-node@npm:0.1.30-next.1"
+"@backstage/plugin-app-node@npm:0.1.30-next.2":
+  version: 0.1.30-next.2
+  resolution: "@backstage/plugin-app-node@npm:0.1.30-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config-loader": "npm:1.9.6-next.0"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     fs-extra: "npm:^11.2.0"
-  checksum: 10/e752ff8171b46535a2dd80b991e49ce0c245d035d4c35f3bcfd7c314f5a77b739aa74078c30a13964f9d24f1514a8360443a288270e0e6128732a585195d1baf
+  checksum: 10/0b60bee9ff7569bf39a1f259ed32d1a278334af59683582583fa5e3e9b329c0e2a172a9a24619f28d9bb8c9285ffad89064aa5db1a9ec1a16233d1cc11f7ee8d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@npm:0.1.6-next.2":
-  version: 0.1.6-next.2
-  resolution: "@backstage/plugin-app@npm:0.1.6-next.2"
+"@backstage/plugin-app@npm:0.1.6-next.3":
+  version: 0.1.6-next.3
+  resolution: "@backstage/plugin-app@npm:0.1.6-next.3"
   dependencies:
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
     "@backstage/integration-react": "npm:1.2.4-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.31-next.0"
     "@backstage/theme": "npm:0.6.4-next.0"
@@ -4929,7 +4930,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7ac1639eb5c49fe74599e01e47a55261a858fd8447dd66372ba301497d229d9bf70751d8248d322282cc1aa0a44abbae2878c0c7b86f8ef6a7a4a5d944f52008
+  checksum: 10/bdafc62640758a65b567f0d2f20014af4a323f98b4f031ab4581860bcb6e3b28d193054e972bbb0d81d8c3249cbba54bb651f74d1a904b07e53e49cdca6b3fc2
   languageName: node
   linkType: hard
 
@@ -4959,269 +4960,269 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-atlassian-provider@npm:0.4.0-next.1":
-  version: 0.4.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-atlassian-provider@npm:0.4.0-next.1"
+"@backstage/plugin-auth-backend-module-atlassian-provider@npm:0.4.0-next.2":
+  version: 0.4.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-atlassian-provider@npm:0.4.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
     passport-atlassian-oauth2: "npm:^2.1.0"
-  checksum: 10/0e87afc440d49027519e788434c2b1121bb009cd9fca9d2b180996d467db51065aff2589f915616752dae60d68e102e3c60171eeb5c9d4d4fd3299ffae6633d5
+  checksum: 10/621c43df24ef48fbd008a28945c6975b5c5ddb3c46df0a9beb9250f81884fd4ff9869c974115b46dfa19fb93aece81deb670f16cff277aa06ea6e9a9cf020f1f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-auth0-provider@npm:0.2.0-next.1":
-  version: 0.2.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-auth0-provider@npm:0.2.0-next.1"
+"@backstage/plugin-auth-backend-module-auth0-provider@npm:0.2.0-next.2":
+  version: 0.2.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-auth0-provider@npm:0.2.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     express: "npm:^4.17.1"
     passport-auth0: "npm:^1.4.3"
     passport-oauth2: "npm:^1.6.1"
-  checksum: 10/b63d82cf436cf207c2428a54741e8da762843f90b6899a7fc5f08b715b170b2067c9cf7b9ce50f61a19c1de80d1e55745ec55c4f259c52edcd7fbd2b486fc0a7
+  checksum: 10/271ae20e975ac27fbfedfd853e244ea9b51b991374fd294ff89b1a578b8d5c35a1520cc7ee9a3e1e4ed6c34abf58ed0fc7beb839d46b0249afa6de3ab4057f08
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.0-next.2":
-  version: 0.4.0-next.2
-  resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.0-next.2"
+"@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.0-next.3":
+  version: 0.4.0-next.3
+  resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.0-next.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-backend": "npm:0.24.3-next.2"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-auth-backend": "npm:0.24.3-next.3"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     jose: "npm:^5.0.0"
     node-cache: "npm:^5.1.2"
-  checksum: 10/47fd30a5e820e51d3456e2696e98ce09fa18450afbe0c770334d89f034369a333aab1df6cd362b0d7883aa78cd8404f794caa695cd79799301a2f4b1f0ee897c
+  checksum: 10/ce759c52d9aad916a73db26847c7d3087c9b9be19fb40d6372c0ef69cfcc2b3a9a392c766e2a64a470b2949f53cc152fd9417f70c5dbcae69f719ec67e811607
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:0.2.5-next.1":
-  version: 0.2.5-next.1
-  resolution: "@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:0.2.5-next.1"
+"@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:0.2.5-next.2":
+  version: 0.2.5-next.2
+  resolution: "@backstage/plugin-auth-backend-module-azure-easyauth-provider@npm:0.2.5-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     "@types/passport": "npm:^1.0.16"
     express: "npm:^4.19.2"
     jose: "npm:^5.0.0"
     passport: "npm:^0.7.0"
-  checksum: 10/8e9e10f88b4ad8caf67cdbf7ca0efa251a6a51232d8d7c5d902afbfa5caa6319e1553b4e1f9f62b0dfa948c39ecf1d918195e8c9c1a25e67a748984daa746b8e
+  checksum: 10/30327299edbe6b9057713758ebc5d802f206d9dedfcdd1d6d8bcce83de05101a842e88cbfb0ac547f206caf2e8ef0910459296d07e23f5e82e9e34d1dc992ccf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.3.0-next.1":
-  version: 0.3.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.3.0-next.1"
+"@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.3.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
     passport-bitbucket-oauth2: "npm:^0.1.2"
-  checksum: 10/aa07c7d872a712cc6518b4badb70d8506c37dde1c8e58b44d0dfcf4c77bc88376a25a71a626ada3ddff08ef6555e42b2fe250f4f84f633c09d556cc53de2013c
+  checksum: 10/eefa79acacb96c4eb95bcfe01921a312034d7fcf8eddf509fb86c5d40ba3fd09d91bf65bd94bd212e7c8ac80dd75fec26de08c1e45a5e96d2761b7f254128287
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-bitbucket-server-provider@npm:0.2.0-next.1":
-  version: 0.2.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-bitbucket-server-provider@npm:0.2.0-next.1"
+"@backstage/plugin-auth-backend-module-bitbucket-server-provider@npm:0.2.0-next.2":
+  version: 0.2.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-bitbucket-server-provider@npm:0.2.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     passport: "npm:^0.7.0"
     passport-oauth2: "npm:^1.6.1"
-  checksum: 10/297e6010e49a7376bc4420c08aef6b15f95c5be691a5529ef95a32162912e1fece358988b2e726ae3197cd1b039281c795ec92c0a414c76405bc406a35fcdd15
+  checksum: 10/53639fc241a75ef26870d44b172e8485669df33c4b9fcbf66efaf2c12a9640d2b344dda4e8e1b8863fd0bef4cdfb52c3194564d8b4b5bef297cde3e35898654f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:0.4.0-next.1":
-  version: 0.4.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:0.4.0-next.1"
+"@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:0.4.0-next.2":
+  version: 0.4.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm:0.4.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     express: "npm:^4.18.2"
     jose: "npm:^5.0.0"
-  checksum: 10/66a1656b32dcb6157b605b9a0f74a690d5aef609ca3b1f1b6a7239763a01d4c7f920a40f6312fd53edc7d386072bf14754e1de05dcb3cc173a9ad6185548907d
+  checksum: 10/d22a7c65ddce2e8c397c01fe5587a6e4753d6ce4cc16d9f49fcca4749e5ca608c22003f26b47e0f321bf2f6693ff65e7a59071cac66d8889744a70731d45734d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:0.4.0-next.1":
-  version: 0.4.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:0.4.0-next.1"
+"@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:0.4.0-next.2":
+  version: 0.4.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-gcp-iap-provider@npm:0.4.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     "@backstage/types": "npm:1.2.1"
     google-auth-library: "npm:^9.0.0"
-  checksum: 10/010fdc830d86aa627db7970f62a27f017639fd3a5e2ea3d6f40b7802ac7b083dc37cb898596f7a8388e56e3915f8cf614756631e181172518e07bd2a0a9af062
+  checksum: 10/591ae4b7116ca79cf288a67263b19d94c609b690ad588cabc069e13bddfd44d26b72a8dc5d4486f5b2aa60295fcfbbf7b39509f1f8053e83a164cdd201eed066
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@npm:0.3.0-next.1, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.0-next.1":
-  version: 0.3.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.0-next.1"
+"@backstage/plugin-auth-backend-module-github-provider@npm:0.3.0-next.2, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     passport-github2: "npm:^0.1.12"
-  checksum: 10/fece3b6ad92331d64bdbf312d4babacc334339a2a38c59736d3ca844ce465ed96a63e6a9f9bf912e1a042adf6e6d5b836809ef25a793ee3ccf52ae50efa4a220
+  checksum: 10/a3bb93f0b6c721947095189c09c4863411853e365268f6e223a1e72593b6086d367110a2eb4bb252b7666f0afc73a08ee0f8a7bf0cae9bf54eed3062e752b3a4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-gitlab-provider@npm:0.3.0-next.1":
-  version: 0.3.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-gitlab-provider@npm:0.3.0-next.1"
+"@backstage/plugin-auth-backend-module-gitlab-provider@npm:0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-gitlab-provider@npm:0.3.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
     passport-gitlab2: "npm:^5.0.0"
-  checksum: 10/31a2fb7bb52993f3546a3ec71b8497815cd89ff26ae7766fc2677bbe4cadb6be7d838d416b732e539af70781c110f1ecf00b05be1c09ab8ae9416ea0e5a5c0f6
+  checksum: 10/8298ce56efb7bb2d3f4316389e702d56e0fc19f1962e87228408e86c992b5a26c50f60e9295b73e742283b4d9b544847c4c77f5664a60532c377e5bbed282db3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-google-provider@npm:0.3.0-next.1":
-  version: 0.3.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-google-provider@npm:0.3.0-next.1"
+"@backstage/plugin-auth-backend-module-google-provider@npm:0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-google-provider@npm:0.3.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     google-auth-library: "npm:^9.0.0"
     passport-google-oauth20: "npm:^2.0.0"
-  checksum: 10/1b815ae132ff8da1b49cd55b21930d909347ae6a4a34d0473b67210a03580acf7279d028ec58453b91a97a939750145cb778c657907a32777ef0958ae778cbbf
+  checksum: 10/cbe90c9ef7cecb7b181177fecfe10cf061cc4438c3a00adaa9daede7837ff81ce49e24e2db360e8f48e7ee7c1b5206544cc5bb1126f9df98906fa0e84bd2dc7a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.5-next.1":
-  version: 0.2.5-next.1
-  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.5-next.1"
+"@backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.5-next.2":
+  version: 0.2.5-next.2
+  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.5-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     passport-oauth2: "npm:^1.7.0"
-  checksum: 10/ff4607a96752da646e9a47e70b140d8b295d08c933d41a10e3c056bac51390edf36413b11e5d0c6972f0d6dd239ea044cd034d2038e192b66595eea9d0267a8d
+  checksum: 10/36e007a25f3634f3a5b541ed9197819345640bc1a1dde47be964127e55307de65f6655dd30946c5ba7ccfb7696070bbb36c7d93c06fe256a8c786037e2b27c26
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-microsoft-provider@npm:0.3.0-next.1":
-  version: 0.3.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-microsoft-provider@npm:0.3.0-next.1"
+"@backstage/plugin-auth-backend-module-microsoft-provider@npm:0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-microsoft-provider@npm:0.3.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     express: "npm:^4.18.2"
     jose: "npm:^5.0.0"
     passport-microsoft: "npm:^1.0.0"
-  checksum: 10/e109cbef289e5d6543276da9a9ec3b3d59ddddcf2d459dc32a2c90c762717375db16ebdfdcb33da7a50a8c36cb91361d5ac69b26981ec2c33f07d8a893df4403
+  checksum: 10/16e6ac566b9bb3369bae3da6f1991e57db89855f4b03a42e7ff4d7663fd0e55be50fa3f2d1e974d1dc76221c683753bbc3e03ae7b5c570d4284bac24b68ae633
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-oauth2-provider@npm:0.4.0-next.1":
-  version: 0.4.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-oauth2-provider@npm:0.4.0-next.1"
+"@backstage/plugin-auth-backend-module-oauth2-provider@npm:0.4.0-next.2":
+  version: 0.4.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-oauth2-provider@npm:0.4.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     passport: "npm:^0.7.0"
     passport-oauth2: "npm:^1.6.1"
-  checksum: 10/38be4d3f72702f47a9faa1c317e2ab331312d62eb3a111b580d6b0da98575ec805cba0f1732c37acfbf828af715513f4858e2c0f74a65ce34d94d0ccde51ce45
+  checksum: 10/a4ade51e770df12577e4c18e122efd4f5f93796c2e11db5e1f81d5d241811490fddfab45d29a014372a0ec5e3726c32601ddd03794095646c6e031830cdfda6f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:0.2.5-next.1":
-  version: 0.2.5-next.1
-  resolution: "@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:0.2.5-next.1"
+"@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:0.2.5-next.2":
+  version: 0.2.5-next.2
+  resolution: "@backstage/plugin-auth-backend-module-oauth2-proxy-provider@npm:0.2.5-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     jose: "npm:^5.0.0"
-  checksum: 10/3c663488e18800015337ddc14855f10b4cffad7fb97f7ae49bc50f4a56f3673961cd80273d7146004a53b472b7c7f1e18bae3b903581aaf28bef370825a119be
+  checksum: 10/cce9ca8674ff2ba0030688ec808bf6a55d78f3bf0c93251752e4568473f352fde1039f5582536d10de71a4e023d770d35485ae7e774d7b9f2702dc5c4d4c8f05
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.0-next.2":
-  version: 0.4.0-next.2
-  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.0-next.2"
+"@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.0-next.3":
+  version: 0.4.0-next.3
+  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.0-next.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-backend": "npm:0.24.3-next.2"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-backend": "npm:0.24.3-next.3"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     express: "npm:^4.18.2"
     openid-client: "npm:^5.5.0"
     passport: "npm:^0.7.0"
-  checksum: 10/dd04346bf058328fa74b60649439db7858ae0e32e236aa8dd76342dd3a0c52a164e2b67d6931e5e6c93e8ffb49ad680fe7c0b7c91287a4b942d43042350213d8
+  checksum: 10/16b6427cb136dda2c2145cb0eac043f401cd7b17f49c8353568ee67aa94449e3c389db3849199a55cf3e1f212a5aaf0bd375ef9e38b21a91c053fbfaffc0cc9a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-okta-provider@npm:0.2.0-next.1":
-  version: 0.2.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-okta-provider@npm:0.2.0-next.1"
+"@backstage/plugin-auth-backend-module-okta-provider@npm:0.2.0-next.2":
+  version: 0.2.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-okta-provider@npm:0.2.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     "@davidzemon/passport-okta-oauth": "npm:^0.0.5"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
-  checksum: 10/e39931e9ddfa7e24a33bdc2e587828b1d8ae43ed835f1f2537d823ebaf87fa9c9f45c4d9839411108e85b50279e8b23075606464eb38d8b07211bd79b268f3d1
+  checksum: 10/e4498ac08913f8383e0f6d981ba0c2509ec0e24ad8982fc9510ef4b076c60e0160e0fcc897279817299f412e683ee1319ff4cb39d4df357b6010101a0c8b70d6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-onelogin-provider@npm:0.3.0-next.1":
-  version: 0.3.0-next.1
-  resolution: "@backstage/plugin-auth-backend-module-onelogin-provider@npm:0.3.0-next.1"
+"@backstage/plugin-auth-backend-module-onelogin-provider@npm:0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/plugin-auth-backend-module-onelogin-provider@npm:0.3.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
     passport-onelogin-oauth: "npm:^0.0.1"
-  checksum: 10/01250cfa6ad3979ccd2bcb7d8d9548359bb0193d6fdb53c73430fa47c7e0e880a81d95903265463db049be7719ac71dc32269ff06e3c591c2f2a08d908c899b3
+  checksum: 10/c59c96b18ec2242f7ab38ee427d71e09d2d026ec1fd17bceb2cdba059414f4dc3b0a638b70653fe3a2d6384076bb903c87207853cf61dceedd7abfa6e8ccc3d8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@npm:0.24.3-next.2, @backstage/plugin-auth-backend@npm:^0.24.3-next.2":
-  version: 0.24.3-next.2
-  resolution: "@backstage/plugin-auth-backend@npm:0.24.3-next.2"
+"@backstage/plugin-auth-backend@npm:0.24.3-next.3, @backstage/plugin-auth-backend@npm:^0.24.3-next.3":
+  version: 0.24.3-next.3
+  resolution: "@backstage/plugin-auth-backend@npm:0.24.3-next.3"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-backend-module-atlassian-provider": "npm:0.4.0-next.1"
-    "@backstage/plugin-auth-backend-module-auth0-provider": "npm:0.2.0-next.1"
-    "@backstage/plugin-auth-backend-module-aws-alb-provider": "npm:0.4.0-next.2"
-    "@backstage/plugin-auth-backend-module-azure-easyauth-provider": "npm:0.2.5-next.1"
-    "@backstage/plugin-auth-backend-module-bitbucket-provider": "npm:0.3.0-next.1"
-    "@backstage/plugin-auth-backend-module-bitbucket-server-provider": "npm:0.2.0-next.1"
-    "@backstage/plugin-auth-backend-module-cloudflare-access-provider": "npm:0.4.0-next.1"
-    "@backstage/plugin-auth-backend-module-gcp-iap-provider": "npm:0.4.0-next.1"
-    "@backstage/plugin-auth-backend-module-github-provider": "npm:0.3.0-next.1"
-    "@backstage/plugin-auth-backend-module-gitlab-provider": "npm:0.3.0-next.1"
-    "@backstage/plugin-auth-backend-module-google-provider": "npm:0.3.0-next.1"
-    "@backstage/plugin-auth-backend-module-microsoft-provider": "npm:0.3.0-next.1"
-    "@backstage/plugin-auth-backend-module-oauth2-provider": "npm:0.4.0-next.1"
-    "@backstage/plugin-auth-backend-module-oauth2-proxy-provider": "npm:0.2.5-next.1"
-    "@backstage/plugin-auth-backend-module-oidc-provider": "npm:0.4.0-next.2"
-    "@backstage/plugin-auth-backend-module-okta-provider": "npm:0.2.0-next.1"
-    "@backstage/plugin-auth-backend-module-onelogin-provider": "npm:0.3.0-next.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
-    "@backstage/plugin-catalog-node": "npm:1.16.0-next.2"
+    "@backstage/plugin-auth-backend-module-atlassian-provider": "npm:0.4.0-next.2"
+    "@backstage/plugin-auth-backend-module-auth0-provider": "npm:0.2.0-next.2"
+    "@backstage/plugin-auth-backend-module-aws-alb-provider": "npm:0.4.0-next.3"
+    "@backstage/plugin-auth-backend-module-azure-easyauth-provider": "npm:0.2.5-next.2"
+    "@backstage/plugin-auth-backend-module-bitbucket-provider": "npm:0.3.0-next.2"
+    "@backstage/plugin-auth-backend-module-bitbucket-server-provider": "npm:0.2.0-next.2"
+    "@backstage/plugin-auth-backend-module-cloudflare-access-provider": "npm:0.4.0-next.2"
+    "@backstage/plugin-auth-backend-module-gcp-iap-provider": "npm:0.4.0-next.2"
+    "@backstage/plugin-auth-backend-module-github-provider": "npm:0.3.0-next.2"
+    "@backstage/plugin-auth-backend-module-gitlab-provider": "npm:0.3.0-next.2"
+    "@backstage/plugin-auth-backend-module-google-provider": "npm:0.3.0-next.2"
+    "@backstage/plugin-auth-backend-module-microsoft-provider": "npm:0.3.0-next.2"
+    "@backstage/plugin-auth-backend-module-oauth2-provider": "npm:0.4.0-next.2"
+    "@backstage/plugin-auth-backend-module-oauth2-proxy-provider": "npm:0.2.5-next.2"
+    "@backstage/plugin-auth-backend-module-oidc-provider": "npm:0.4.0-next.3"
+    "@backstage/plugin-auth-backend-module-okta-provider": "npm:0.2.0-next.2"
+    "@backstage/plugin-auth-backend-module-onelogin-provider": "npm:0.3.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
+    "@backstage/plugin-catalog-node": "npm:1.16.0-next.3"
     "@backstage/types": "npm:1.2.1"
     "@google-cloud/firestore": "npm:^7.0.0"
     "@node-saml/passport-saml": "npm:^5.0.0"
@@ -5254,15 +5255,15 @@ __metadata:
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/dbdb7894768181659c04c71d71ea88734e3609520a462a137f1653ec47c321588512b0ac875909cdfa57c7abfff620b67d49c19fd80f79869fbad56c6f2e2f39
+  checksum: 10/a721f735d063e5509b5e778bbfa8ae88204af5bed82d15fa20a46e6f2ba625196f6b3591ca564b06d60dcb17bc0610a93ca571d74041a17240faeeee0ec8c26c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:0.6.0-next.1":
-  version: 0.6.0-next.1
-  resolution: "@backstage/plugin-auth-node@npm:0.6.0-next.1"
+"@backstage/plugin-auth-node@npm:0.6.0-next.2":
+  version: 0.6.0-next.2
+  resolution: "@backstage/plugin-auth-node@npm:0.6.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
@@ -5277,7 +5278,7 @@ __metadata:
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.21.4"
     zod-validation-error: "npm:^3.4.0"
-  checksum: 10/d602b62930fe7202242c70da3dac329c21b439c832ce8ebd4295f025bb87e08999d3494bfc16a0ee4f614c0dbdea9392f6d6d108ebdfaad615e2272cec059cdd
+  checksum: 10/c89076d15c88aef9151b4e3cebd934bdbaccc6df48b6ef73a215b0507bd7d381807c097580196ec83d98f2239b280e8cd338b2294173857b55d2975c9679ac69
   languageName: node
   linkType: hard
 
@@ -5362,48 +5363,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@npm:^0.1.7-next.2":
-  version: 0.1.7-next.2
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.7-next.2"
+"@backstage/plugin-catalog-backend-module-logs@npm:^0.1.7-next.3":
+  version: 0.1.7-next.3
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.7-next.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
-    "@backstage/plugin-catalog-backend": "npm:1.31.0-next.2"
-    "@backstage/plugin-events-node": "npm:0.4.8-next.1"
-  checksum: 10/9b38fb6b07f4d90f1cacf52b5fe68ca806756bdb13f8321fb8c6df2c8bef312a05d638ef61092e6897096d9d571444df18b9c3a77aa69b8bb81003ee63f15876
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
+    "@backstage/plugin-catalog-backend": "npm:1.31.0-next.3"
+    "@backstage/plugin-events-node": "npm:0.4.8-next.2"
+  checksum: 10/59de308a52140954eab9580d6c8453eee943f7d1549e64643a7dbbf7ff90be1ea26986300f30aa1a43013021c0b49f5d8f8d712ded9af0362a4bdfcb106edd8e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.5-next.2, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.5-next.2":
-  version: 0.2.5-next.2
-  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.5-next.2"
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.5-next.3, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.5-next.3":
+  version: 0.2.5-next.3
+  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.5-next.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.16.0-next.2"
+    "@backstage/plugin-catalog-node": "npm:1.16.0-next.3"
     "@backstage/plugin-scaffolder-common": "npm:1.5.9"
-  checksum: 10/ba06eb324b7fac14807971ac5c2b3f8633c52e69cbccc6887a0a297d6a1ccd058eb80a64e92f8f4ab7d6b9a0cf5c1edaa149e597a16adb62d0cd758e2f817efb
+  checksum: 10/99dc938b88bc6d005f7a275b4ccb3df60844736ca34b5f24f594804de49d2d2a21b4ff862199f183c66caf34d2a812e02064ebf2d85147563c9e39445437abcf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@npm:1.31.0-next.2, @backstage/plugin-catalog-backend@npm:^1.31.0-next.2":
-  version: 1.31.0-next.2
-  resolution: "@backstage/plugin-catalog-backend@npm:1.31.0-next.2"
+"@backstage/plugin-catalog-backend@npm:1.31.0-next.3, @backstage/plugin-catalog-backend@npm:^1.31.0-next.3":
+  version: 1.31.0-next.3
+  resolution: "@backstage/plugin-catalog-backend@npm:1.31.0-next.3"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-openapi-utils": "npm:0.5.0-next.2"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-openapi-utils": "npm:0.5.0-next.3"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.16.0-next.2"
-    "@backstage/plugin-events-node": "npm:0.4.8-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.16.0-next.3"
+    "@backstage/plugin-events-node": "npm:0.4.8-next.2"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.8.8-next.1"
-    "@backstage/plugin-search-backend-module-catalog": "npm:0.3.1-next.2"
+    "@backstage/plugin-permission-node": "npm:0.8.8-next.2"
+    "@backstage/plugin-search-backend-module-catalog": "npm:0.3.1-next.3"
     "@backstage/plugin-search-common": "npm:1.2.17"
     "@backstage/types": "npm:1.2.1"
     "@opentelemetry/api": "npm:^1.9.0"
@@ -5425,7 +5426,7 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/56153dd850a1150becaf6ef1cde34ca42cfc490cfa8d909262adec08dc4cf2a821c99a953cc65d46756e0faccc30d655809e7e6a96439286a39464106aa11725
+  checksum: 10/a707d9a6559959490d8215c3ad7a04dadda6b6802f39ecf669fb71b4fde076da822b1cd77851736f0fb60b6bbf3d7a9c1384e3dadd6ed6429a6400b7879e9758
   languageName: node
   linkType: hard
 
@@ -5440,17 +5441,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@npm:^0.4.16-next.2":
-  version: 0.4.16-next.2
-  resolution: "@backstage/plugin-catalog-graph@npm:0.4.16-next.2"
+"@backstage/plugin-catalog-graph@npm:^0.4.16-next.3":
+  version: 0.4.16-next.3
+  resolution: "@backstage/plugin-catalog-graph@npm:0.4.16-next.3"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5468,23 +5469,23 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6c5e352a13f557640567cb525c083902ff017993b90cceba882b84cd738c3735f733c129af1d76ae9d290c38df292358382b9c5b7d770f4c2b4a69b8ba6594ad
+  checksum: 10/c14a6fb9ff26613d91051d133f5e8b85b5bfe5b0a7d1ef743d1255276223891c508522120eb97f6ef0693d508ee4124db52d6ac63f649952d52b6f3f0ee48419
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:1.16.0-next.2, @backstage/plugin-catalog-node@npm:^1.16.0-next.2":
-  version: 1.16.0-next.2
-  resolution: "@backstage/plugin-catalog-node@npm:1.16.0-next.2"
+"@backstage/plugin-catalog-node@npm:1.16.0-next.3, @backstage/plugin-catalog-node@npm:^1.16.0-next.3":
+  version: 1.16.0-next.3
+  resolution: "@backstage/plugin-catalog-node@npm:1.16.0-next.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.8.8-next.1"
+    "@backstage/plugin-permission-node": "npm:0.8.8-next.2"
     "@backstage/types": "npm:1.2.1"
-  checksum: 10/2c8655c2442691fc044324f3f64c23e06bbc69129cc576514462690a25f3668f6d802b8b46346c0b20870f0f3d73be2b498a976e6d0c2555aac51f4a053082b1
+  checksum: 10/05a55c6a37b5176b93d10cb52d0cfec2cc1156c190615bccbe54f88a654858cc8beba52c0130030efa1489f5088053da9c2a06c3ad51368658b78ce243185413
   languageName: node
   linkType: hard
 
@@ -5504,18 +5505,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@npm:1.15.2-next.2, @backstage/plugin-catalog-react@npm:^1.15.2-next.2":
-  version: 1.15.2-next.2
-  resolution: "@backstage/plugin-catalog-react@npm:1.15.2-next.2"
+"@backstage/plugin-catalog-react@npm:1.15.2-next.3, @backstage/plugin-catalog-react@npm:^1.15.2-next.3":
+  version: 1.15.2-next.3
+  resolution: "@backstage/plugin-catalog-react@npm:1.15.2-next.3"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/frontend-test-utils": "npm:0.2.6-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/frontend-test-utils": "npm:0.2.6-next.3"
     "@backstage/integration-react": "npm:1.2.4-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
     "@backstage/plugin-permission-common": "npm:0.8.4"
@@ -5541,7 +5542,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fe891d60689a4c9afc596cdb6ba7d689ad6d951f2ed402f3f9cfbc38951739d7db5cfeba78d31b43749470b9b90baf6d98e77edb3e3130d077ef1f59674f95e0
+  checksum: 10/47b030d5beb747b42fb956b566e3bc01b5de5eda92a1ed63569b96dbb30a2feb5429d70b141f4a87c62664c902121284b4eae7e383fccfa7a206ac40841ae0a4
   languageName: node
   linkType: hard
 
@@ -5586,24 +5587,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@npm:1.27.0-next.2, @backstage/plugin-catalog@npm:^1.27.0-next.2":
-  version: 1.27.0-next.2
-  resolution: "@backstage/plugin-catalog@npm:1.27.0-next.2"
+"@backstage/plugin-catalog@npm:1.27.0-next.3, @backstage/plugin-catalog@npm:^1.27.0-next.3":
+  version: 1.27.0-next.3
+  resolution: "@backstage/plugin-catalog@npm:1.27.0-next.3"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
     "@backstage/integration-react": "npm:1.2.4-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/plugin-permission-react": "npm:0.4.31-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.5.9"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.6-next.2"
+    "@backstage/plugin-search-react": "npm:1.8.6-next.3"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5624,20 +5625,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e8f49535901e975f211f43144a68538f01cb8e5c9db0f93712b478093d218d0f6258d51d28eb77c9b63a00ae58b11ef122890e745a312d85a15ad1c024ef80f4
+  checksum: 10/fccf3f956380ce0470393d4b9e66d7b5ca8dc1da2e07af58cf52c3a79bc2e333c8e3d120e4e19187168eef630641cadd9738058b913a20cac617a3e75960abdf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@npm:^0.4.2-next.2":
-  version: 0.4.2-next.2
-  resolution: "@backstage/plugin-events-backend@npm:0.4.2-next.2"
+"@backstage/plugin-events-backend@npm:^0.4.2-next.3":
+  version: 0.4.2-next.3
+  resolution: "@backstage/plugin-events-backend@npm:0.4.2-next.3"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-openapi-utils": "npm:0.5.0-next.2"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-openapi-utils": "npm:0.5.0-next.3"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-events-node": "npm:0.4.8-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.8-next.2"
     "@backstage/types": "npm:1.2.1"
     "@types/express": "npm:^4.17.6"
     content-type: "npm:^1.0.5"
@@ -5645,20 +5646,20 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     winston: "npm:^3.2.1"
-  checksum: 10/ae28b4c91e8a108f22b838a934e4bc1726982a829b84179224032de21d47c89614e23005a1f22b7169f8e48016c3ad1c2aeca03740b228156f723a640b295a52
+  checksum: 10/f045146be3f7aaaeffedea6fbc7a908c2732c07da6b90cf4e5aa9471465300ac7d1908c1fabe09e68bb991b280c57dd72ef0f81c046cf373b63a58d07d4c3890
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-node@npm:0.4.8-next.1":
-  version: 0.4.8-next.1
-  resolution: "@backstage/plugin-events-node@npm:0.4.8-next.1"
+"@backstage/plugin-events-node@npm:0.4.8-next.2":
+  version: 0.4.8-next.2
+  resolution: "@backstage/plugin-events-node@npm:0.4.8-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/types": "npm:1.2.1"
     cross-fetch: "npm:^4.0.0"
     uri-template: "npm:^2.0.0"
-  checksum: 10/2bb0022457147ab5996ffa233cbeb5a9f3ac6e7a6c0714e3ff93caf46b82e0ca76318fba775301509a1d4457dc18f82e8a78bd7a2155bdcf39ad9747efbe5f68
+  checksum: 10/95fa96cbce5fc18c58c791ad503c2509924e1a16162923d5ae1f62d3c5322dde0ff3e67196b9eb9090312862219a315c24faeb1f3db4a675b3763103c0626932
   languageName: node
   linkType: hard
 
@@ -5683,19 +5684,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@npm:^0.8.5-next.2":
-  version: 0.8.5-next.2
-  resolution: "@backstage/plugin-home@npm:0.8.5-next.2"
+"@backstage/plugin-home@npm:^0.8.5-next.3":
+  version: 0.8.5-next.3
+  resolution: "@backstage/plugin-home@npm:0.8.5-next.3"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/core-app-api": "npm:1.15.5-next.0"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/plugin-home-react": "npm:0.1.23-next.1"
     "@backstage/theme": "npm:0.6.4-next.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -5719,31 +5720,31 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5657f6a2006c94056d35d53ed30cfeed606a097503fffa5c41be449eea3c41f695bd015b7ef3e6d6bf99a2750cd219e7a35a43492097ed27a51d1bcecb873e48
+  checksum: 10/1f4768aaa9fd1fdbb5ee176fe9b11955397cd386c77396b9a0c093aab46bbe6a655fd962aedb56cdcb27072e36d4ac2eda872105d83ba2fb34d55a1a1d6dfc6f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@npm:^0.19.3-next.2":
-  version: 0.19.3-next.2
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.3-next.2"
+"@backstage/plugin-kubernetes-backend@npm:^0.19.3-next.3":
+  version: 0.19.3-next.3
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.3-next.3"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@aws-sdk/signature-v4": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration-aws-node": "npm:0.1.15"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
-    "@backstage/plugin-catalog-node": "npm:1.16.0-next.2"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
+    "@backstage/plugin-catalog-node": "npm:1.16.0-next.3"
     "@backstage/plugin-kubernetes-common": "npm:0.9.3-next.1"
-    "@backstage/plugin-kubernetes-node": "npm:0.2.3-next.1"
+    "@backstage/plugin-kubernetes-node": "npm:0.2.3-next.2"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.8.8-next.1"
+    "@backstage/plugin-permission-node": "npm:0.8.8-next.2"
     "@backstage/types": "npm:1.2.1"
     "@google-cloud/container": "npm:^5.0.0"
     "@jest-mock/express": "npm:^2.0.1"
@@ -5765,7 +5766,7 @@ __metadata:
     stream-buffers: "npm:^3.0.2"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/63716a6d725ee1694b0e634eea1d3a446cbd20b08f2ad093cfbb9398d0e2f2aa18a9f2e6db4ad6e9be27f43cd70b0861ed451392daf27ba23b497264ec06804c
+  checksum: 10/5a9b1d1b57b88db99ccfa9ca7c894c05f5e006cd1f34265872fa4c199b65a8b76a55fcd746036a9fc672a0fb3121d0777a2821fe563f0c02f6fb75d4386520fe
   languageName: node
   linkType: hard
 
@@ -5784,18 +5785,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-node@npm:0.2.3-next.1":
-  version: 0.2.3-next.1
-  resolution: "@backstage/plugin-kubernetes-node@npm:0.2.3-next.1"
+"@backstage/plugin-kubernetes-node@npm:0.2.3-next.2":
+  version: 0.2.3-next.2
+  resolution: "@backstage/plugin-kubernetes-node@npm:0.2.3-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/plugin-kubernetes-common": "npm:0.9.3-next.1"
     "@backstage/types": "npm:1.2.1"
     "@kubernetes/client-node": "npm:1.0.0-rc7"
     node-fetch: "npm:^2.7.0"
     winston: "npm:^3.2.1"
-  checksum: 10/fc54b135f90cd561107a9ad08303c382a608ebf411391f97afe63421651204d3f095ea53e444d06bbaadd842bcd901a296612b42f9c02d3a5c224832c5cae21a
+  checksum: 10/cdd1a9e52ace006210454b002d5b46d11ad0b6dc09cc1b5f7857fdc85a76960aad4456fff8a92dfa44063d01aba3be02453500e904b8772f16ef07d9db62c290
   languageName: node
   linkType: hard
 
@@ -5836,16 +5837,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@npm:^0.12.4-next.2":
-  version: 0.12.4-next.2
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.4-next.2"
+"@backstage/plugin-kubernetes@npm:^0.12.4-next.3":
+  version: 0.12.4-next.3
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.4-next.3"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/plugin-kubernetes-common": "npm:0.9.3-next.1"
     "@backstage/plugin-kubernetes-react": "npm:0.5.4-next.2"
     "@backstage/plugin-permission-react": "npm:0.4.31-next.0"
@@ -5869,32 +5870,32 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/55b1e7793e887e697cc9aa8a3aa5571004205c20e01b70e818b6c2f1722032c0f8a35dd2b87776024092c38e3694f12ecb709809304cc3e4b8a32e0eab09c2b5
+  checksum: 10/9c1837fd55be7659cf7ad78700796a8a6a1e832677b4f8d37a1669092c0012500a0ed8dacd0e772b6d0d1092475917226c8446654a0ef8c4e2be9598c383c5c0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@npm:^0.5.2-next.2":
-  version: 0.5.2-next.2
-  resolution: "@backstage/plugin-notifications-backend@npm:0.5.2-next.2"
+"@backstage/plugin-notifications-backend@npm:^0.5.2-next.3":
+  version: 0.5.2-next.3
+  resolution: "@backstage/plugin-notifications-backend@npm:0.5.2-next.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
-    "@backstage/plugin-catalog-node": "npm:1.16.0-next.2"
-    "@backstage/plugin-events-node": "npm:0.4.8-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
+    "@backstage/plugin-catalog-node": "npm:1.16.0-next.3"
+    "@backstage/plugin-events-node": "npm:0.4.8-next.2"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
-    "@backstage/plugin-notifications-node": "npm:0.2.12-next.1"
-    "@backstage/plugin-signals-node": "npm:0.1.17-next.1"
+    "@backstage/plugin-notifications-node": "npm:0.2.12-next.2"
+    "@backstage/plugin-signals-node": "npm:0.1.17-next.2"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/0ec5a6d2ccb49ba1b4e0123b56f29b0642ead478ec30199a99991d1b45dcab4fe48d9be4bd42dfec34ae18aa1500598265c9c237cce61c341573db1da7f3b724
+  checksum: 10/24995f67ff79de983a3f2155905c9c0c5862c34e4863944ca44febd322e7fc116cfb8ba084146cbf9bbdd5bcdced1fb21969517048f31b8703c954bc09ce2d55
   languageName: node
   linkType: hard
 
@@ -5908,18 +5909,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@npm:0.2.12-next.1":
-  version: 0.2.12-next.1
-  resolution: "@backstage/plugin-notifications-node@npm:0.2.12-next.1"
+"@backstage/plugin-notifications-node@npm:0.2.12-next.2":
+  version: 0.2.12-next.2
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.12-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
-    "@backstage/plugin-signals-node": "npm:0.1.17-next.1"
+    "@backstage/plugin-signals-node": "npm:0.1.17-next.2"
     knex: "npm:^3.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/edd55cda62c3d36d79e160edb8c99155ececbeb2227425dddf3b00e9c3fdce39c5c3764568b15ed88b456da04d2eed4d54a2b06b56387305b3b9fc6608c1b759
+  checksum: 10/1990c2cf234f222664de1a7eea6f3daa50263b6d8a96c63a0b77f3b2df583cd9aafef9121231d32b3c183c5fda279e9772d015a53e670ec5f8872c13e188878d
   languageName: node
   linkType: hard
 
@@ -5954,17 +5955,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@npm:^0.6.36-next.2":
-  version: 0.6.36-next.2
-  resolution: "@backstage/plugin-org@npm:0.6.36-next.2"
+"@backstage/plugin-org@npm:^0.6.36-next.3":
+  version: 0.6.36-next.3
+  resolution: "@backstage/plugin-org@npm:0.6.36-next.3"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5981,7 +5982,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/75c8c4d0ce63e8dd4e4d0422c1095b38b2f1b858f007d86dd6489669a8bc594e90fa8d7d15dbd4cabf425a501d3647ad09cb89f98b075b157d0143ed9b4535b9
+  checksum: 10/3136962b8c3211e9bc1b2723d73dc15538d27fb572cdbb20b00bdcd2e7db33b876809f3c34faa91b4fb2bc4cc1ac7eb706f98e8f511c435d3c5ee980f6805e92
   languageName: node
   linkType: hard
 
@@ -6000,22 +6001,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:0.8.8-next.1":
-  version: 0.8.8-next.1
-  resolution: "@backstage/plugin-permission-node@npm:0.8.8-next.1"
+"@backstage/plugin-permission-node@npm:0.8.8-next.2":
+  version: 0.8.8-next.2
+  resolution: "@backstage/plugin-permission-node@npm:0.8.8-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     "@backstage/plugin-permission-common": "npm:0.8.4"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/5e456bd145657d89eb997e413efb6c4234813452fc21f44ab8d5fd73367534794553d86d6e92175517baef83ef62bd884625296d6a01128725cf0dbeff081277
+  checksum: 10/b530398922027b77e1d87ac7c4bd77d1fac44abc116f7d04cdd5962e9e9c99cd21da65b683231ac498f49b882574fcb1ae971cf34b8cee79a99645f24f87c8a1
   languageName: node
   linkType: hard
 
@@ -6078,14 +6079,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@npm:^0.5.11-next.1":
-  version: 0.5.11-next.1
-  resolution: "@backstage/plugin-proxy-backend@npm:0.5.11-next.1"
+"@backstage/plugin-proxy-backend@npm:^0.5.11-next.2":
+  version: 0.5.11-next.2
+  resolution: "@backstage/plugin-proxy-backend@npm:0.5.11-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-proxy-node": "npm:0.1.1-next.1"
+    "@backstage/plugin-proxy-node": "npm:0.1.1-next.2"
     "@backstage/types": "npm:1.2.1"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
@@ -6097,180 +6098,180 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     yup: "npm:^1.0.0"
-  checksum: 10/0f3c361d21351c23db0a035d3b2668ad138ce645e6be32d04cc7d85e1a7b15c4818b5130b093b5851b8c29be728d251ebfa2ab20a1f9685a8b479e283272468b
+  checksum: 10/32554d3d8b20d3e62e2857b9de421fb9a990957c1a966937ce1496fea6b50370bdb5f8dcafe0d9e6c9c8ecb629decdf82cfc1cc1d061920725d6b21079cb8902
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-node@npm:0.1.1-next.1":
-  version: 0.1.1-next.1
-  resolution: "@backstage/plugin-proxy-node@npm:0.1.1-next.1"
+"@backstage/plugin-proxy-node@npm:0.1.1-next.2":
+  version: 0.1.1-next.2
+  resolution: "@backstage/plugin-proxy-node@npm:0.1.1-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     http-proxy-middleware: "npm:^2.0.0"
-  checksum: 10/0004cadda3449ddc3b390ce87ee0cd1f5ec9105b10025675a8528d7ac62435cc09de4f9ebd7f39633b66fe424f6960c3aadb7a75597f8ddc914d2ef372f0854b
+  checksum: 10/8e5fc8dae0f183d9ec4b869eb2f0497825417c3718b71bea1c3efbb1dd2581e0acf55fc0e42ad82a807086d67b3d413f1884d19374969efe8f18622760a0aeb5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.6-next.1":
-  version: 0.2.6-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.6-next.1"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.6-next.2":
+  version: 0.2.6-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.6-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.2"
     azure-devops-node-api: "npm:^14.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/a9ff8f992577672a3ab30a1d75e67bad56a672e3ee3fbdcd074acaea32f6acf2babb8d02d30f82375c3162c5706afbb619c80264e6a216e0ee572456a6f347f2
+  checksum: 10/1967a4ebd1f8326d1506f13a49d447c376b6c298168d3c8fa02666f6147a0a8dde1f96bbf65f41220a811eb9fcafadde06b200fca52978a95dda5403f16dd079
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.6-next.1":
-  version: 0.2.6-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.6-next.1"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.6-next.2":
+  version: 0.2.6-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.6-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
     "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.27"
-    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.2"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/628a997ef163a4b546d26792ef5f8561fb9e5e847f4a93ad0dc3a56701abbfa52464891ab9079abf7c27b1fcafb4dc4d7a52aa7079bd88ffc356dd8dee3020a8
+  checksum: 10/1e24d30c1fcaee6024753380aec092459c54c3881165b62c43ee9ab0386bfaa08764fadf600f76ab2b2c075489975e2d33475e3129ece16cfdb258cf81f491f5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.6-next.1":
-  version: 0.2.6-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.6-next.1"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.6-next.2":
+  version: 0.2.6-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.6-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.2"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/43eeff410f8e3dcbe68984e87b55b15c7c1e39a97366ad71cb630e4003ce1a6e8920ca551027776c92d6df7f497b267821edc48b9551ff2d0387e398d26f135e
+  checksum: 10/ced42837c9489da3ad523688e8d141b6a9a69b2febac1928065de391be15d5fd6191e834f11e50112bc70eaef7a2e8a89056a03b41423d335b6725da70268658
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.7-next.1":
-  version: 0.3.7-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.7-next.1"
+"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.7-next.2":
+  version: 0.3.7-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.7-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.6-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.6-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.6-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.6-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.2"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/8c378e0ea1232d1d74d12f7bb6408829ebab256c6c9e22442ebe645fa82f3417c44b017d8bb011edad5d1a4b4165fac5ff63ae4149d92f191ca39aceb3fb88b3
+  checksum: 10/b9cc49f42fe7cf201c3d2ef6fb51b200edfad455d297f67e6cfa9f5606d2c6a509ed8684390fdb39beff1d5451e9439613fb6a8fd7c13cc4b622d08df55a5dbf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.6-next.1":
-  version: 0.2.6-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.6-next.1"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.6-next.2":
+  version: 0.2.6-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.6-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.2"
     yaml: "npm:^2.0.0"
-  checksum: 10/36616cae184f63a8e33da45360c3e188eb38ada7c35711570ff8110f05acbc536466cd03a5c25ed81063912ac15aa9aaf9ae53a8a32d65fbbfbd3b351d216040
+  checksum: 10/96e2a14e303b31f12ee463a0faa45f22577b5a0202c95a719b429de8d3fcad51d3cbe9bab3c2bb515ec8917437e272449f222dbd73e55a6fc02de0209fde5a5b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.6-next.1":
-  version: 0.2.6-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.6-next.1"
+"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.6-next.2":
+  version: 0.2.6-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.6-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.2"
     yaml: "npm:^2.0.0"
-  checksum: 10/96de1e9445b5bed62213a08478af3b24418a683c154c52555d8ebfdf17bfdca28a6b999f046814e5f150419777dced9e921b1858d56b9d6c8a74b9e3d35295e8
+  checksum: 10/a9296478d048539ac078200a1f3f2075cf1aeafa71188c8d74773b4106aa163cc8582dec025b49e20228a6661995837c8111ae7a1ca0f8bebbc4967943361602
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@npm:0.5.6-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.5.6-next.1":
-  version: 0.5.6-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.5.6-next.1"
+"@backstage/plugin-scaffolder-backend-module-github@npm:0.6.0-next.2, @backstage/plugin-scaffolder-backend-module-github@npm:^0.6.0-next.2":
+  version: 0.6.0-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.6.0-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.2"
     "@octokit/webhooks": "npm:^10.9.2"
     libsodium-wrappers: "npm:^0.7.11"
     octokit: "npm:^3.0.0"
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/49386438f72972e6a51872a9bb8cd39a97fa7b798eda28e0be36b4a3cfc7840f08e8bb8d6874e7902b92160a852ef65c21ba949a80eb7981fc0281b5b74a72df
+  checksum: 10/2c4da1b29d9e5b5d478ba19457f5c142146a68343cbf8daf5e057867a09c7fc8539739cfb57701bb4d640259c0d95723fdf04ac7ea8f4d41f6dec0b5d5a19379
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.8.0-next.2":
-  version: 0.8.0-next.2
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.8.0-next.2"
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.8.0-next.3":
+  version: 0.8.0-next.3
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.8.0-next.3"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.2"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     winston: "npm:^3.2.1"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/cd148284e607ac83d5ce7bef751de358193c55c2a5fcc40e1f34c7ab9175387f9166ca02d83d43730370eebc4c3bc14d4a8b8ecfc911ca021f4239b5676eb18b
+  checksum: 10/9f56c79b614800fcc50155e98c8ac2d9493664f69b0896b1e0a383159e2805742a78eb7f4c3ab099470aad3f5f393523a271aa440dc7f1c5b7fecc1473fad6c1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@npm:^1.30.0-next.2":
-  version: 1.30.0-next.2
-  resolution: "@backstage/plugin-scaffolder-backend@npm:1.30.0-next.2"
+"@backstage/plugin-scaffolder-backend@npm:^1.30.0-next.3":
+  version: 1.30.0-next.3
+  resolution: "@backstage/plugin-scaffolder-backend@npm:1.30.0-next.3"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-defaults": "npm:0.8.0-next.2"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-defaults": "npm:0.8.0-next.3"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
     "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.27"
-    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.5-next.2"
-    "@backstage/plugin-catalog-node": "npm:1.16.0-next.2"
-    "@backstage/plugin-events-node": "npm:0.4.8-next.1"
+    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.5-next.3"
+    "@backstage/plugin-catalog-node": "npm:1.16.0-next.3"
+    "@backstage/plugin-events-node": "npm:0.4.8-next.2"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.8.8-next.1"
-    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.6-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.7-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.6-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.6-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.6-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.6-next.1"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.5.6-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.8.0-next.2"
+    "@backstage/plugin-permission-node": "npm:0.8.8-next.2"
+    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.6-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.7-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.6-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.6-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.6-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.6-next.2"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.6.0-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.8.0-next.3"
     "@backstage/plugin-scaffolder-common": "npm:1.5.9"
-    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.7.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/express": "npm:^4.17.6"
@@ -6299,7 +6300,7 @@ __metadata:
     yaml: "npm:^2.0.0"
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
-  checksum: 10/d8fcff34257e3ae27a1ef4649fd27fe9e13004f96805328515328b6ac8fbbef2126d51d0cdf9b429d6301d868ca3a24152efca1fd214adaa1b29c42304061968
+  checksum: 10/af2453a2dd4a56ee8e002cefc84b111d49177dbc5483c4bdd0250a12e2b9bb4287ea5786fecd3cb572dc3009f0dd6b18c1c241f92ca31d4eef07cbeb76aa9af6
   languageName: node
   linkType: hard
 
@@ -6314,12 +6315,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:0.7.0-next.1":
-  version: 0.7.0-next.1
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.7.0-next.1"
+"@backstage/plugin-scaffolder-node@npm:0.7.0-next.2":
+  version: 0.7.0-next.2
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.7.0-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
@@ -6335,20 +6336,20 @@ __metadata:
     winston: "npm:^3.2.1"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/fbed08eaa778952f73684c34fd979bf84bfc88564bb0d1a014e17549b97776cb16745fe72083070207517898fc89ff04040691de46c2d72f71f38a60f7d40d2e
+  checksum: 10/36894cc0f7ef7a48a5b81fe442143f3c5bf805e5e5e9e24881c8b7772b021039b8f56ee732ba087fde86e155fa05a588dc91719433c072088af0466422805bf3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.14.5-next.2":
-  version: 1.14.5-next.2
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.14.5-next.2"
+"@backstage/plugin-scaffolder-react@npm:1.14.5-next.3":
+  version: 1.14.5-next.3
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.14.5-next.3"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/plugin-permission-react": "npm:0.4.31-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.5.9"
     "@backstage/theme": "npm:0.6.4-next.0"
@@ -6387,28 +6388,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0f516c7cf94e6139797d3d8648e66b45643966b2c561f9c34235e7a01f09baf0c6af73a46063d67dfab92eb6cbd2cc99e70c7fbde9ba044f2ded5db98c28f657
+  checksum: 10/575bcc7714711846c82b777fb31d086a39205901ee23f9b640b4c3d6386853d5d1ed8e306447ac07f10e71d23543296f5a0fafc716270b2a07801be2270d64a4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@npm:^1.28.0-next.2":
-  version: 1.28.0-next.2
-  resolution: "@backstage/plugin-scaffolder@npm:1.28.0-next.2"
+"@backstage/plugin-scaffolder@npm:^1.28.0-next.3":
+  version: 1.28.0-next.3
+  resolution: "@backstage/plugin-scaffolder@npm:1.28.0-next.3"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
     "@backstage/integration": "npm:1.16.1"
     "@backstage/integration-react": "npm:1.2.4-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/plugin-permission-react": "npm:0.4.31-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.5.9"
-    "@backstage/plugin-scaffolder-react": "npm:1.14.5-next.2"
+    "@backstage/plugin-scaffolder-react": "npm:1.14.5-next.3"
     "@backstage/types": "npm:1.2.1"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
@@ -6448,68 +6449,68 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/64937035b6e251457fe8926715e856821459843e5d03df37c86ffdabd27d31fe3e2abe725e37cd6edfa81fdd0ac76305855550df8fb8d6d36c0c3a8b53daa4bc
+  checksum: 10/1e2490d4ceef23fd53c9b022c6fd979f45aa949766a84e1592fdf0e4ea81d0126bef895b4888aeb43dedae7317300bcc49dc798e7f1296a0d34c3d2e1c53acc7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@npm:0.3.1-next.2, @backstage/plugin-search-backend-module-catalog@npm:^0.3.1-next.2":
-  version: 0.3.1-next.2
-  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.1-next.2"
+"@backstage/plugin-search-backend-module-catalog@npm:0.3.1-next.3, @backstage/plugin-search-backend-module-catalog@npm:^0.3.1-next.3":
+  version: 0.3.1-next.3
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.1-next.3"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.16.0-next.2"
+    "@backstage/plugin-catalog-node": "npm:1.16.0-next.3"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-search-backend-node": "npm:1.3.8-next.1"
+    "@backstage/plugin-search-backend-node": "npm:1.3.8-next.2"
     "@backstage/plugin-search-common": "npm:1.2.17"
-  checksum: 10/d70b2b9112715d9cb73551ea049765346cad7b9d160aa98983a544b9dcba29837806275c0fbd3de05fb1b44275324de1edc61e457b3de169ca7d0c1cda15df34
+  checksum: 10/968267f1d953984ab08d009fdfe4a3c367d95ddc7cfe48a2d755f46a1bc06a9e2aa5deb4a8755fd4f6389b16bd8528c1081aee6d1ee6649b229785bec8c8af1a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-explore@npm:^0.2.8-next.1":
-  version: 0.2.8-next.1
-  resolution: "@backstage/plugin-search-backend-module-explore@npm:0.2.8-next.1"
+"@backstage/plugin-search-backend-module-explore@npm:^0.2.8-next.2":
+  version: 0.2.8-next.2
+  resolution: "@backstage/plugin-search-backend-module-explore@npm:0.2.8-next.2"
   dependencies:
     "@backstage-community/plugin-explore-common": "npm:^0.0.7"
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-search-backend-node": "npm:1.3.8-next.1"
+    "@backstage/plugin-search-backend-node": "npm:1.3.8-next.2"
     "@backstage/plugin-search-common": "npm:1.2.17"
-  checksum: 10/408733d7adb9057cac96f4f5357477dd76517a719b1b890bf1fca2e99995f45ef19e51f623513ef95bac43513b52f260751ae41509f19cab6563390448ce39b6
+  checksum: 10/e24567ccfdee250b37de54fdadee535803ab4a22e784c946039b86ca031d580cbbbd3ead7336200a26fa9e0cfe241ee5e33b1135090e9973ef89aa7589a51f4f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-techdocs@npm:0.3.6-next.2":
-  version: 0.3.6-next.2
-  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.3.6-next.2"
+"@backstage/plugin-search-backend-module-techdocs@npm:0.3.6-next.3":
+  version: 0.3.6-next.3
+  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.3.6-next.3"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.16.0-next.2"
+    "@backstage/plugin-catalog-node": "npm:1.16.0-next.3"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-search-backend-node": "npm:1.3.8-next.1"
+    "@backstage/plugin-search-backend-node": "npm:1.3.8-next.2"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-techdocs-node": "npm:1.13.0-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.13.0-next.2"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/11f479ded1507bff1b6ca10e208b37e6c9293cafc29dfc03a8827a869d98dc495f732c3791f9858009015e07e53641e67df79340b871acd063685b0460a2ef4d
+  checksum: 10/f1b2d63deb836727650903d3d3e5ef052a49bd836857de0cdfa6392f4f7f7f44c39cddd9e53d8885de6675f35d8a90d8f97ee67e47126244fff7c24b1ddf0a12
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-node@npm:1.3.8-next.1":
-  version: 1.3.8-next.1
-  resolution: "@backstage/plugin-search-backend-node@npm:1.3.8-next.1"
+"@backstage/plugin-search-backend-node@npm:1.3.8-next.2":
+  version: 1.3.8-next.2
+  resolution: "@backstage/plugin-search-backend-node@npm:1.3.8-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-permission-common": "npm:0.8.4"
@@ -6519,23 +6520,23 @@ __metadata:
     lunr: "npm:^2.3.9"
     ndjson: "npm:^2.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/b95f1878a9e7744395a26ee55739134ad07a3db12fea6793c67515f945809477a5559b53621ff9ad7fc025d1fccb81c1d3a447b3246eb0bab2e57e8823df60b4
+  checksum: 10/3d158ff54c28188295d126cf77ba5a5e49bcd506d27a34ffc92a56a29f4f035fb52f13f939b9ebfa7820f2328a4e74c384aa8b26f021a4de1bc66c935b1ea3f3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@npm:^1.8.2-next.2":
-  version: 1.8.2-next.2
-  resolution: "@backstage/plugin-search-backend@npm:1.8.2-next.2"
+"@backstage/plugin-search-backend@npm:^1.8.2-next.3":
+  version: 1.8.2-next.3
+  resolution: "@backstage/plugin-search-backend@npm:1.8.2-next.3"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-defaults": "npm:0.8.0-next.2"
-    "@backstage/backend-openapi-utils": "npm:0.5.0-next.2"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-defaults": "npm:0.8.0-next.3"
+    "@backstage/backend-openapi-utils": "npm:0.5.0-next.3"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.8.8-next.1"
-    "@backstage/plugin-search-backend-node": "npm:1.3.8-next.1"
+    "@backstage/plugin-permission-node": "npm:0.8.8-next.2"
+    "@backstage/plugin-search-backend-node": "npm:1.3.8-next.2"
     "@backstage/plugin-search-common": "npm:1.2.17"
     "@backstage/types": "npm:1.2.1"
     "@types/express": "npm:^4.17.6"
@@ -6545,7 +6546,7 @@ __metadata:
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/e52ad805fe0480196ef9a8a951e7a4bfb20bbf9ba7096d22560114627d5b0e86a675040742fe64c1d0bd80601fb5b32be0da5df15b4355d989e5b2f544c59f02
+  checksum: 10/8825db9c7546f26a732851d829a55205779f4e3dd9f9af8c68497c4fc5f934e57cbd3845aa2a106520a5893cd8d3f72cafc436b66374c2d6f944ee85e7c70382
   languageName: node
   linkType: hard
 
@@ -6559,13 +6560,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@npm:1.8.6-next.2, @backstage/plugin-search-react@npm:^1.8.6-next.2":
-  version: 1.8.6-next.2
-  resolution: "@backstage/plugin-search-react@npm:1.8.6-next.2"
+"@backstage/plugin-search-react@npm:1.8.6-next.3, @backstage/plugin-search-react@npm:^1.8.6-next.3":
+  version: 1.8.6-next.3
+  resolution: "@backstage/plugin-search-react@npm:1.8.6-next.3"
   dependencies:
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
     "@backstage/plugin-search-common": "npm:1.2.17"
     "@backstage/theme": "npm:0.6.4-next.0"
     "@backstage/types": "npm:1.2.1"
@@ -6585,7 +6586,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b054c23db2a30bae1cb030e7eef1ef5297cc330f0cd8036fbeb1d4e099cc4e2ad5f02aa01d8647c848d777a2ab4ac438fda6183089ed7b171d1b17f7b6965735
+  checksum: 10/23b8cbe013ff86273baaa6f655f82a4f6a44f74a1c215f02072a00b3968887427ef9a02869d166932d783ee0ef9ab233c4e4d9b16b2f02a1fd6efa92879d8edb
   languageName: node
   linkType: hard
 
@@ -6619,18 +6620,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@npm:^1.4.23-next.2":
-  version: 1.4.23-next.2
-  resolution: "@backstage/plugin-search@npm:1.4.23-next.2"
+"@backstage/plugin-search@npm:^1.4.23-next.3":
+  version: 1.4.23-next.3
+  resolution: "@backstage/plugin-search@npm:1.4.23-next.3"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.6-next.2"
+    "@backstage/plugin-search-react": "npm:1.8.6-next.3"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11-next.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -6645,19 +6646,19 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/bd29503041fca2442835c14f12cecfa17b0c570364ee2d2afc680b2b4ec90a9598596755ba83c40d560d95eee55ebd223c408b2dd8fe79c1ea73a3cf542013c1
+  checksum: 10/66133e2030c512e4ef637c522e839917241f73e4b5932ce1bcd1bf113a17c46f215916fdb395120d8673274fe5f07314fbb4ec69898b62e42891b2b8266ccbbe
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@npm:^0.3.1-next.1":
-  version: 0.3.1-next.1
-  resolution: "@backstage/plugin-signals-backend@npm:0.3.1-next.1"
+"@backstage/plugin-signals-backend@npm:^0.3.1-next.2":
+  version: 0.3.1-next.2
+  resolution: "@backstage/plugin-signals-backend@npm:0.3.1-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
-    "@backstage/plugin-events-node": "npm:0.4.8-next.1"
-    "@backstage/plugin-signals-node": "npm:0.1.17-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
+    "@backstage/plugin-events-node": "npm:0.4.8-next.2"
+    "@backstage/plugin-signals-node": "npm:0.1.17-next.2"
     "@backstage/types": "npm:1.2.1"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -6666,23 +6667,23 @@ __metadata:
     winston: "npm:^3.2.1"
     ws: "npm:^8.18.0"
     yn: "npm:^4.0.0"
-  checksum: 10/dcc0ac1c104513b84dc6d3f04abed0175c2e4876a1bc787e6501a35ea0b71a2de0a73cd679089bbd8c4d6e6eec1791a51b6659869c696dea09a94357b04a3431
+  checksum: 10/a065115806060ea932c6f7791c5d69ca17973aba5bd7be88aec0ac0f1f7d79bf9d37c08747d9df81ac9068706a91e8f62df58b48f0a34c0515a4cf69de570bbe
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-node@npm:0.1.17-next.1":
-  version: 0.1.17-next.1
-  resolution: "@backstage/plugin-signals-node@npm:0.1.17-next.1"
+"@backstage/plugin-signals-node@npm:0.1.17-next.2":
+  version: 0.1.17-next.2
+  resolution: "@backstage/plugin-signals-node@npm:0.1.17-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-auth-node": "npm:0.6.0-next.1"
-    "@backstage/plugin-events-node": "npm:0.4.8-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.0-next.2"
+    "@backstage/plugin-events-node": "npm:0.4.8-next.2"
     "@backstage/types": "npm:1.2.1"
     express: "npm:^4.17.1"
     uuid: "npm:^11.0.0"
     ws: "npm:^8.18.0"
-  checksum: 10/4b363b9a29d704843e30e4e0261d34cb16dc1f87e8c2b67aa5c10fdbc77a85df90653fdbbff18120f5370b4d185a29c163ab8ba330e09010890e3afb308c160a
+  checksum: 10/1e2dc68fa4dbe3986dba132c1625e071f9682f9bf0fb33496bd7b050520078b9c2bb3ac01ae0027a2836084b6c9a28b5e93581ca8c13f9ef22af4901449d8643
   languageName: node
   linkType: hard
 
@@ -6731,23 +6732,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@npm:^1.11.6-next.2":
-  version: 1.11.6-next.2
-  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.6-next.2"
+"@backstage/plugin-techdocs-backend@npm:^1.11.6-next.3":
+  version: 1.11.6-next.3
+  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.6-next.3"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.1"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.16.0-next.2"
+    "@backstage/plugin-catalog-node": "npm:1.16.0-next.3"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-search-backend-module-techdocs": "npm:0.3.6-next.2"
+    "@backstage/plugin-search-backend-module-techdocs": "npm:0.3.6-next.3"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-node": "npm:1.13.0-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.13.0-next.2"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -6756,7 +6757,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/607783375719fa1682984869f4ff97c28a122e1bc440c7d7fa2c5e4241072644f8ce1259da961a85f2f7c6ad14b4b811534eb7019c87431edc2a1949833a2877
+  checksum: 10/a3cf6b15a7748c8f501d9db842283b1f942c032db89fa92654f91b2a8b28f0df96e93e4d3d95985c6ac80ba7b0ec792738b7818bb0b8492eb6228bbff398d396
   languageName: node
   linkType: hard
 
@@ -6793,9 +6794,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@npm:1.13.0-next.1, @backstage/plugin-techdocs-node@npm:^1.13.0-next.1":
-  version: 1.13.0-next.1
-  resolution: "@backstage/plugin-techdocs-node@npm:1.13.0-next.1"
+"@backstage/plugin-techdocs-node@npm:1.13.0-next.2, @backstage/plugin-techdocs-node@npm:^1.13.0-next.2":
+  version: 1.13.0-next.2
+  resolution: "@backstage/plugin-techdocs-node@npm:1.13.0-next.2"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -6803,7 +6804,7 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-plugin-api": "npm:1.2.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.2.0-next.2"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
@@ -6826,7 +6827,7 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/ea221851eefe88d6f9b88a348bcdf57f04b6ec33bc1ef5ebd8af0d21df01ef289ebdccbec9b8b1ae0fe24b7a873bfd5a0af76bcd16752bbe18660ef109b22a43
+  checksum: 10/3dab6b87e8911a2a3b27a4346d959dbad859aa2052b4bdbb35d17dfca4687028ca8303c7d32bc7cf8a191058425ec943fa7f846f74fd3b9f953d56e1d14eac34
   languageName: node
   linkType: hard
 
@@ -6884,24 +6885,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@npm:^1.12.3-next.2":
-  version: 1.12.3-next.2
-  resolution: "@backstage/plugin-techdocs@npm:1.12.3-next.2"
+"@backstage/plugin-techdocs@npm:^1.12.3-next.3":
+  version: 1.12.3-next.3
+  resolution: "@backstage/plugin-techdocs@npm:1.12.3-next.3"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
     "@backstage/integration": "npm:1.16.1"
     "@backstage/integration-react": "npm:1.2.4-next.0"
     "@backstage/plugin-auth-react": "npm:0.1.12-next.1"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.6-next.2"
+    "@backstage/plugin-search-react": "npm:1.8.6-next.3"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
     "@backstage/plugin-techdocs-react": "npm:1.2.14-next.1"
     "@backstage/theme": "npm:0.6.4-next.0"
@@ -6924,7 +6925,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5151d6fc6c87bf3b45c8921bee4e668a13ee9b6f1fb649727f309a97ffbdda36458d20c2e96024ce32b1e0aad726472cd69464459175f260add7d77d92ec82cf
+  checksum: 10/efc7c278c6de1c7f3272b581b7a39ec6c1670df8ed3929de81d27c473a68ed9c1158eeafdef7b786e0fafccdba459c6f5742880819604aebb1583c257dee7501
   languageName: node
   linkType: hard
 
@@ -6935,18 +6936,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@npm:^0.8.19-next.2":
-  version: 0.8.19-next.2
-  resolution: "@backstage/plugin-user-settings@npm:0.8.19-next.2"
+"@backstage/plugin-user-settings@npm:^0.8.19-next.3":
+  version: 0.8.19-next.3
+  resolution: "@backstage/plugin-user-settings@npm:0.8.19-next.3"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/core-app-api": "npm:1.15.5-next.0"
-    "@backstage/core-compat-api": "npm:0.3.6-next.2"
+    "@backstage/core-compat-api": "npm:0.3.6-next.3"
     "@backstage/core-components": "npm:0.16.4-next.1"
     "@backstage/core-plugin-api": "npm:1.10.4-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.9.5-next.2"
-    "@backstage/plugin-catalog-react": "npm:1.15.2-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.9.5-next.3"
+    "@backstage/plugin-catalog-react": "npm:1.15.2-next.3"
     "@backstage/plugin-signals-react": "npm:0.0.10-next.0"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
     "@backstage/theme": "npm:0.6.4-next.0"
@@ -6964,7 +6965,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9dd0d1a81a1d6fb6c85f2b9dfe4b7fc7f9b9d18a3ef94b57c641f19d47075d381988dfdaf848f2343f4aac526c7629591e5ebc04d9cbcf890994e33dfa2537a0
+  checksum: 10/a811d5469c15801b903291d8a53576d24c112251d63270ff73df6a992a2b3bbd895a94c6d390eb8286feac9fab765fa5fa818e4aea1bb8c5a7a5b106862526b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.36.0-next.3 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.36.0-next.3](https://github.com/backstage/backstage/blob/master/docs/releases/v1.36.0-next.3-changelog.md)
- Upgrade Helper: [From 1.36.0-next.2 to 1.36.0-next.3](https://backstage.github.io/upgrade-helper/?from=1.36.0-next.2&to=1.36.0-next.3)
 
Created by [Version Bump 13282825746](https://github.com/backstage/demo/actions/runs/13282825746)
 