### PR TITLE
v1.38.0-next.1 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 254c816a15098e2a0b414345caf9144409fbf6a63da7ec8ec8d3454aa1d2edfbbc32cd264d8c464b7ec4aca7809c690848a7c1191b5f8167dec81dbdf6107b01
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.38.0-next.0/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.38.0-next.1/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.38.0-next.0"
+  "version": "1.38.0-next.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3503,15 +3503,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@backstage/app-defaults@npm:1.6.0"
+"@backstage/app-defaults@npm:^1.6.1-next.0":
+  version: 1.6.1-next.0
+  resolution: "@backstage/app-defaults@npm:1.6.1-next.0"
   dependencies:
-    "@backstage/core-app-api": "npm:^1.16.0"
-    "@backstage/core-components": "npm:^0.17.0"
-    "@backstage/core-plugin-api": "npm:^1.10.5"
-    "@backstage/plugin-permission-react": "npm:^0.4.32"
-    "@backstage/theme": "npm:^0.6.4"
+    "@backstage/core-app-api": "npm:1.16.0"
+    "@backstage/core-components": "npm:0.17.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/plugin-permission-react": "npm:0.4.32"
+    "@backstage/theme": "npm:0.6.4"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -3522,7 +3522,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9d4def43db372d57ee18c4d48a09bd6f7088429b1e7a0c4cb21308d0171d4d32fc166867557522671aa09a028b8b75decf5ff94a293865ed66863b1edcd0e043
+  checksum: 10/e3e1c57cb635e873dd51764624bf03cbae252b0387fb0726ca88caf8fc298fd626a6c147e98bb39de734203aaad8d5760f660a80ef897a1c958b63780eb4d7a3
   languageName: node
   linkType: hard
 
@@ -3690,9 +3690,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:0.9.0-next.0, @backstage/backend-defaults@npm:^0.9.0-next.0":
-  version: 0.9.0-next.0
-  resolution: "@backstage/backend-defaults@npm:0.9.0-next.0"
+"@backstage/backend-defaults@npm:0.9.0-next.1, @backstage/backend-defaults@npm:^0.9.0-next.1":
+  version: 0.9.0-next.1
+  resolution: "@backstage/backend-defaults@npm:0.9.0-next.1"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -3707,7 +3707,7 @@ __metadata:
     "@backstage/config": "npm:1.3.2"
     "@backstage/config-loader": "npm:1.10.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
+    "@backstage/integration": "npm:1.16.3-next.0"
     "@backstage/integration-aws-node": "npm:0.1.15"
     "@backstage/plugin-auth-node": "npm:0.6.1"
     "@backstage/plugin-events-node": "npm:0.4.9"
@@ -3765,7 +3765,7 @@ __metadata:
   peerDependenciesMeta:
     "@google-cloud/cloud-sql-connector":
       optional: true
-  checksum: 10/49ef73ad1073e905123aa8d6330ed506b80200c423e68ffefb216a3a923bab4407d151567dede11b996fe09024c4504f3027c9e7c218b600c588d7ea8c9ca472
+  checksum: 10/e165fc750bcccdcf2c6f255a946de9b160301d78d83a00f7809ba742e501557959523802de8ac3eae63d29f6d3de8db1036ea0b2616c45392a04c7a40b797f8d
   languageName: node
   linkType: hard
 
@@ -3917,9 +3917,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/canon@npm:^0.2.1-next.0":
-  version: 0.2.1-next.0
-  resolution: "@backstage/canon@npm:0.2.1-next.0"
+"@backstage/canon@npm:^0.2.1-next.1":
+  version: 0.2.1-next.1
+  resolution: "@backstage/canon@npm:0.2.1-next.1"
   dependencies:
     "@base-ui-components/react": "npm:^1.0.0-alpha.5"
     "@remixicon/react": "npm:^4.5.0"
@@ -3932,7 +3932,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d568f3ba8fbbabc4e575585f0ca78ebd8b014304561795b4b5f0a26042ca493190555df29409beb051c5632396b4587c045c609aeac9b5de96003e6619e74cb3
+  checksum: 10/d89bfee5c077666e3a4af3b9760336461dd6075ebd4b0e7e742ded482517b730681f51a221d2e702281141772515e31e6d1af4361d88043ae7b5b05c240dc1d1
   languageName: node
   linkType: hard
 
@@ -3983,9 +3983,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:^0.32.0-next.0":
-  version: 0.32.0-next.0
-  resolution: "@backstage/cli@npm:0.32.0-next.0"
+"@backstage/cli@npm:^0.32.0-next.1":
+  version: 0.32.0-next.1
+  resolution: "@backstage/cli@npm:0.32.0-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/cli-common": "npm:0.1.15"
@@ -3994,7 +3994,7 @@ __metadata:
     "@backstage/config-loader": "npm:1.10.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/eslint-plugin": "npm:0.1.10"
-    "@backstage/integration": "npm:1.16.2"
+    "@backstage/integration": "npm:1.16.3-next.0"
     "@backstage/release-manifests": "npm:0.0.12"
     "@backstage/types": "npm:1.2.1"
     "@manypkg/get-packages": "npm:^1.1.3"
@@ -4114,7 +4114,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/6d57cc2a16522f02cd20f1ca31a1055c5a31f0ead3f8f533597d378b12bd92c7e0e7f05821f6ae593d01e9fac9faab4da1a4f3f2bb973b97e5863b6b33ec643f
+  checksum: 10/e964e6937b1248bd95e908cab958cdd651a04d0d7abaeb9c1177d719334254bf9ef0cf369e00324323d9ca46fd1ad6f26e6cb923c7e33debd73adfdaeee87dd9
   languageName: node
   linkType: hard
 
@@ -4180,13 +4180,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@npm:0.4.1-next.0":
-  version: 0.4.1-next.0
-  resolution: "@backstage/core-compat-api@npm:0.4.1-next.0"
+"@backstage/core-compat-api@npm:0.4.1-next.1":
+  version: 0.4.1-next.1
+  resolution: "@backstage/core-compat-api@npm:0.4.1-next.1"
   dependencies:
     "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/version-bridge": "npm:1.0.11"
     lodash: "npm:^4.17.21"
   peerDependencies:
@@ -4197,7 +4197,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4be7a0d6b4492bfb561db174104775d6f94722c15ba7a938a562ccab3e98c18be02db80a2e12c163ee02739ab5d191af4eab3c8e1e9abf21c1e4c8a0f703d8b5
+  checksum: 10/e5325c7495536397782935338f8ad9ce869248f4b3b123074d2c6b58ace08d255fef9c1bdf8dd62d80b3a62a6a02e45f86f85678888899278c7450e05539f6fc
   languageName: node
   linkType: hard
 
@@ -4238,7 +4238,110 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:0.17.0, @backstage/core-components@npm:^0.17.0":
+"@backstage/core-components@npm:0.17.1-next.0, @backstage/core-components@npm:^0.17.1-next.0":
+  version: 0.17.1-next.0
+  resolution: "@backstage/core-components@npm:0.17.1-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/theme": "npm:0.6.4"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.1.3"
+    linkifyjs: "npm:4.1.3"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/ebee9832c2ee113e8ddcb870a4f09603f91ca0430d6e0d57f4e0a6d761fd5fbe93d8dea3f51b0e8411f7e5f1841f0630ac4f837475561abe8b92dba5784eb314
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:^0.14.10":
+  version: 0.14.10
+  resolution: "@backstage/core-components@npm:0.14.10"
+  dependencies:
+    "@backstage/config": "npm:^1.2.0"
+    "@backstage/core-plugin-api": "npm:^1.9.3"
+    "@backstage/errors": "npm:^1.2.4"
+    "@backstage/theme": "npm:^0.5.6"
+    "@backstage/version-bridge": "npm:^1.0.8"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    dagre: "npm:^0.8.5"
+    linkify-react: "npm:4.1.3"
+    linkifyjs: "npm:4.1.3"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  checksum: 10/870f4c58e490c13b043f855c101f23e0155497a755677e84b9e6accf0f829343dc5f702de6382fdaf73a34f7540562f0842393feb7e83e498483256c3425da8c
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:^0.17.0":
   version: 0.17.0
   resolution: "@backstage/core-components@npm:0.17.0"
   dependencies:
@@ -4289,55 +4392,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/b48f7a3a6df469f26eb033f2f59da36dcf56bb52ba7298b7dba05d9132c90f8ab5b58dd247a8f9c1b652b91138358fbae482654465550c74780a32fe04bf6e7e
-  languageName: node
-  linkType: hard
-
-"@backstage/core-components@npm:^0.14.10":
-  version: 0.14.10
-  resolution: "@backstage/core-components@npm:0.14.10"
-  dependencies:
-    "@backstage/config": "npm:^1.2.0"
-    "@backstage/core-plugin-api": "npm:^1.9.3"
-    "@backstage/errors": "npm:^1.2.4"
-    "@backstage/theme": "npm:^0.5.6"
-    "@backstage/version-bridge": "npm:^1.0.8"
-    "@date-io/core": "npm:^1.3.13"
-    "@material-table/core": "npm:^3.1.0"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@react-hookz/web": "npm:^24.0.0"
-    "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
-    "@types/react-sparklines": "npm:^1.7.0"
-    ansi-regex: "npm:^6.0.1"
-    classnames: "npm:^2.2.6"
-    d3-selection: "npm:^3.0.0"
-    d3-shape: "npm:^3.0.0"
-    d3-zoom: "npm:^3.0.0"
-    dagre: "npm:^0.8.5"
-    linkify-react: "npm:4.1.3"
-    linkifyjs: "npm:4.1.3"
-    lodash: "npm:^4.17.21"
-    pluralize: "npm:^8.0.0"
-    qs: "npm:^6.9.4"
-    rc-progress: "npm:3.5.1"
-    react-helmet: "npm:6.1.0"
-    react-hook-form: "npm:^7.12.2"
-    react-idle-timer: "npm:5.7.2"
-    react-markdown: "npm:^8.0.0"
-    react-sparklines: "npm:^1.7.0"
-    react-syntax-highlighter: "npm:^15.4.5"
-    react-use: "npm:^17.3.2"
-    react-virtualized-auto-sizer: "npm:^1.0.11"
-    react-window: "npm:^1.8.6"
-    remark-gfm: "npm:^3.0.1"
-    zen-observable: "npm:^0.10.0"
-    zod: "npm:^3.22.4"
-  peerDependencies:
-    react: ^16.13.1 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
-    react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 10/870f4c58e490c13b043f855c101f23e0155497a755677e84b9e6accf0f829343dc5f702de6382fdaf73a34f7540562f0842393feb7e83e498483256c3425da8c
   languageName: node
   linkType: hard
 
@@ -4397,6 +4451,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-app-api@npm:0.11.1-next.0":
+  version: 0.11.1-next.0
+  resolution: "@backstage/frontend-app-api@npm:0.11.1-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-app-api": "npm:1.16.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-defaults": "npm:0.2.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/3f022099cc9acb3af9c750a12aed26306f6213cb23a642f10a48af9ffae777ff2d336af5b9cc54636b51f9acca3505a87544c114dd65b725f2ad5ca86555ca3f
+  languageName: node
+  linkType: hard
+
 "@backstage/frontend-app-api@npm:^0.11.0":
   version: 0.11.0
   resolution: "@backstage/frontend-app-api@npm:0.11.0"
@@ -4423,6 +4503,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-defaults@npm:0.2.1-next.0":
+  version: 0.2.1-next.0
+  resolution: "@backstage/frontend-defaults@npm:0.2.1-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-app-api": "npm:0.11.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-app": "npm:0.1.8-next.0"
+    "@react-hookz/web": "npm:^24.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/008e6725b720f3d8f9d8a4b581515e326328e8c501df3d89467c65169a82bcb395861d8fe1fccb4befc734e9ab1bb5e34d40b16d36cae1135e28003660a607dd
+  languageName: node
+  linkType: hard
+
 "@backstage/frontend-defaults@npm:^0.2.0":
   version: 0.2.0
   resolution: "@backstage/frontend-defaults@npm:0.2.0"
@@ -4445,7 +4547,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:0.10.0, @backstage/frontend-plugin-api@npm:^0.10.0":
+"@backstage/frontend-plugin-api@npm:0.10.1-next.0":
+  version: 0.10.1-next.0
+  resolution: "@backstage/frontend-plugin-api@npm:0.10.1-next.0"
+  dependencies:
+    "@backstage/core-components": "npm:0.17.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.4"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.21.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/c4f9939dc833a0df21fac5549cd1d05070618fba1e430b4569b723c8cf2a4339d81802543f5314c0218ad7e6a6d1fab0a43d9a4643d4b90d67d40659c9d79b8e
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:^0.10.0":
   version: 0.10.0
   resolution: "@backstage/frontend-plugin-api@npm:0.10.0"
   dependencies:
@@ -4489,7 +4615,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-test-utils@npm:0.3.0, @backstage/frontend-test-utils@npm:^0.3.0":
+"@backstage/frontend-test-utils@npm:0.3.1-next.0":
+  version: 0.3.1-next.0
+  resolution: "@backstage/frontend-test-utils@npm:0.3.1-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/frontend-app-api": "npm:0.11.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-app": "npm:0.1.8-next.0"
+    "@backstage/test-utils": "npm:1.7.6"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/4dcfbb1147c51a5cf9a4bff8a9c59d3186abcdfece834bed12c9660ef9fe92f2548065348a3e90c39f281440ef542e18a6c8bed92d9f86295d40149d4d3a7913
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-test-utils@npm:^0.3.0":
   version: 0.3.0
   resolution: "@backstage/frontend-test-utils@npm:0.3.0"
   dependencies:
@@ -4529,7 +4680,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@npm:1.2.5, @backstage/integration-react@npm:^1.2.5":
+"@backstage/integration-react@npm:1.2.6-next.0, @backstage/integration-react@npm:^1.2.6-next.0":
+  version: 1.2.6-next.0
+  resolution: "@backstage/integration-react@npm:1.2.6-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/d042d7b5e5e8350202ae69bc9d259c5614c58779ac39ead4d02edd19eec0368afb1c1dc308668b8b5823a66d8a4e9c7dfc8d31298cce4f6880aee87cc5cc3827
+  languageName: node
+  linkType: hard
+
+"@backstage/integration-react@npm:^1.2.5":
   version: 1.2.5
   resolution: "@backstage/integration-react@npm:1.2.5"
   dependencies:
@@ -4550,7 +4722,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration@npm:1.16.2, @backstage/integration@npm:^1.13.0, @backstage/integration@npm:^1.15.0, @backstage/integration@npm:^1.16.2":
+"@backstage/integration@npm:1.16.3-next.0, @backstage/integration@npm:^1.16.3-next.0":
+  version: 1.16.3-next.0
+  resolution: "@backstage/integration@npm:1.16.3-next.0"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+  checksum: 10/af86bfe3068394f44ec7e512666d4857e78ab75d02d6de799dadc1a376f81bce93d7402f6c00c4ed6ac45687e2504c1e4f07fc19cc2506ad2b2bdbe70b4b99bb
+  languageName: node
+  linkType: hard
+
+"@backstage/integration@npm:^1.13.0, @backstage/integration@npm:^1.15.0, @backstage/integration@npm:^1.16.2":
   version: 1.16.2
   resolution: "@backstage/integration@npm:1.16.2"
   dependencies:
@@ -4568,19 +4758,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@npm:^0.12.6-next.0":
-  version: 0.12.6-next.0
-  resolution: "@backstage/plugin-api-docs@npm:0.12.6-next.0"
+"@backstage/plugin-api-docs@npm:^0.12.6-next.1":
+  version: 0.12.6-next.1
+  resolution: "@backstage/plugin-api-docs@npm:0.12.6-next.1"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/plugin-catalog": "npm:1.29.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-catalog": "npm:1.29.0-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.32"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -4600,7 +4790,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a0c7aaa5a6c5a0c837ba2f2e5c50dde56900dfe8b5c1d18c965f3c5426abf9bd8a77d438b48edbf8c026ec18a2dc52c0043dbcf772a9d79c63f733929c9700d4
+  checksum: 10/1914979958e7e3fce3f062389e5dc55dfe9b6e40825b979de7458a166057f89193fe34c10bcf9f756044651fad05fa3aaa08950f4d83b11d374838ea425f7d0f
   languageName: node
   linkType: hard
 
@@ -4638,6 +4828,33 @@ __metadata:
     express: "npm:^4.17.1"
     fs-extra: "npm:^11.2.0"
   checksum: 10/198fbf707f5e0707a47e949001bd59303fab4098a09fe1c3b366a883c4690fddf59300336bfd82d60a90c06ce0ec1e9f33cdcda14887ee70b8e2f8dd9435adfb
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-app@npm:0.1.8-next.0":
+  version: 0.1.8-next.0
+  resolution: "@backstage/plugin-app@npm:0.1.8-next.0"
+  dependencies:
+    "@backstage/core-components": "npm:0.17.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/integration-react": "npm:1.2.6-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.32"
+    "@backstage/theme": "npm:0.6.4"
+    "@backstage/types": "npm:1.2.1"
+    "@material-ui/core": "npm:^4.9.13"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/cf5a865107f1e725389b3e904b68e3a987bc8158cea841c1e391d5041c959d0daa0d876d849d11d5acb38714121cb63d0771f65a409a7b4e43646060a933f5d0
   languageName: node
   linkType: hard
 
@@ -4694,17 +4911,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.2-next.0":
-  version: 0.4.2-next.0
-  resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.2-next.0"
+"@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.2-next.1":
+  version: 0.4.2-next.1
+  resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.2-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-backend": "npm:0.24.5-next.0"
+    "@backstage/plugin-auth-backend": "npm:0.24.5-next.1"
     "@backstage/plugin-auth-node": "npm:0.6.1"
     jose: "npm:^5.0.0"
     node-cache: "npm:^5.1.2"
-  checksum: 10/258fbc424797af65a2754b1a2411bdc3c5f7400d474e5e6171b71ce49e6a4cf1e13b112862f14369b1c8a784344dd147c7775ee36f1fca4c7ae22d532d4bbdd9
+  checksum: 10/4291c790da05b675c512dc67355385a42985a43e86b1df1c70244a83457ed64bee1676c73012d0c9b1ec589e3d117ab13a811b26f2b3abceffc11d8b82195640
   languageName: node
   linkType: hard
 
@@ -4724,16 +4941,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.3.1":
-  version: 0.3.1
-  resolution: "@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.3.1"
+"@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.3.2-next.0":
+  version: 0.3.2-next.0
+  resolution: "@backstage/plugin-auth-backend-module-bitbucket-provider@npm:0.3.2-next.0"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.2.1"
-    "@backstage/plugin-auth-node": "npm:^0.6.1"
+    "@backstage/backend-plugin-api": "npm:1.2.1"
+    "@backstage/plugin-auth-node": "npm:0.6.1"
     express: "npm:^4.18.2"
     passport: "npm:^0.7.0"
     passport-bitbucket-oauth2: "npm:^0.1.2"
-  checksum: 10/2298316ddf74ed782d7f9201ae2ad5176d290e1bc369e56cfe8c966c0b0ebe056557a7e7e6d5b1f7dbc3c8b34f4315bbf17415c572b6e1d2c0ddf55d91ec5351
+  checksum: 10/d221be68c7613cb745fe3f85deb1ec1d27ce4708288953d3d5d8b28dd9376833e16b3f36fa19a2adb20d345ed08ee48ba7fbeeaa1677a30d41bde104b1cd85bd
   languageName: node
   linkType: hard
 
@@ -4862,19 +5079,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.2-next.0":
-  version: 0.4.2-next.0
-  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.2-next.0"
+"@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.2-next.1":
+  version: 0.4.2-next.1
+  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.2-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-auth-backend": "npm:0.24.5-next.0"
+    "@backstage/plugin-auth-backend": "npm:0.24.5-next.1"
     "@backstage/plugin-auth-node": "npm:0.6.1"
     "@backstage/types": "npm:1.2.1"
     express: "npm:^4.18.2"
     openid-client: "npm:^5.5.0"
     passport: "npm:^0.7.0"
-  checksum: 10/2603566175c58986bea0ec2ec8df5c0ad78807a28ef64d7c0832b888293690fa6ff3404d525b0af026c3f71935f3ac3da46c4f696dc899a23ce55886701314bc
+  checksum: 10/4fbb137ebec3a8a41bf9ad036d4ca2f137422f92234a83fb7b598bad91ea72133a0f946b583c2b814a65d6daf12ad042a207676ff348e9d0836e2c71bc9356c6
   languageName: node
   linkType: hard
 
@@ -4904,9 +5121,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@npm:0.24.5-next.0, @backstage/plugin-auth-backend@npm:^0.24.5-next.0":
-  version: 0.24.5-next.0
-  resolution: "@backstage/plugin-auth-backend@npm:0.24.5-next.0"
+"@backstage/plugin-auth-backend@npm:0.24.5-next.1, @backstage/plugin-auth-backend@npm:^0.24.5-next.1":
+  version: 0.24.5-next.1
+  resolution: "@backstage/plugin-auth-backend@npm:0.24.5-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
     "@backstage/backend-plugin-api": "npm:1.2.1"
@@ -4916,9 +5133,9 @@ __metadata:
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-auth-backend-module-atlassian-provider": "npm:0.4.1"
     "@backstage/plugin-auth-backend-module-auth0-provider": "npm:0.2.1"
-    "@backstage/plugin-auth-backend-module-aws-alb-provider": "npm:0.4.2-next.0"
+    "@backstage/plugin-auth-backend-module-aws-alb-provider": "npm:0.4.2-next.1"
     "@backstage/plugin-auth-backend-module-azure-easyauth-provider": "npm:0.2.6"
-    "@backstage/plugin-auth-backend-module-bitbucket-provider": "npm:0.3.1"
+    "@backstage/plugin-auth-backend-module-bitbucket-provider": "npm:0.3.2-next.0"
     "@backstage/plugin-auth-backend-module-bitbucket-server-provider": "npm:0.2.1"
     "@backstage/plugin-auth-backend-module-cloudflare-access-provider": "npm:0.4.1"
     "@backstage/plugin-auth-backend-module-gcp-iap-provider": "npm:0.4.1"
@@ -4928,7 +5145,7 @@ __metadata:
     "@backstage/plugin-auth-backend-module-microsoft-provider": "npm:0.3.1"
     "@backstage/plugin-auth-backend-module-oauth2-provider": "npm:0.4.1"
     "@backstage/plugin-auth-backend-module-oauth2-proxy-provider": "npm:0.2.6"
-    "@backstage/plugin-auth-backend-module-oidc-provider": "npm:0.4.2-next.0"
+    "@backstage/plugin-auth-backend-module-oidc-provider": "npm:0.4.2-next.1"
     "@backstage/plugin-auth-backend-module-okta-provider": "npm:0.2.1"
     "@backstage/plugin-auth-backend-module-onelogin-provider": "npm:0.3.1"
     "@backstage/plugin-auth-node": "npm:0.6.1"
@@ -4965,7 +5182,7 @@ __metadata:
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/5cf1fd0ae22630bae6d459472ede59012f45ddc1afc2a50ac5205ad4a5da5ad9b8e18981a1e1519f205b56888097783dd4e9da54a517403e7c2e111daddd9bb5
+  checksum: 10/898b3fd0163e7ec934afae5759a5965503c152e110f668c841aa1c7b4584048c4d06f962f749bb6f155204dbd6f61a618e09e92384131fa69fe05af07af6cc61
   languageName: node
   linkType: hard
 
@@ -5042,13 +5259,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-react@npm:0.1.13":
-  version: 0.1.13
-  resolution: "@backstage/plugin-auth-react@npm:0.1.13"
+"@backstage/plugin-auth-react@npm:0.1.14-next.0":
+  version: 0.1.14-next.0
+  resolution: "@backstage/plugin-auth-react@npm:0.1.14-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.17.0"
-    "@backstage/core-plugin-api": "npm:^1.10.5"
-    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/core-components": "npm:0.17.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/errors": "npm:1.2.7"
     "@material-ui/core": "npm:^4.9.13"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
@@ -5059,28 +5276,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d941d67c71932cbe7c084aa83a64b48a27f119b61bfbd501fb3fe44b796f48cdf9826fe37f9fe67415fe4d91949ad28cf20b40becc55893116f7c7a016726dbd
+  checksum: 10/eb6892cf8985f36a97426a892741a3ce1e531594e997829d7b4de5a476196ecdb870b63198fc7390162c25ea4defbda3bebf44760336d17b95b1082f27e5f61f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-bitbucket-cloud-common@npm:0.2.28":
-  version: 0.2.28
-  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.2.28"
+"@backstage/plugin-bitbucket-cloud-common@npm:0.2.29-next.0":
+  version: 0.2.29-next.0
+  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.2.29-next.0"
   dependencies:
-    "@backstage/integration": "npm:^1.16.2"
+    "@backstage/integration": "npm:1.16.3-next.0"
     cross-fetch: "npm:^4.0.0"
-  checksum: 10/65677c2c3df960e2b53f3f2ee7edd09b612878c3b28af4a9ff62eff3447e00677271d4b679f56dc00a99ee83ace164e5e07e19d7e4a83d28e9d29f6cc4f66d35
+  checksum: 10/56ea38fe9d396e7697ad8440bcc26bf51f5e91ad09a639ef4b449a818ebf44ce622fa36ff629b8584b10396107c8129d476718bbe9ec1a5e89729aa03d28d253
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@npm:^0.1.8":
-  version: 0.1.8
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.8"
+"@backstage/plugin-catalog-backend-module-logs@npm:^0.1.9-next.0":
+  version: 0.1.9-next.0
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.9-next.0"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.2.1"
-    "@backstage/plugin-catalog-backend": "npm:^1.32.0"
-    "@backstage/plugin-events-node": "npm:^0.4.9"
-  checksum: 10/fe95e25e59d8be538ffcdece124c3ad885b33560babf92a8b4bc10829295fbdb1ab65bb94d99b3e2f65fe1663c6eb7b1c6556e0ed85b8885c7dc2115ac8bd20c
+    "@backstage/backend-plugin-api": "npm:1.2.1"
+    "@backstage/plugin-catalog-backend": "npm:1.32.1-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.9"
+  checksum: 10/b9132fa209fb9fdc0cfe4c551c1f11998c1fca789087a5c3fed41da721fa3ef37dced48f07d7de52c72620c0a633aca398fa7e985a4ed4378e8ee7d4cd0cc25e
   languageName: node
   linkType: hard
 
@@ -5097,26 +5314,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@npm:^1.32.0":
-  version: 1.32.0
-  resolution: "@backstage/plugin-catalog-backend@npm:1.32.0"
+"@backstage/plugin-catalog-backend@npm:1.32.1-next.0, @backstage/plugin-catalog-backend@npm:^1.32.1-next.0":
+  version: 1.32.1-next.0
+  resolution: "@backstage/plugin-catalog-backend@npm:1.32.1-next.0"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-openapi-utils": "npm:^0.5.1"
-    "@backstage/backend-plugin-api": "npm:^1.2.1"
-    "@backstage/catalog-client": "npm:^1.9.1"
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/config": "npm:^1.3.2"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/integration": "npm:^1.16.2"
-    "@backstage/plugin-catalog-common": "npm:^1.1.3"
-    "@backstage/plugin-catalog-node": "npm:^1.16.1"
-    "@backstage/plugin-events-node": "npm:^0.4.9"
-    "@backstage/plugin-permission-common": "npm:^0.8.4"
-    "@backstage/plugin-permission-node": "npm:^0.9.0"
-    "@backstage/plugin-search-backend-module-catalog": "npm:^0.3.2"
-    "@backstage/plugin-search-common": "npm:^1.2.17"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/backend-openapi-utils": "npm:0.5.1"
+    "@backstage/backend-plugin-api": "npm:1.2.1"
+    "@backstage/catalog-client": "npm:1.9.1"
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.3"
+    "@backstage/plugin-catalog-node": "npm:1.16.1"
+    "@backstage/plugin-events-node": "npm:0.4.9"
+    "@backstage/plugin-permission-common": "npm:0.8.4"
+    "@backstage/plugin-permission-node": "npm:0.9.0"
+    "@backstage/plugin-search-backend-module-catalog": "npm:0.3.2"
+    "@backstage/plugin-search-common": "npm:1.2.17"
+    "@backstage/types": "npm:1.2.1"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/express": "npm:^4.17.6"
     codeowners-utils: "npm:^1.0.2"
@@ -5136,7 +5353,7 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/4acde1d7fc6c4940547f74fdd1332e0dcdcfb27f1799db135ac217be5cb467455eaa5efaf806e9ea51dc430d825b45c8cab53e9a61b056fc5c0a868a4ebfe17e
+  checksum: 10/ea2bfa09db0b5f435adcc71945b12b6804c21bf5df50c4dea692ce67384a6de232d8b9c18e0df98ea843e14b9870e9d7357c9289c53aba83ab256c4bce88db3b
   languageName: node
   linkType: hard
 
@@ -5151,17 +5368,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@npm:^0.4.18-next.0":
-  version: 0.4.18-next.0
-  resolution: "@backstage/plugin-catalog-graph@npm:0.4.18-next.0"
+"@backstage/plugin-catalog-graph@npm:^0.4.18-next.1":
+  version: 0.4.18-next.1
+  resolution: "@backstage/plugin-catalog-graph@npm:0.4.18-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5179,7 +5396,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6b59d33ab1ddd4e2c088d9bbeb67081b5c2737ee898a1ccb35eb4cf920d50a0d712a7584eb3f81c8f7701d4ad0d4ff8c18c139835c3a88e60ac1ff759aaec3f3
+  checksum: 10/9029d5ad780041256dda226c2664e46c92cecbc3ada5c66fb84acc575b89131881e9a85b60a34336c7099b7961ebe71cb8ddc1628b9a777198146eb1999edfbf
   languageName: node
   linkType: hard
 
@@ -5199,19 +5416,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@npm:1.16.1-next.0, @backstage/plugin-catalog-react@npm:^1.16.1-next.0":
-  version: 1.16.1-next.0
-  resolution: "@backstage/plugin-catalog-react@npm:1.16.1-next.0"
+"@backstage/plugin-catalog-react@npm:1.16.1-next.1, @backstage/plugin-catalog-react@npm:^1.16.1-next.1":
+  version: 1.16.1-next.1
+  resolution: "@backstage/plugin-catalog-react@npm:1.16.1-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/frontend-test-utils": "npm:0.3.0"
-    "@backstage/integration-react": "npm:1.2.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/frontend-test-utils": "npm:0.3.1-next.0"
+    "@backstage/integration-react": "npm:1.2.6-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
     "@backstage/plugin-permission-common": "npm:0.8.4"
     "@backstage/plugin-permission-react": "npm:0.4.32"
@@ -5236,7 +5453,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e6262ac90f0691cb48d43df140bdefa23e53de55288f07418e4e7bd6dc0b47f2db9947e1c861a73dd365b78d9e2c2a510b72e036a38cc3a8b71d192ac112b471
+  checksum: 10/0799c2082c4dc02890a5fe2ec350193a5656c6dd979ec6ddec7e13d0775c95c137d19ef391c338a2affef1a607906b56293b0c915c65f604ab7b19e549129795
   languageName: node
   linkType: hard
 
@@ -5281,24 +5498,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@npm:1.29.0-next.0, @backstage/plugin-catalog@npm:^1.29.0-next.0":
-  version: 1.29.0-next.0
-  resolution: "@backstage/plugin-catalog@npm:1.29.0-next.0"
+"@backstage/plugin-catalog@npm:1.29.0-next.1, @backstage/plugin-catalog@npm:^1.29.0-next.1":
+  version: 1.29.0-next.1
+  resolution: "@backstage/plugin-catalog@npm:1.29.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/integration-react": "npm:1.2.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/integration-react": "npm:1.2.6-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.32"
     "@backstage/plugin-scaffolder-common": "npm:1.5.10"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.7"
+    "@backstage/plugin-search-react": "npm:1.8.8-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5320,7 +5537,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b38565e03a2f81702e9dc0f076468ab6fa9facafa9a679675605fbefe96c839d323d66dd7fd5a9d3c97042219538ce6d68c1afe7c624d850678fed7963c35b75
+  checksum: 10/19ab9d22714014b46d15ea33eb41f7a3ca68b145fbd805aff1a3602454f194cdecc46d2e7f89858d82567d9261da68092ed04cdf380e31a7caf5bc6a8ebb396c
   languageName: node
   linkType: hard
 
@@ -5360,11 +5577,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@npm:0.1.25-next.0":
-  version: 0.1.25-next.0
-  resolution: "@backstage/plugin-home-react@npm:0.1.25-next.0"
+"@backstage/plugin-home-react@npm:0.1.25-next.1":
+  version: 0.1.25-next.1
+  resolution: "@backstage/plugin-home-react@npm:0.1.25-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5377,24 +5594,24 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ee9460175a6be8eb27f01b8c58f945c029cded3cc7544cfdbdb6477a3066903c627df426db5f249c919a73ec531f2b829a15f99ef7b9ba8addd89a12a24183a3
+  checksum: 10/e5de7c6f7496ba2c53a8f2ff798a37f6546e17dd165a0709a2afbc5892e474242655d497cc6d2a6667696719b675dea887584e90cff0f9ed5ea12eba5607e1a8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@npm:^0.8.7-next.0":
-  version: 0.8.7-next.0
-  resolution: "@backstage/plugin-home@npm:0.8.7-next.0"
+"@backstage/plugin-home@npm:^0.8.7-next.1":
+  version: 0.8.7-next.1
+  resolution: "@backstage/plugin-home@npm:0.8.7-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/core-app-api": "npm:1.16.0"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
-    "@backstage/plugin-home-react": "npm:0.1.25-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
+    "@backstage/plugin-home-react": "npm:0.1.25-next.1"
     "@backstage/theme": "npm:0.6.4"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5417,7 +5634,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/f95c3812b5741f31d62e832d4617f923d58b9e1c4ab2a096f8308635abb0ff574461e62105040479125620d21012bfa91d7443af11362e78071bdb7bafc43d5b
+  checksum: 10/a6d34dbfdeb3f5856d359c2db4cec19df47738cb7d60586b694ad66a34ece4df373f107ca11cbe89a5184f22a75c55e7d73caafc18ba3afcb38e038850cabdef
   languageName: node
   linkType: hard
 
@@ -5497,16 +5714,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-react@npm:0.5.5":
-  version: 0.5.5
-  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.5"
+"@backstage/plugin-kubernetes-react@npm:0.5.6-next.0":
+  version: 0.5.6-next.0
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.6-next.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/core-components": "npm:^0.17.0"
-    "@backstage/core-plugin-api": "npm:^1.10.5"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-kubernetes-common": "npm:^0.9.4"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/core-components": "npm:0.17.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.4"
+    "@backstage/types": "npm:1.2.1"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
     "@kubernetes/client-node": "npm:1.0.0-rc7"
@@ -5530,22 +5747,22 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ca7404149063af67533f0a2b2a2b0063efb065b9362e73248aeeddad8f7c88824d19dc26ffb75c2b767d063cd667b04de596f0fb672c47366c1973a68332ca66
+  checksum: 10/a69a8403e185d890ce0a26fac4195a74d3d38bf9975c8cdc78f3b1e4accd8f895f56b56d095ae32562dad87bbd286656fa55868cc79f0778f9145800df0237e2
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@npm:^0.12.6-next.0":
-  version: 0.12.6-next.0
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.6-next.0"
+"@backstage/plugin-kubernetes@npm:^0.12.6-next.1":
+  version: 0.12.6-next.1
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.6-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/plugin-kubernetes-common": "npm:0.9.4"
-    "@backstage/plugin-kubernetes-react": "npm:0.5.5"
+    "@backstage/plugin-kubernetes-react": "npm:0.5.6-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.32"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
@@ -5567,32 +5784,34 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7f9581618c97635159a0084516eb38480bf1c55ee1ee11b36d37b3430e25b864ef3d62630c47d1a4f9eaa564bd9e37a8d4d536a9b2b02a8475a3d88fd8c54095
+  checksum: 10/d9ae0ce9db8d513a9c09b1d5c1872b7e864eccaa87d84b46f380e55f50f1e557c01f70845012660c0da2bfcd41b84807b7f513334aaa4a3ad7e89718216b5895
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@npm:^0.5.4":
-  version: 0.5.4
-  resolution: "@backstage/plugin-notifications-backend@npm:0.5.4"
+"@backstage/plugin-notifications-backend@npm:^0.5.5-next.0":
+  version: 0.5.5-next.0
+  resolution: "@backstage/plugin-notifications-backend@npm:0.5.5-next.0"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.2.1"
-    "@backstage/catalog-client": "npm:^1.9.1"
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/config": "npm:^1.3.2"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-auth-node": "npm:^0.6.1"
-    "@backstage/plugin-catalog-node": "npm:^1.16.1"
-    "@backstage/plugin-events-node": "npm:^0.4.9"
-    "@backstage/plugin-notifications-common": "npm:^0.0.8"
-    "@backstage/plugin-notifications-node": "npm:^0.2.13"
-    "@backstage/plugin-signals-node": "npm:^0.1.18"
+    "@backstage/backend-plugin-api": "npm:1.2.1"
+    "@backstage/catalog-client": "npm:1.9.1"
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/plugin-auth-node": "npm:0.6.1"
+    "@backstage/plugin-catalog-node": "npm:1.16.1"
+    "@backstage/plugin-events-node": "npm:0.4.9"
+    "@backstage/plugin-notifications-common": "npm:0.0.8"
+    "@backstage/plugin-notifications-node": "npm:0.2.13"
+    "@backstage/plugin-signals-node": "npm:0.1.18"
+    "@backstage/types": "npm:1.2.1"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
+    p-throttle: "npm:^4.1.1"
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/e18693a6e5a04f6dbc41b640431276c6f5d3a0ea05025592295ebf7567c43e719b593b6aefde74f4f1ab89c695dff5ed6f2fea30791d4428f848db3bfad39165
+  checksum: 10/437785b18477df2b4f2d035ecea062874a61d390e99caa232ba887e2ba2c5adbfc8f1358a4b896bf94b069e086df7cd496cc743bf2d70179b33813778d2ddad5
   languageName: node
   linkType: hard
 
@@ -5621,15 +5840,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@npm:^0.5.4-next.0":
-  version: 0.5.4-next.0
-  resolution: "@backstage/plugin-notifications@npm:0.5.4-next.0"
+"@backstage/plugin-notifications@npm:^0.5.4-next.1":
+  version: 0.5.4-next.1
+  resolution: "@backstage/plugin-notifications@npm:0.5.4-next.1"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
     "@backstage/plugin-signals-react": "npm:0.0.11"
     "@backstage/theme": "npm:0.6.4"
@@ -5650,21 +5869,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4297bb5eb5d283ca84f925e62c466eef05bf12820c4e7af3dc724203a4afb670c1af26dc76bd18074f277ad79ac927e5292fc6ba3b97086da55df060e225a429
+  checksum: 10/6406cf9d9e46f95a3075a6223458610387c71dfcc605ed79d3452ed1dc16139e8dbdb3464f62fc63d0ee3c3ff69a7407be73d235050052d66cfe10fdf48fbc0e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@npm:^0.6.38-next.0":
-  version: 0.6.38-next.0
-  resolution: "@backstage/plugin-org@npm:0.6.38-next.0"
+"@backstage/plugin-org@npm:^0.6.38-next.1":
+  version: 0.6.38-next.1
+  resolution: "@backstage/plugin-org@npm:0.6.38-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5681,7 +5900,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/13893335c293041962bf9743aa344f2e69667c314746a36fd57f1ddf0e6c0e6a0b0bf1c9a3c76bbe6eb5f30632611ccea3cfaae6c826c1d95d7619570517f879
+  checksum: 10/208adf1c06a6002ce0c9338bfcd26e0f0aace25c80c75b04fd47078c4eb1c22bc7bd5686bf0f0a285b6642fbaa2168d4fdafa54c65455ff9f6662f1ca0a91b6b
   languageName: node
   linkType: hard
 
@@ -5761,180 +5980,180 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.8-next.0":
-  version: 0.2.8-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.8-next.0"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.8-next.1":
+  version: 0.2.8-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.8-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     azure-devops-node-api: "npm:^14.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/3942b3d3a614911042e1584e9383935e1bf6622ef009947f8920f0fd8448f61cbd0bab6b9690741f46b8bf9228bbed72ccff485b1aadde7f7553962e65644ff7
+  checksum: 10/ef9dc65d91180f3cb2c7f29da3d57445922b09975eed0680ad92b58e11b0fd058b8be355a92fe299af04e0d1ea9ea97d90e0bba1b7102e68ea3bfae5f4b9de84
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.8-next.0":
-  version: 0.2.8-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.8-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.8-next.1":
+  version: 0.2.8-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.8-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.28"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.29-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     bitbucket: "npm:^2.12.0"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/d67f166d17aa96c0ff0063efe57c2a3a860abbccb315864a526f57e02e6b98ccd3f320d0c769e7e172b74c109f1314e8460d8135f5026e1974bd7b641e03e56c
+  checksum: 10/fa2b2f4842313d400e834d371ea8b21ee5b19b73b3eda43583b0d263d9067e6bc7a704eedc6f458ba23b9c1ef158126344ec750eff07b63acf1229855e15836e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.8-next.0":
-  version: 0.2.8-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.8-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.8-next.1":
+  version: 0.2.8-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.8-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/413fb02901eef74e9db12216911fc84e2e9a63def8627ec475326d0238168bd475e468e4fbf81668aab77aad7e9108bf94804168070317a0d32841331453fa6d
+  checksum: 10/ae4943f44ccd46f7d4810cf80df881decae60f3d8e068bfedfcd7c8874c9ca80708ec0ea8286a02b91ecff864ae9e9644d54c251b88c68cfb7a80f248dcc2818
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.9-next.0":
-  version: 0.3.9-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.9-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.9-next.1":
+  version: 0.3.9-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.9-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.8-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.8-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.8-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.8-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/9c8f3c063fa9e136feecc288f235e5a4f687a3b8c646f7e890fec7c34e8bb052d62fa00172e0fa2b312c2f212e9a993241b7965c4ca69c01bfdcbfd5b9750e7b
+  checksum: 10/b6402c0865d8d02d1284a3bfa9ac93fc51277ade196ebb204a02caac45a3d9e05bef84424b91dab5cd0f83e2dd6f2e907e47fa3dac7660561136495c05c53dbd
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.8-next.0":
-  version: 0.2.8-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.8-next.0"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.8-next.1":
+  version: 0.2.8-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.8-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/b10495144216d7a3d19f6bbf6d1986c166e46aeab8eb870f8eee79cf53c8e72d81d5ab434ce14136abe09d399b781f250d6ce58b4a7e443f4dc1496b08b752f0
+  checksum: 10/4667b1cf0153a77d43c74a00771eaf5f12b24e3e61aa106cd39f4721aab8dc65d212d86a35c5c5f6a9203015e3ad59f085f823723fa68ceea1a4d39b3c8d7f6f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.8-next.0":
-  version: 0.2.8-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.8-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.8-next.1":
+  version: 0.2.8-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.8-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/081bb109f0a5a6f1947f2ee557e001aa3e0cd52d4993c1c39507d1ef27d4a4f1546cbe213f613ba04b4ce6f861f87cbf43592766f30dd7ae89b9268ff08b1b81
+  checksum: 10/0c55acce18847e54df8cf2e8607c79f23909e3337e84cfc2342b7f6f54328d13c76cdfcb09519cb22b9ce0773da8a242e0c91c58e473bb23648c20442dc379bf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@npm:0.6.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.6.2-next.0":
-  version: 0.6.2-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.6.2-next.0"
+"@backstage/plugin-scaffolder-backend-module-github@npm:0.6.2-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.6.2-next.1":
+  version: 0.6.2-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.6.2-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     "@backstage/types": "npm:1.2.1"
     "@octokit/webhooks": "npm:^10.9.2"
     libsodium-wrappers: "npm:^0.7.11"
     octokit: "npm:^3.0.0"
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/086e13b4bdcec176f2cbff8d4d61e86d567c4b96ad0c4ef179fcf3c9fd8d03ca7bc0c63612e528dfe1e9a8a0e4831450f01f47a531ef56fc2742956dec51a7d6
+  checksum: 10/0cc1c4b16055575d1555b3b1afb8cd3643e75143ece6a2bb951f5cf403e00bc386badabea738ad78e42d3c1cb97b932bf30bed56f9706d44c111060d337b87b6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.8.2-next.0":
-  version: 0.8.2-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.8.2-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.8.2-next.1":
+  version: 0.8.2-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.8.2-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     winston: "npm:^3.2.1"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/2b627c7370f32935b2ab9c253ec0e7fb28a7cd1eec9cdc605aff413a00df22636e4e20538e9ee4aa55a7ae8a358342b7a98b4c05b51be6443ab9ad1094fd5231
+  checksum: 10/1398a77541989cf5236c0d262bc0a2e248242a421906cfc25f4111356770dd9303ec7c6ec8959c349789c4e16e3809a369d8f82f4211e86897e65ea5dd88cbcf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.9-next.0":
-  version: 0.1.9-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.9-next.0"
+"@backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.9-next.1":
+  version: 0.1.9-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.9-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
     "@backstage/plugin-notifications-node": "npm:0.2.13"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     octokit: "npm:^3.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/3180aa55f08aa01e27c20c17352bc55710a4d4aea69cbbc06367a88fecb9ba636f3d9175a406185cd80baa9c8315017afd86176e836370de279d2b4f6c1d51bd
+  checksum: 10/d06c5982adc3fb47a9634802707919942131e758ad63812ad0ce573a1f8214e5cc5de7c1ca101d6d3f600d51ef6f0ed8c9167a2b3d88f844db4b22aedd5770c1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@npm:^1.32.0-next.0":
-  version: 1.32.0-next.0
-  resolution: "@backstage/plugin-scaffolder-backend@npm:1.32.0-next.0"
+"@backstage/plugin-scaffolder-backend@npm:^1.32.0-next.1":
+  version: 1.32.0-next.1
+  resolution: "@backstage/plugin-scaffolder-backend@npm:1.32.0-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-defaults": "npm:0.9.0-next.0"
+    "@backstage/backend-defaults": "npm:0.9.0-next.1"
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
+    "@backstage/integration": "npm:1.16.3-next.0"
     "@backstage/plugin-auth-node": "npm:0.6.1"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.28"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.29-next.0"
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.6"
     "@backstage/plugin-catalog-node": "npm:1.16.1"
     "@backstage/plugin-events-node": "npm:0.4.9"
     "@backstage/plugin-permission-common": "npm:0.8.4"
     "@backstage/plugin-permission-node": "npm:0.9.0"
-    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.8-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.9-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.8-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.8-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.8-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.8-next.0"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.6.2-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.8.2-next.0"
+    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.8-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.9-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.8-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.8-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.8-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.8-next.1"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.6.2-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.8.2-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.5.10"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
     "@backstage/types": "npm:1.2.1"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/express": "npm:^4.17.6"
@@ -5964,7 +6183,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/c05082303a09f57fa082bfbe291202a02ab063c2335c0b62d2a7a436c90b657156bcaed2a1090f7926dc5a59a019b62330741d97bae22c986573afd37d12c47e
+  checksum: 10/f73216aea6e30149c6965fb386574321e6c6b55aa9caf3f764f0e720b22c8f52c4aae751f4f4a248b10f3bcdf5ed8bc3dfd84429a29874e4a3ab086ce30c8989
   languageName: node
   linkType: hard
 
@@ -5979,14 +6198,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:0.8.1-next.0":
-  version: 0.8.1-next.0
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.8.1-next.0"
+"@backstage/plugin-scaffolder-node@npm:0.8.1-next.1":
+  version: 0.8.1-next.1
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.8.1-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
+    "@backstage/integration": "npm:1.16.3-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.5.10"
     "@backstage/types": "npm:1.2.1"
     "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
@@ -6001,20 +6220,20 @@ __metadata:
     winston-transport: "npm:^4.7.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/e79e215f4a4aa1f74a06c7a499ea67f381a24849c35280636cd68e7703b3540b3acec1f7b9f7c87e1998e5d4fc5c2057d347c38507faef6bea6ae8465373672e
+  checksum: 10/7b0232bf1f1e404ed3c84563cc6b9919517a2d66544149048671f91be49a7a5aa1fd575dbf0536f69be8a985d7d3b18873d2108778107a428c03965f9fea05a3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.15.0-next.0":
-  version: 1.15.0-next.0
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.15.0-next.0"
+"@backstage/plugin-scaffolder-react@npm:1.15.0-next.1":
+  version: 1.15.0-next.1
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.15.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.32"
     "@backstage/plugin-scaffolder-common": "npm:1.5.10"
     "@backstage/theme": "npm:0.6.4"
@@ -6053,28 +6272,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0d99ec3c9cf59d25188fb9a15ec7bdd86cbc065e0536265ac10ce60e5404141e0d05f5dbd293937b515578f31fb141862ca807d976df482015dd7e688dcc126e
+  checksum: 10/f1aa10dfd1f5f7e3e9aed7b2b4810ac9d8a2ee60afbaa2a3cd77b3da9b49a0d2324bf2b802c7e273cc8bc3c74de65d231ce173ed5c4e440045148d12d5a39efe
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@npm:^1.30.0-next.0":
-  version: 1.30.0-next.0
-  resolution: "@backstage/plugin-scaffolder@npm:1.30.0-next.0"
+"@backstage/plugin-scaffolder@npm:^1.30.0-next.1":
+  version: 1.30.0-next.1
+  resolution: "@backstage/plugin-scaffolder@npm:1.30.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/integration-react": "npm:1.2.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/integration-react": "npm:1.2.6-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.32"
     "@backstage/plugin-scaffolder-common": "npm:1.5.10"
-    "@backstage/plugin-scaffolder-react": "npm:1.15.0-next.0"
+    "@backstage/plugin-scaffolder-react": "npm:1.15.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
@@ -6114,11 +6333,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/f41c1b2904a9d20c1915f655e470167fc08c2131b14fbb1eb68fadf390916c88d0237e4ce52bf3dbe918c2a4e75e9d96729298c8a42cad128ee4b2274f93f43e
+  checksum: 10/5c7e866b4517e81bdb68e633bb7dfbaf8df68521f6636293410b5dec224e73c4b6f5b6d68cd627660331518354f0ce28af4797eaac2e7eaaf54ea10b34dca544
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@npm:^0.3.2":
+"@backstage/plugin-search-backend-module-catalog@npm:0.3.2, @backstage/plugin-search-backend-module-catalog@npm:^0.3.2":
   version: 0.3.2
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.2"
   dependencies:
@@ -6149,9 +6368,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-techdocs@npm:0.4.1-next.0":
-  version: 0.4.1-next.0
-  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.4.1-next.0"
+"@backstage/plugin-search-backend-module-techdocs@npm:0.4.1-next.1":
+  version: 0.4.1-next.1
+  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.4.1-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-client": "npm:1.9.1"
@@ -6162,10 +6381,10 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:0.8.4"
     "@backstage/plugin-search-backend-node": "npm:1.3.9"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-techdocs-node": "npm:1.13.2-next.0"
+    "@backstage/plugin-techdocs-node": "npm:1.13.2-next.1"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/b87046de9589e315ed40743c9640a57f93204f91136987032ccce512188508b4734233dccb05835852486b4d86f5cb47c4b114a1c702d694bc1d0bfb3955e328
+  checksum: 10/70473907f77cb9b015cf0a785290a1b66204488cce2054e8f98ea9086582a69303205bcaee3b1485f264737c119a465def0952efbd0734b8ee7b11f47f2540e3
   languageName: node
   linkType: hard
 
@@ -6187,11 +6406,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@npm:^2.0.1-next.0":
-  version: 2.0.1-next.0
-  resolution: "@backstage/plugin-search-backend@npm:2.0.1-next.0"
+"@backstage/plugin-search-backend@npm:^2.0.1-next.1":
+  version: 2.0.1-next.1
+  resolution: "@backstage/plugin-search-backend@npm:2.0.1-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.9.0-next.0"
+    "@backstage/backend-defaults": "npm:0.9.0-next.1"
     "@backstage/backend-openapi-utils": "npm:0.5.1"
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
@@ -6207,7 +6426,7 @@ __metadata:
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/1951c743fde0e8472a63481f2238768fcb2fea1afd7c3ec279f44372438ea5b8dfd3c4dd81954a1a18fc1633e336716ba8bffbf24cc99ceafb9af8dc8ea668d5
+  checksum: 10/ac3a4f9c21f827c80597f073f2078fdea087a5e22c6c93f8eeec0e5b554e1899afaa900cd7cad9ad10a97425a0c4c1887ac451f63d313956784d52301791478b
   languageName: node
   linkType: hard
 
@@ -6221,7 +6440,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@npm:1.8.7, @backstage/plugin-search-react@npm:^1.8.7":
+"@backstage/plugin-search-react@npm:1.8.8-next.0, @backstage/plugin-search-react@npm:^1.8.8-next.0":
+  version: 1.8.8-next.0
+  resolution: "@backstage/plugin-search-react@npm:1.8.8-next.0"
+  dependencies:
+    "@backstage/core-components": "npm:0.17.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.17"
+    "@backstage/theme": "npm:0.6.4"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    lodash: "npm:^4.17.21"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.3.2"
+    uuid: "npm:^11.0.2"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/695cf26e28f902a1bafa715e3a8f47778bd33c94a1955ed145f425fa40947545c3378a16739e64f450542d91db075dd463103b60c46562db4deafc7cad45e5ac
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-react@npm:^1.8.7":
   version: 1.8.7
   resolution: "@backstage/plugin-search-react@npm:1.8.7"
   dependencies:
@@ -6251,18 +6500,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@npm:^1.4.25-next.0":
-  version: 1.4.25-next.0
-  resolution: "@backstage/plugin-search@npm:1.4.25-next.0"
+"@backstage/plugin-search@npm:^1.4.25-next.1":
+  version: 1.4.25-next.1
+  resolution: "@backstage/plugin-search@npm:1.4.25-next.1"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.7"
+    "@backstage/plugin-search-react": "npm:1.8.8-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -6277,7 +6526,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/cc968751b90758562b6b95f9db17adc613dee11f30b936a4146d868b25f800fac6a87ce48b0134dc37bc497d3bf8dacc91e57e866f036b0ea729d9d44be02d28
+  checksum: 10/56e0e3fce213f15ae15bddabddb206fd55d83da8b1d2ff6c3d2d22e660fe18a265d6bcc0a4de1dc7cba17079dc2cd3b9f4ee8ac35d564baa2d1e7250178b0797
   languageName: node
   linkType: hard
 
@@ -6302,7 +6551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-node@npm:^0.1.18":
+"@backstage/plugin-signals-node@npm:0.1.18, @backstage/plugin-signals-node@npm:^0.1.18":
   version: 0.1.18
   resolution: "@backstage/plugin-signals-node@npm:0.1.18"
   dependencies:
@@ -6318,7 +6567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-react@npm:0.0.11, @backstage/plugin-signals-react@npm:^0.0.11":
+"@backstage/plugin-signals-react@npm:0.0.11":
   version: 0.0.11
   resolution: "@backstage/plugin-signals-react@npm:0.0.11"
   dependencies:
@@ -6337,16 +6586,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@npm:^0.0.17":
-  version: 0.0.17
-  resolution: "@backstage/plugin-signals@npm:0.0.17"
+"@backstage/plugin-signals@npm:^0.0.18-next.0":
+  version: 0.0.18-next.0
+  resolution: "@backstage/plugin-signals@npm:0.0.18-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.17.0"
-    "@backstage/core-plugin-api": "npm:^1.10.5"
-    "@backstage/frontend-plugin-api": "npm:^0.10.0"
-    "@backstage/plugin-signals-react": "npm:^0.0.11"
-    "@backstage/theme": "npm:^0.6.4"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-signals-react": "npm:0.0.11"
+    "@backstage/theme": "npm:0.6.4"
+    "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
@@ -6360,27 +6609,27 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d1cd26c21aaf2bfbd5b899cf115ceeb22e5dcf248edcda9ed6b1fc91d1f898d4b7fee12f1020ac90eebae3d2f81446b0687fd283c5d7180c92288fd76309308b
+  checksum: 10/546480204050d268872613b5804c1c916112c3c3ef663edbdc054caa7585781967137f22bb7d5f85fa4ce925375eaada0489bf954a134e816b88e121256c29aa
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@npm:^2.0.1-next.0":
-  version: 2.0.1-next.0
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.1-next.0"
+"@backstage/plugin-techdocs-backend@npm:^2.0.1-next.1":
+  version: 2.0.1-next.1
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.1-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.9.0-next.0"
+    "@backstage/backend-defaults": "npm:0.9.0-next.1"
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
+    "@backstage/integration": "npm:1.16.3-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
     "@backstage/plugin-catalog-node": "npm:1.16.1"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-search-backend-module-techdocs": "npm:0.4.1-next.0"
+    "@backstage/plugin-search-backend-module-techdocs": "npm:0.4.1-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-node": "npm:1.13.2-next.0"
+    "@backstage/plugin-techdocs-node": "npm:1.13.2-next.1"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
@@ -6388,7 +6637,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/5a0eb0c4507f1ddf80031d1da34acd0e1a28419108cfa260b76119e3815a45b185e9f14084268d2991397d00451c2f7468953e8b5812374baff8fd74a8f715b7
+  checksum: 10/704043eeaba0196d4dbf29deeda483840b6b8c1d57678f546ae308c0fda8c921b1274383ce224a0a380c7c7da04b2bba848d6c34e44f52a16fca2b386e57068a
   languageName: node
   linkType: hard
 
@@ -6399,16 +6648,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.22":
-  version: 1.1.22
-  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.22"
+"@backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.23-next.0":
+  version: 1.1.23-next.0
+  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.23-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.17.0"
-    "@backstage/core-plugin-api": "npm:^1.10.5"
-    "@backstage/frontend-plugin-api": "npm:^0.10.0"
-    "@backstage/integration": "npm:^1.16.2"
-    "@backstage/integration-react": "npm:^1.2.5"
-    "@backstage/plugin-techdocs-react": "npm:^1.2.15"
+    "@backstage/core-components": "npm:0.17.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/integration-react": "npm:1.2.6-next.0"
+    "@backstage/plugin-techdocs-react": "npm:1.2.16-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@react-hookz/web": "npm:^24.0.0"
@@ -6422,13 +6671,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c589d8e3b1a657ab247c94e3aaa323de4023aa436e3cc31d5f4d5ab843c18f91932f421fadfe95fd3107a4e4154d1b0bb0861bcd6a19074bde7e984f38cc9568
+  checksum: 10/c5c1c06ffbb7440edaf6c0b3810eaa846003a30810f41f8206ff5254b4ab26c66d515abe4901755d8d8884822dce583a0fa8c3e5b94d592cf47f946427f16fb7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@npm:1.13.2-next.0, @backstage/plugin-techdocs-node@npm:^1.13.2-next.0":
-  version: 1.13.2-next.0
-  resolution: "@backstage/plugin-techdocs-node@npm:1.13.2-next.0"
+"@backstage/plugin-techdocs-node@npm:1.13.2-next.1, @backstage/plugin-techdocs-node@npm:^1.13.2-next.1":
+  version: 1.13.2-next.1
+  resolution: "@backstage/plugin-techdocs-node@npm:1.13.2-next.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -6440,7 +6689,7 @@ __metadata:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.2"
+    "@backstage/integration": "npm:1.16.3-next.0"
     "@backstage/integration-aws-node": "npm:0.1.15"
     "@backstage/plugin-search-common": "npm:1.2.17"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
@@ -6459,11 +6708,39 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/72cb657e9b38f4316180caf9a1719a270837d75bcc93747c320464ff18b8dc1d2966a59413d5fa11e3ed7faadef130c49ca8f0ea262309b4080c729fa996b8d6
+  checksum: 10/497ad79ac0599c82ff4e7a9e3f69db7aa688d178408153ef310ab61e7d1b3e3fd7df5071770afc92b073d93be75a372cd4182d553e3f3fbfd667ba90086123b2
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@npm:1.2.15, @backstage/plugin-techdocs-react@npm:^1.2.15":
+"@backstage/plugin-techdocs-react@npm:1.2.16-next.0, @backstage/plugin-techdocs-react@npm:^1.2.16-next.0":
+  version: 1.2.16-next.0
+  resolution: "@backstage/plugin-techdocs-react@npm:1.2.16-next.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-components": "npm:0.17.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/styles": "npm:^4.11.0"
+    jss: "npm:~10.10.0"
+    lodash: "npm:^4.17.21"
+    react-helmet: "npm:6.1.0"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/2e31637361facf6f8805cbce307cf7d73f55f60ebd8733e9bbc7f9ce86a35753a41018f5640961d46d27b485dec9d2ab07045cabca9c2c39c81a48ef951fcea8
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs-react@npm:^1.2.15":
   version: 1.2.15
   resolution: "@backstage/plugin-techdocs-react@npm:1.2.15"
   dependencies:
@@ -6491,26 +6768,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@npm:^1.12.5-next.0":
-  version: 1.12.5-next.0
-  resolution: "@backstage/plugin-techdocs@npm:1.12.5-next.0"
+"@backstage/plugin-techdocs@npm:^1.12.5-next.1":
+  version: 1.12.5-next.1
+  resolution: "@backstage/plugin-techdocs@npm:1.12.5-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/integration": "npm:1.16.2"
-    "@backstage/integration-react": "npm:1.2.5"
-    "@backstage/plugin-auth-react": "npm:0.1.13"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/integration": "npm:1.16.3-next.0"
+    "@backstage/integration-react": "npm:1.2.6-next.0"
+    "@backstage/plugin-auth-react": "npm:0.1.14-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.7"
+    "@backstage/plugin-search-react": "npm:1.8.8-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-react": "npm:1.2.15"
+    "@backstage/plugin-techdocs-react": "npm:1.2.16-next.0"
     "@backstage/theme": "npm:0.6.4"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6531,7 +6808,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/76ef9059ebce52202e33ce7c4dfe61baf641f0e23fe2afd8422bc14053de77b348bc9ca26bd3aeeceda0190874f8b0b25ba1160a5ebb8daf1f7b10763dba5961
+  checksum: 10/cdd75beaa8c07df50e759d92af0362e4be5bdb6747b9a014f57f59a4be8265b53959980a3a12d14035cd071c2c440cd52604d7d93ff84482fa26fe7ee578b27e
   languageName: node
   linkType: hard
 
@@ -6542,18 +6819,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@npm:^0.8.21-next.0":
-  version: 0.8.21-next.0
-  resolution: "@backstage/plugin-user-settings@npm:0.8.21-next.0"
+"@backstage/plugin-user-settings@npm:^0.8.21-next.1":
+  version: 0.8.21-next.1
+  resolution: "@backstage/plugin-user-settings@npm:0.8.21-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/core-app-api": "npm:1.16.0"
-    "@backstage/core-compat-api": "npm:0.4.1-next.0"
-    "@backstage/core-components": "npm:0.17.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.1"
+    "@backstage/core-components": "npm:0.17.1-next.0"
     "@backstage/core-plugin-api": "npm:1.10.5"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.11"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
     "@backstage/theme": "npm:0.6.4"
@@ -6571,7 +6848,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6199aefec2d563f7f19c3f5e2a1b839597001bbe1b28c66fec9f64413de4952a9defaf25eae87728196627c0302bb539bc0af5bd835ea08902808e205cc30a83
+  checksum: 10/2910cfdcf52ba8beeb295d2054a287c666c7000f20a23764bec34e4dad6c4a27586ef167c98025f885c42ae1f0c838c117d5fa21bd7038b998fe778bfc4763c8
   languageName: node
   linkType: hard
 
@@ -6582,7 +6859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/test-utils@npm:^1.7.6":
+"@backstage/test-utils@npm:1.7.6, @backstage/test-utils@npm:^1.7.6":
   version: 1.7.6
   resolution: "@backstage/test-utils@npm:1.7.6"
   dependencies:


### PR DESCRIPTION
Backstage release v1.38.0-next.1 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.38.0-next.1](https://github.com/backstage/backstage/blob/master/docs/releases/v1.38.0-next.1-changelog.md)
- Upgrade Helper: [From 1.38.0-next.0 to 1.38.0-next.1](https://backstage.github.io/upgrade-helper/?from=1.38.0-next.0&to=1.38.0-next.1)
 
Created by [Version Bump 14216956935](https://github.com/backstage/demo/actions/runs/14216956935)
 