### PR TITLE
v1.38.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 254c816a15098e2a0b414345caf9144409fbf6a63da7ec8ec8d3454aa1d2edfbbc32cd264d8c464b7ec4aca7809c690848a7c1191b5f8167dec81dbdf6107b01
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.38.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.38.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.38.0-next.1"
+  "version": "1.38.0-next.2"
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
     "node": "20 || 22"
   },
   "scripts": {
-    "dev": "yarn workspaces foreach -A --include backend --include app --parallel --jobs unlimited -v -i run start",
-    "start": "yarn workspace app start",
-    "start-backend": "yarn workspace backend start",
+    "start": "backstage-cli repo start",
     "build:backend": "yarn workspace backend build",
     "build:all": "backstage-cli repo build --all",
     "build-image": "yarn workspace backend build-image",

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import App from './App';
 import { v4 } from 'uuid';

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -31,7 +31,7 @@ import { UnifiedThemeProvider, themes } from '@backstage/theme';
 
 import { ApiExplorerPage } from '@backstage/plugin-api-docs';
 import { GraphiQLPage } from '@backstage-community/plugin-graphiql';
-import React from 'react';
+
 import { Root } from './components/Root';
 import { SearchPage } from '@backstage/plugin-search';
 import { TechRadarPage } from '@backstage-community/plugin-tech-radar';

--- a/packages/app/src/components/Root/ApertureLogoFull.tsx
+++ b/packages/app/src/components/Root/ApertureLogoFull.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles({

--- a/packages/app/src/components/Root/ApertureLogoIcon.tsx
+++ b/packages/app/src/components/Root/ApertureLogoIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles({

--- a/packages/app/src/components/Root/LogoFull.tsx
+++ b/packages/app/src/components/Root/LogoFull.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles({

--- a/packages/app/src/components/Root/LogoIcon.tsx
+++ b/packages/app/src/components/Root/LogoIcon.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import React from 'react';
 import { makeStyles } from '@material-ui/core';
 
 const useStyles = makeStyles({

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 import { Link, Theme, makeStyles } from '@material-ui/core';
 import HomeIcon from '@material-ui/icons/Home';
 import ExtensionIcon from '@material-ui/icons/Extension';

--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Button, Grid } from '@material-ui/core';
 import BadgeIcon from '@material-ui/icons/CallToAction';
 import {

--- a/packages/app/src/components/home/CustomizableHomePage.tsx
+++ b/packages/app/src/components/home/CustomizableHomePage.tsx
@@ -11,7 +11,7 @@ import {
 } from '@backstage/plugin-home';
 import { HomePageSearchBar } from '@backstage/plugin-search';
 import { Grid } from '@material-ui/core';
-import React from 'react';
+
 import { tools, useLogoStyles } from './shared';
 
 const defaultConfig = [

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -10,7 +10,7 @@ import {
 import { HomePageSearchBar } from '@backstage/plugin-search';
 import { SearchContextProvider } from '@backstage/plugin-search-react';
 import { Grid, makeStyles } from '@material-ui/core';
-import React from 'react';
+
 import { tools, useLogoStyles } from './shared';
 
 const useStyles = makeStyles(theme => ({

--- a/packages/app/src/components/home/shared.tsx
+++ b/packages/app/src/components/home/shared.tsx
@@ -1,6 +1,5 @@
 import { TemplateBackstageLogoIcon } from '@backstage/plugin-home';
 import { makeStyles } from '@material-ui/core/styles';
-import React from 'react';
 
 export const useLogoStyles = makeStyles(theme => ({
   container: {

--- a/packages/app/src/components/search/SearchPage.tsx
+++ b/packages/app/src/components/search/SearchPage.tsx
@@ -17,7 +17,7 @@ import {
 } from '@backstage/plugin-search-react';
 import { TechDocsSearchResultListItem } from '@backstage/plugin-techdocs';
 import { Grid, List, makeStyles, Paper, Theme } from '@material-ui/core';
-import React from 'react';
+
 import { ToolSearchResultListItem } from '@backstage-community/plugin-explore';
 import { useApi } from '@backstage/core-plugin-api';
 import {

--- a/packages/app/src/components/settings/NotificationSettings.tsx
+++ b/packages/app/src/components/settings/NotificationSettings.tsx
@@ -8,7 +8,7 @@ import {
 } from '@backstage/core-plugin-api';
 
 import { InfoCard } from '@backstage/core-components';
-import React from 'react';
+
 import { UserNotificationSettingsCard } from '@backstage/plugin-notifications';
 
 export const NotificationSettings = () => {

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import '@backstage/canon/css/styles.css';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
     ? []
     : [
         {
-          command: 'yarn dev',
+          command: 'yarn start',
           port: 3000,
           reuseExistingServer: true,
           timeout: 60_000,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
   "exclude": ["node_modules"],
   "compilerOptions": {
     "outDir": "dist-types",
-    "rootDir": "."
+    "rootDir": ".",
+    "jsx": "react-jsx"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3503,15 +3503,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@npm:^1.6.1-next.0":
-  version: 1.6.1-next.0
-  resolution: "@backstage/app-defaults@npm:1.6.1-next.0"
+"@backstage/app-defaults@npm:^1.6.1-next.1":
+  version: 1.6.1-next.1
+  resolution: "@backstage/app-defaults@npm:1.6.1-next.1"
   dependencies:
-    "@backstage/core-app-api": "npm:1.16.0"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/plugin-permission-react": "npm:0.4.32"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/core-app-api": "npm:1.16.1-next.0"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.33-next.0"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -3522,7 +3522,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e3e1c57cb635e873dd51764624bf03cbae252b0387fb0726ca88caf8fc298fd626a6c147e98bb39de734203aaad8d5760f660a80ef897a1c958b63780eb4d7a3
+  checksum: 10/62a56c2e4b5a8a516c4f7ff41287009ef090dd9421672d3ed4a6eba65a9bbe2678a09a7dbe1cc7c3634e0f7fb68b5a4459d0a6f9c2b1a6a4dfa5029eb9c87742
   languageName: node
   linkType: hard
 
@@ -3690,9 +3690,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:0.9.0-next.1, @backstage/backend-defaults@npm:^0.9.0-next.1":
-  version: 0.9.0-next.1
-  resolution: "@backstage/backend-defaults@npm:0.9.0-next.1"
+"@backstage/backend-defaults@npm:0.9.0-next.2, @backstage/backend-defaults@npm:^0.9.0-next.2":
+  version: 0.9.0-next.2
+  resolution: "@backstage/backend-defaults@npm:0.9.0-next.2"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -3765,7 +3765,7 @@ __metadata:
   peerDependenciesMeta:
     "@google-cloud/cloud-sql-connector":
       optional: true
-  checksum: 10/e165fc750bcccdcf2c6f255a946de9b160301d78d83a00f7809ba742e501557959523802de8ac3eae63d29f6d3de8db1036ea0b2616c45392a04c7a40b797f8d
+  checksum: 10/9362ac107e53db226507f28a5f5cff91fb9d06773ff0a4f03a7b89df8c568034d17c67625c203182443d819bb7bb0a2e0a9fbbfbe63752c0ca6ced0a8651cf1f
   languageName: node
   linkType: hard
 
@@ -3917,9 +3917,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/canon@npm:^0.2.1-next.1":
-  version: 0.2.1-next.1
-  resolution: "@backstage/canon@npm:0.2.1-next.1"
+"@backstage/canon@npm:^0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/canon@npm:0.3.0-next.2"
   dependencies:
     "@base-ui-components/react": "npm:^1.0.0-alpha.5"
     "@remixicon/react": "npm:^4.5.0"
@@ -3932,7 +3932,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d89bfee5c077666e3a4af3b9760336461dd6075ebd4b0e7e742ded482517b730681f51a221d2e702281141772515e31e6d1af4361d88043ae7b5b05c240dc1d1
+  checksum: 10/46bc5ebeef9757e083e928a3707eade3db71033da267630deeae580f3e525ceddd212f34e56f91fb3838d96b2a88256bf25c834277ac4dbc41eaa261651dc59e
   languageName: node
   linkType: hard
 
@@ -3983,9 +3983,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@npm:^0.32.0-next.1":
-  version: 0.32.0-next.1
-  resolution: "@backstage/cli@npm:0.32.0-next.1"
+"@backstage/cli@npm:^0.32.0-next.2":
+  version: 0.32.0-next.2
+  resolution: "@backstage/cli@npm:0.32.0-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/cli-common": "npm:0.1.15"
@@ -4114,7 +4114,8 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/e964e6937b1248bd95e908cab958cdd651a04d0d7abaeb9c1177d719334254bf9ef0cf369e00324323d9ca46fd1ad6f26e6cb923c7e33debd73adfdaeee87dd9
+    backstage-cli-alpha: bin/backstage-cli-alpha
+  checksum: 10/de6a3d11368c4d3f98a1a4477a774e5923d00fb268f85169d8a2941493ee7f240923c7b99b1b100e2b87cb4a2fbf9f0c0fcd1e943acbc0834448fafc26fd5ff9
   languageName: node
   linkType: hard
 
@@ -4152,7 +4153,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@npm:1.16.0, @backstage/core-app-api@npm:^1.16.0":
+"@backstage/core-app-api@npm:1.16.1-next.0, @backstage/core-app-api@npm:^1.16.1-next.0":
+  version: 1.16.1-next.0
+  resolution: "@backstage/core-app-api@npm:1.16.1-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@types/prop-types": "npm:^15.7.3"
+    history: "npm:^5.0.0"
+    i18next: "npm:^22.4.15"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/15db264f569fbfcd58284cbc45b3628dd644679cf20829a78f86e46254bf6870dee4b37c14ededee8a5e7764b1341e0d7801fec2eab0cd04a0c638d9bc9dfa4d
+  languageName: node
+  linkType: hard
+
+"@backstage/core-app-api@npm:^1.16.0":
   version: 1.16.0
   resolution: "@backstage/core-app-api@npm:1.16.0"
   dependencies:
@@ -4180,13 +4209,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@npm:0.4.1-next.1":
-  version: 0.4.1-next.1
-  resolution: "@backstage/core-compat-api@npm:0.4.1-next.1"
+"@backstage/core-compat-api@npm:0.4.1-next.2":
+  version: 0.4.1-next.2
+  resolution: "@backstage/core-compat-api@npm:0.4.1-next.2"
   dependencies:
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
     "@backstage/version-bridge": "npm:1.0.11"
     lodash: "npm:^4.17.21"
   peerDependencies:
@@ -4197,7 +4226,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e5325c7495536397782935338f8ad9ce869248f4b3b123074d2c6b58ace08d255fef9c1bdf8dd62d80b3a62a6a02e45f86f85678888899278c7450e05539f6fc
+  checksum: 10/83ca906412e92b9583b6208e1b0b56087e44ccfd813143d14c71c71300ba9beaadd46865baeb6f946aee747880181c3faa03cbcdca91acb209bb166235dc96d5
   languageName: node
   linkType: hard
 
@@ -4238,14 +4267,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:0.17.1-next.0, @backstage/core-components@npm:^0.17.1-next.0":
-  version: 0.17.1-next.0
-  resolution: "@backstage/core-components@npm:0.17.1-next.0"
+"@backstage/core-components@npm:0.17.1-next.1, @backstage/core-components@npm:^0.17.1-next.1":
+  version: 0.17.1-next.1
+  resolution: "@backstage/core-components@npm:0.17.1-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@backstage/version-bridge": "npm:1.0.11"
     "@dagrejs/dagre": "npm:^1.1.4"
     "@date-io/core": "npm:^1.3.13"
@@ -4288,7 +4317,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ebee9832c2ee113e8ddcb870a4f09603f91ca0430d6e0d57f4e0a6d761fd5fbe93d8dea3f51b0e8411f7e5f1841f0630ac4f837475561abe8b92dba5784eb314
+  checksum: 10/e9a0a3aab761473ea82a792b9a54c96adec7eb5fe41186bd0f336cffa1a0cd19cbf13da70951a65abbcb5a4be9142ea13bb9aadc9ee2ec30fab4219dfd347883
   languageName: node
   linkType: hard
 
@@ -4395,7 +4424,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@npm:1.10.5, @backstage/core-plugin-api@npm:^1.10.5, @backstage/core-plugin-api@npm:^1.9.3":
+"@backstage/core-plugin-api@npm:1.10.6-next.0, @backstage/core-plugin-api@npm:^1.10.6-next.0":
+  version: 1.10.6-next.0
+  resolution: "@backstage/core-plugin-api@npm:1.10.6-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    history: "npm:^5.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/dcec2a5e4bffd885e35b82add65fb630e6990d774a266e35c7b6b16ad5c68203e74ef0f8f589889b31a0a6519d2ad8b10ec5d6e92a18123699c905e257299618
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:^1.10.5, @backstage/core-plugin-api@npm:^1.9.3":
   version: 1.10.5
   resolution: "@backstage/core-plugin-api@npm:1.10.5"
   dependencies:
@@ -4451,16 +4501,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-app-api@npm:0.11.1-next.0":
-  version: 0.11.1-next.0
-  resolution: "@backstage/frontend-app-api@npm:0.11.1-next.0"
+"@backstage/frontend-app-api@npm:0.11.1-next.1":
+  version: 0.11.1-next.1
+  resolution: "@backstage/frontend-app-api@npm:0.11.1-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-app-api": "npm:1.16.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-app-api": "npm:1.16.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-defaults": "npm:0.2.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/frontend-defaults": "npm:0.2.1-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     lodash: "npm:^4.17.21"
@@ -4473,7 +4523,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3f022099cc9acb3af9c750a12aed26306f6213cb23a642f10a48af9ffae777ff2d336af5b9cc54636b51f9acca3505a87544c114dd65b725f2ad5ca86555ca3f
+  checksum: 10/3d1f3cdf8a7a25e46d2beb32880cb5b52504d5fa33c0a21d0f841d3c4ac5389499ff18055546f883e29aaf6ebde293dd872b71fd1280816a3f6e95b6a75783e1
   languageName: node
   linkType: hard
 
@@ -4503,15 +4553,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@npm:0.2.1-next.0":
-  version: 0.2.1-next.0
-  resolution: "@backstage/frontend-defaults@npm:0.2.1-next.0"
+"@backstage/frontend-defaults@npm:0.2.1-next.1":
+  version: 0.2.1-next.1
+  resolution: "@backstage/frontend-defaults@npm:0.2.1-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-app-api": "npm:0.11.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-app": "npm:0.1.8-next.0"
+    "@backstage/frontend-app-api": "npm:0.11.1-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-app": "npm:0.1.8-next.1"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -4521,7 +4571,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/008e6725b720f3d8f9d8a4b581515e326328e8c501df3d89467c65169a82bcb395861d8fe1fccb4befc734e9ab1bb5e34d40b16d36cae1135e28003660a607dd
+  checksum: 10/3d15bb83cacfe3a6de9023678491848d8b1520284cd575c22b96f5bd798abf35abc193060eaf24ed6d3a75228d122b0dc715c8db1eabc2bc0351c7fd9a7c59e7
   languageName: node
   linkType: hard
 
@@ -4547,12 +4597,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:0.10.1-next.0":
-  version: 0.10.1-next.0
-  resolution: "@backstage/frontend-plugin-api@npm:0.10.1-next.0"
+"@backstage/frontend-plugin-api@npm:0.10.1-next.1":
+  version: 0.10.1-next.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.10.1-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.4"
@@ -4567,7 +4617,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c4f9939dc833a0df21fac5549cd1d05070618fba1e430b4569b723c8cf2a4339d81802543f5314c0218ad7e6a6d1fab0a43d9a4643d4b90d67d40659c9d79b8e
+  checksum: 10/ab2e8127d0ac3b189db07eb866dc043db1d52e74825e848f25dfe9ab817b52918489eedafca1d9a3787b1b8e0736fedd8248607327c0fc07cdfb965509898efd
   languageName: node
   linkType: hard
 
@@ -4615,15 +4665,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-test-utils@npm:0.3.1-next.0":
-  version: 0.3.1-next.0
-  resolution: "@backstage/frontend-test-utils@npm:0.3.1-next.0"
+"@backstage/frontend-test-utils@npm:0.3.1-next.1":
+  version: 0.3.1-next.1
+  resolution: "@backstage/frontend-test-utils@npm:0.3.1-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/frontend-app-api": "npm:0.11.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-app": "npm:0.1.8-next.0"
-    "@backstage/test-utils": "npm:1.7.6"
+    "@backstage/frontend-app-api": "npm:0.11.1-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-app": "npm:0.1.8-next.1"
+    "@backstage/test-utils": "npm:1.7.7-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     zod: "npm:^3.22.4"
@@ -4636,7 +4686,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4dcfbb1147c51a5cf9a4bff8a9c59d3186abcdfece834bed12c9660ef9fe92f2548065348a3e90c39f281440ef542e18a6c8bed92d9f86295d40149d4d3a7913
+  checksum: 10/d9f9605e700316f8f462cba855ac2e241fea54a53851197a5c1507a95aa567094379e190f0b72ade6c87c404ab4c5ef11a3848b24f425a354592c6e8965b8ec1
   languageName: node
   linkType: hard
 
@@ -4680,12 +4730,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@npm:1.2.6-next.0, @backstage/integration-react@npm:^1.2.6-next.0":
-  version: 1.2.6-next.0
-  resolution: "@backstage/integration-react@npm:1.2.6-next.0"
+"@backstage/integration-react@npm:1.2.6-next.1, @backstage/integration-react@npm:^1.2.6-next.1":
+  version: 1.2.6-next.1
+  resolution: "@backstage/integration-react@npm:1.2.6-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/integration": "npm:1.16.3-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4697,7 +4747,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d042d7b5e5e8350202ae69bc9d259c5614c58779ac39ead4d02edd19eec0368afb1c1dc308668b8b5823a66d8a4e9c7dfc8d31298cce4f6880aee87cc5cc3827
+  checksum: 10/ba580af8d5b451bc91dab1bcf0936f20f6dcfea3d4c0ac545b8108e297da2d53c7528d5d3f68c90a42d04e9d1a691fd72246ffd6e19bbac6a50bc808e667021e
   languageName: node
   linkType: hard
 
@@ -4758,20 +4808,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@npm:^0.12.6-next.1":
-  version: 0.12.6-next.1
-  resolution: "@backstage/plugin-api-docs@npm:0.12.6-next.1"
+"@backstage/plugin-api-docs@npm:^0.12.6-next.2":
+  version: 0.12.6-next.2
+  resolution: "@backstage/plugin-api-docs@npm:0.12.6-next.2"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-catalog": "npm:1.29.0-next.1"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-catalog": "npm:1.29.0-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
-    "@backstage/plugin-permission-react": "npm:0.4.32"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
+    "@backstage/plugin-permission-react": "npm:0.4.33-next.0"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4790,7 +4840,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1914979958e7e3fce3f062389e5dc55dfe9b6e40825b979de7458a166057f89193fe34c10bcf9f756044651fad05fa3aaa08950f4d83b11d374838ea425f7d0f
+  checksum: 10/196aefc46c88371e271dee05b03db5f55f546457bd6c5aec09686d51579c6057b0198e2294cfb03f3aadf611e37835a3ecfefe442daa675e8dba157a0a498aec
   languageName: node
   linkType: hard
 
@@ -4831,16 +4881,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@npm:0.1.8-next.0":
-  version: 0.1.8-next.0
-  resolution: "@backstage/plugin-app@npm:0.1.8-next.0"
+"@backstage/plugin-app@npm:0.1.8-next.1":
+  version: 0.1.8-next.1
+  resolution: "@backstage/plugin-app@npm:0.1.8-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/integration-react": "npm:1.2.6-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.32"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/integration-react": "npm:1.2.6-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.33-next.0"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4854,7 +4904,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/cf5a865107f1e725389b3e904b68e3a987bc8158cea841c1e391d5041c959d0daa0d876d849d11d5acb38714121cb63d0771f65a409a7b4e43646060a933f5d0
+  checksum: 10/3c3b9a939468d5ec298a9a4c23aac200abacc0408207e064939b3baff78d7fc3cd0be9c787543cdd312dc980c7191e2dcca6fef0a935b6e640b2676affd66e63
   languageName: node
   linkType: hard
 
@@ -4911,17 +4961,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.2-next.1":
-  version: 0.4.2-next.1
-  resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.2-next.1"
+"@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.2-next.2":
+  version: 0.4.2-next.2
+  resolution: "@backstage/plugin-auth-backend-module-aws-alb-provider@npm:0.4.2-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-backend": "npm:0.24.5-next.1"
+    "@backstage/plugin-auth-backend": "npm:0.24.5-next.2"
     "@backstage/plugin-auth-node": "npm:0.6.1"
     jose: "npm:^5.0.0"
     node-cache: "npm:^5.1.2"
-  checksum: 10/4291c790da05b675c512dc67355385a42985a43e86b1df1c70244a83457ed64bee1676c73012d0c9b1ec589e3d117ab13a811b26f2b3abceffc11d8b82195640
+  checksum: 10/fd4cdce94992f1d292508a177dbac3de2f25c4973acc818feaa2908cd332d16885efafe91eee17a80deb91edf33e16ffc18dcf0a1dab010827845eb5c43fa5cd
   languageName: node
   linkType: hard
 
@@ -5079,19 +5129,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.2-next.1":
-  version: 0.4.2-next.1
-  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.2-next.1"
+"@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.2-next.2":
+  version: 0.4.2-next.2
+  resolution: "@backstage/plugin-auth-backend-module-oidc-provider@npm:0.4.2-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-auth-backend": "npm:0.24.5-next.1"
+    "@backstage/plugin-auth-backend": "npm:0.24.5-next.2"
     "@backstage/plugin-auth-node": "npm:0.6.1"
     "@backstage/types": "npm:1.2.1"
     express: "npm:^4.18.2"
     openid-client: "npm:^5.5.0"
     passport: "npm:^0.7.0"
-  checksum: 10/4fbb137ebec3a8a41bf9ad036d4ca2f137422f92234a83fb7b598bad91ea72133a0f946b583c2b814a65d6daf12ad042a207676ff348e9d0836e2c71bc9356c6
+  checksum: 10/f75ccf93a340316ec986b6f5db77e2d65d8fb397e5386ed6a08dcfbf84a495cca2db7aeb66c5e676d2847aa49ba8babc5ddc215a5884edc100dcf43b5701b94d
   languageName: node
   linkType: hard
 
@@ -5121,9 +5171,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@npm:0.24.5-next.1, @backstage/plugin-auth-backend@npm:^0.24.5-next.1":
-  version: 0.24.5-next.1
-  resolution: "@backstage/plugin-auth-backend@npm:0.24.5-next.1"
+"@backstage/plugin-auth-backend@npm:0.24.5-next.2, @backstage/plugin-auth-backend@npm:^0.24.5-next.2":
+  version: 0.24.5-next.2
+  resolution: "@backstage/plugin-auth-backend@npm:0.24.5-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
     "@backstage/backend-plugin-api": "npm:1.2.1"
@@ -5133,7 +5183,7 @@ __metadata:
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-auth-backend-module-atlassian-provider": "npm:0.4.1"
     "@backstage/plugin-auth-backend-module-auth0-provider": "npm:0.2.1"
-    "@backstage/plugin-auth-backend-module-aws-alb-provider": "npm:0.4.2-next.1"
+    "@backstage/plugin-auth-backend-module-aws-alb-provider": "npm:0.4.2-next.2"
     "@backstage/plugin-auth-backend-module-azure-easyauth-provider": "npm:0.2.6"
     "@backstage/plugin-auth-backend-module-bitbucket-provider": "npm:0.3.2-next.0"
     "@backstage/plugin-auth-backend-module-bitbucket-server-provider": "npm:0.2.1"
@@ -5145,11 +5195,11 @@ __metadata:
     "@backstage/plugin-auth-backend-module-microsoft-provider": "npm:0.3.1"
     "@backstage/plugin-auth-backend-module-oauth2-provider": "npm:0.4.1"
     "@backstage/plugin-auth-backend-module-oauth2-proxy-provider": "npm:0.2.6"
-    "@backstage/plugin-auth-backend-module-oidc-provider": "npm:0.4.2-next.1"
+    "@backstage/plugin-auth-backend-module-oidc-provider": "npm:0.4.2-next.2"
     "@backstage/plugin-auth-backend-module-okta-provider": "npm:0.2.1"
     "@backstage/plugin-auth-backend-module-onelogin-provider": "npm:0.3.1"
     "@backstage/plugin-auth-node": "npm:0.6.1"
-    "@backstage/plugin-catalog-node": "npm:1.16.1"
+    "@backstage/plugin-catalog-node": "npm:1.16.3-next.0"
     "@backstage/types": "npm:1.2.1"
     "@google-cloud/firestore": "npm:^7.0.0"
     "@node-saml/passport-saml": "npm:^5.0.0"
@@ -5182,7 +5232,7 @@ __metadata:
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/898b3fd0163e7ec934afae5759a5965503c152e110f668c841aa1c7b4584048c4d06f962f749bb6f155204dbd6f61a618e09e92384131fa69fe05af07af6cc61
+  checksum: 10/477fb7e345d7e0298383570adbb491aa31f7a34e743b91f7fbc0aebf643c4910f2259fdc3c46e6ab285fce3e502e77df7887ed62ff421d3b9a802fcc08ffece5
   languageName: node
   linkType: hard
 
@@ -5259,12 +5309,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-react@npm:0.1.14-next.0":
-  version: 0.1.14-next.0
-  resolution: "@backstage/plugin-auth-react@npm:0.1.14-next.0"
+"@backstage/plugin-auth-react@npm:0.1.14-next.1":
+  version: 0.1.14-next.1
+  resolution: "@backstage/plugin-auth-react@npm:0.1.14-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@material-ui/core": "npm:^4.9.13"
     "@react-hookz/web": "npm:^24.0.0"
@@ -5276,7 +5326,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/eb6892cf8985f36a97426a892741a3ce1e531594e997829d7b4de5a476196ecdb870b63198fc7390162c25ea4defbda3bebf44760336d17b95b1082f27e5f61f
+  checksum: 10/83ee358ab5533afa52f495bdb75fc06c080bb4039d8cc88af2d071e82464d443456cac6752e179d10fd52d528e44274ef75a8ccd67df450fb02f62b49105bb19
   languageName: node
   linkType: hard
 
@@ -5290,33 +5340,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@npm:^0.1.9-next.0":
-  version: 0.1.9-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.9-next.0"
+"@backstage/plugin-catalog-backend-module-logs@npm:^0.1.9-next.1":
+  version: 0.1.9-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.9-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
-    "@backstage/plugin-catalog-backend": "npm:1.32.1-next.0"
+    "@backstage/plugin-catalog-backend": "npm:1.32.1-next.1"
     "@backstage/plugin-events-node": "npm:0.4.9"
-  checksum: 10/b9132fa209fb9fdc0cfe4c551c1f11998c1fca789087a5c3fed41da721fa3ef37dced48f07d7de52c72620c0a633aca398fa7e985a4ed4378e8ee7d4cd0cc25e
+  checksum: 10/26c0529816b210e7838b69c42dda46ef1e5c3bcf18c613cd42f856eaae9c5a2605f7665c308988980ae3b8c68fb395802978d441d04e4b28aa50dc237403ecf0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.6, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.6":
-  version: 0.2.6
-  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.6"
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.7-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.7-next.0":
+  version: 0.2.7-next.0
+  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.7-next.0"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.2.1"
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/plugin-catalog-common": "npm:^1.1.3"
-    "@backstage/plugin-catalog-node": "npm:^1.16.1"
-    "@backstage/plugin-scaffolder-common": "npm:^1.5.10"
-  checksum: 10/d05b9083031968b7e703dba61ae426ae2b0aeb955021e5b477645b2ab864d9f3697c21e2aded77d428e490fa832ddd6df4a8ff270d527a3edcc82a6454fcbd8e
+    "@backstage/backend-plugin-api": "npm:1.2.1"
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/plugin-catalog-common": "npm:1.1.3"
+    "@backstage/plugin-catalog-node": "npm:1.16.3-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.10"
+  checksum: 10/de3d63aeb778c5b8288b0b1aaa3aa9ea1eff138c08ffbfae25d5cc9cde5aa5c596b79a2bdec7bf5628d6a39a1fff131d6d94f82335c2d7039ccbd19f80d767cb
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@npm:1.32.1-next.0, @backstage/plugin-catalog-backend@npm:^1.32.1-next.0":
-  version: 1.32.1-next.0
-  resolution: "@backstage/plugin-catalog-backend@npm:1.32.1-next.0"
+"@backstage/plugin-catalog-backend@npm:1.32.1-next.1, @backstage/plugin-catalog-backend@npm:^1.32.1-next.1":
+  version: 1.32.1-next.1
+  resolution: "@backstage/plugin-catalog-backend@npm:1.32.1-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
     "@backstage/backend-openapi-utils": "npm:0.5.1"
@@ -5327,11 +5377,11 @@ __metadata:
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.3-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.16.1"
+    "@backstage/plugin-catalog-node": "npm:1.16.3-next.0"
     "@backstage/plugin-events-node": "npm:0.4.9"
     "@backstage/plugin-permission-common": "npm:0.8.4"
     "@backstage/plugin-permission-node": "npm:0.9.0"
-    "@backstage/plugin-search-backend-module-catalog": "npm:0.3.2"
+    "@backstage/plugin-search-backend-module-catalog": "npm:0.3.3-next.0"
     "@backstage/plugin-search-common": "npm:1.2.17"
     "@backstage/types": "npm:1.2.1"
     "@opentelemetry/api": "npm:^1.9.0"
@@ -5353,7 +5403,7 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/ea2bfa09db0b5f435adcc71945b12b6804c21bf5df50c4dea692ce67384a6de232d8b9c18e0df98ea843e14b9870e9d7357c9289c53aba83ab256c4bce88db3b
+  checksum: 10/969cac89f5f5ef86231f2db0d2e1c31e837ae38ef363f57018d79387007ab1bc28f914119262d7a35512109d4f0127937cca46dc1e67e5e6277209cc1ff81f89
   languageName: node
   linkType: hard
 
@@ -5368,17 +5418,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@npm:^0.4.18-next.1":
-  version: 0.4.18-next.1
-  resolution: "@backstage/plugin-catalog-graph@npm:0.4.18-next.1"
+"@backstage/plugin-catalog-graph@npm:^0.4.18-next.2":
+  version: 0.4.18-next.2
+  resolution: "@backstage/plugin-catalog-graph@npm:0.4.18-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5396,11 +5446,27 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9029d5ad780041256dda226c2664e46c92cecbc3ada5c66fb84acc575b89131881e9a85b60a34336c7099b7961ebe71cb8ddc1628b9a777198146eb1999edfbf
+  checksum: 10/f07a0709ba76343a053520505eba8be74185e0a9e0eb18cda32e367636580e114c550bee889de66d6deff927108c82e138671e1606c9fd959a2f9a2a30a73b4f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:1.16.1, @backstage/plugin-catalog-node@npm:^1.12.4, @backstage/plugin-catalog-node@npm:^1.16.1":
+"@backstage/plugin-catalog-node@npm:1.16.3-next.0, @backstage/plugin-catalog-node@npm:^1.16.3-next.0":
+  version: 1.16.3-next.0
+  resolution: "@backstage/plugin-catalog-node@npm:1.16.3-next.0"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.2.1"
+    "@backstage/catalog-client": "npm:1.9.1"
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/plugin-catalog-common": "npm:1.1.3"
+    "@backstage/plugin-permission-common": "npm:0.8.4"
+    "@backstage/plugin-permission-node": "npm:0.9.0"
+    "@backstage/types": "npm:1.2.1"
+  checksum: 10/2a05a9bc8c242d098944604b64d6b8c059614e65ae5adf778605352196b05d7b5b0e04691683698b6fd5c72365605db123d8cf2e54516e0c36bce483d158461a
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-node@npm:^1.12.4, @backstage/plugin-catalog-node@npm:^1.16.1":
   version: 1.16.1
   resolution: "@backstage/plugin-catalog-node@npm:1.16.1"
   dependencies:
@@ -5416,22 +5482,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@npm:1.16.1-next.1, @backstage/plugin-catalog-react@npm:^1.16.1-next.1":
-  version: 1.16.1-next.1
-  resolution: "@backstage/plugin-catalog-react@npm:1.16.1-next.1"
+"@backstage/plugin-catalog-react@npm:1.17.0-next.2, @backstage/plugin-catalog-react@npm:^1.17.0-next.2":
+  version: 1.17.0-next.2
+  resolution: "@backstage/plugin-catalog-react@npm:1.17.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/frontend-test-utils": "npm:0.3.1-next.0"
-    "@backstage/integration-react": "npm:1.2.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/frontend-test-utils": "npm:0.3.1-next.1"
+    "@backstage/integration-react": "npm:1.2.6-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-react": "npm:0.4.32"
+    "@backstage/plugin-permission-react": "npm:0.4.33-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -5453,7 +5519,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0799c2082c4dc02890a5fe2ec350193a5656c6dd979ec6ddec7e13d0775c95c137d19ef391c338a2affef1a607906b56293b0c915c65f604ab7b19e549129795
+  checksum: 10/be5e348619ff0fd7cc69bfed435ca9a500541f8523fc9d5b92d62f907a3e74bda4f30dbd92688f31ef7d2a332b0884354ff66ae97cd56663fc017d99e7dcd39b
   languageName: node
   linkType: hard
 
@@ -5498,25 +5564,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@npm:1.29.0-next.1, @backstage/plugin-catalog@npm:^1.29.0-next.1":
-  version: 1.29.0-next.1
-  resolution: "@backstage/plugin-catalog@npm:1.29.0-next.1"
+"@backstage/plugin-catalog@npm:1.29.0-next.2, @backstage/plugin-catalog@npm:^1.29.0-next.2":
+  version: 1.29.0-next.2
+  resolution: "@backstage/plugin-catalog@npm:1.29.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/integration-react": "npm:1.2.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/integration-react": "npm:1.2.6-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
-    "@backstage/plugin-permission-react": "npm:0.4.32"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
+    "@backstage/plugin-permission-react": "npm:0.4.33-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.5.10"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.8-next.0"
+    "@backstage/plugin-search-react": "npm:1.8.8-next.1"
     "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5537,7 +5604,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/19ab9d22714014b46d15ea33eb41f7a3ca68b145fbd805aff1a3602454f194cdecc46d2e7f89858d82567d9261da68092ed04cdf380e31a7caf5bc6a8ebb396c
+  checksum: 10/10ed0f3ce120d7cb6d3e2b4cfde5f2336e69cc7b38639003f06d013ea7f61e2cddfaa7972ab1213f7884b99d1dcac9bde6dfc73829f0dc0df8febbb2eb8f2f58
   languageName: node
   linkType: hard
 
@@ -5577,12 +5644,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@npm:0.1.25-next.1":
-  version: 0.1.25-next.1
-  resolution: "@backstage/plugin-home-react@npm:0.1.25-next.1"
+"@backstage/plugin-home-react@npm:0.1.25-next.2":
+  version: 0.1.25-next.2
+  resolution: "@backstage/plugin-home-react@npm:0.1.25-next.2"
   dependencies:
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@rjsf/utils": "npm:5.23.2"
@@ -5594,25 +5661,25 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e5de7c6f7496ba2c53a8f2ff798a37f6546e17dd165a0709a2afbc5892e474242655d497cc6d2a6667696719b675dea887584e90cff0f9ed5ea12eba5607e1a8
+  checksum: 10/e2cb280380ddc9e7a2443d69670e66601a53424ef8f5b757e24148aa41f0684dc9bcab4be74ca7e4c08c095f03689508f9b74246d0bcb980d460e84abc469bf6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@npm:^0.8.7-next.1":
-  version: 0.8.7-next.1
-  resolution: "@backstage/plugin-home@npm:0.8.7-next.1"
+"@backstage/plugin-home@npm:^0.8.7-next.2":
+  version: 0.8.7-next.2
+  resolution: "@backstage/plugin-home@npm:0.8.7-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-app-api": "npm:1.16.0"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
-    "@backstage/plugin-home-react": "npm:0.1.25-next.1"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/core-app-api": "npm:1.16.1-next.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
+    "@backstage/plugin-home-react": "npm:0.1.25-next.2"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5634,32 +5701,32 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a6d34dbfdeb3f5856d359c2db4cec19df47738cb7d60586b694ad66a34ece4df373f107ca11cbe89a5184f22a75c55e7d73caafc18ba3afcb38e038850cabdef
+  checksum: 10/c6914057d963abe2aa7b700883f7582690c3fc10b1d3929929537f8d26175974c189c40e788153bfade0bfe5ffe94600547f2b4ba1899103d2f58aa5c6b34dcb
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@npm:^0.19.4":
-  version: 0.19.4
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.4"
+"@backstage/plugin-kubernetes-backend@npm:^0.19.5-next.0":
+  version: 0.19.5-next.0
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.5-next.0"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@aws-sdk/signature-v4": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:^1.2.1"
-    "@backstage/catalog-client": "npm:^1.9.1"
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/config": "npm:^1.3.2"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/integration-aws-node": "npm:^0.1.15"
-    "@backstage/plugin-auth-node": "npm:^0.6.1"
-    "@backstage/plugin-catalog-node": "npm:^1.16.1"
-    "@backstage/plugin-kubernetes-common": "npm:^0.9.4"
-    "@backstage/plugin-kubernetes-node": "npm:^0.2.4"
-    "@backstage/plugin-permission-common": "npm:^0.8.4"
-    "@backstage/plugin-permission-node": "npm:^0.9.0"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/backend-plugin-api": "npm:1.2.1"
+    "@backstage/catalog-client": "npm:1.9.1"
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/integration-aws-node": "npm:0.1.15"
+    "@backstage/plugin-auth-node": "npm:0.6.1"
+    "@backstage/plugin-catalog-node": "npm:1.16.3-next.0"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.4"
+    "@backstage/plugin-kubernetes-node": "npm:0.2.4"
+    "@backstage/plugin-permission-common": "npm:0.8.4"
+    "@backstage/plugin-permission-node": "npm:0.9.0"
+    "@backstage/types": "npm:1.2.1"
     "@google-cloud/container": "npm:^5.0.0"
     "@jest-mock/express": "npm:^2.0.1"
     "@kubernetes/client-node": "npm:1.0.0-rc7"
@@ -5680,7 +5747,7 @@ __metadata:
     stream-buffers: "npm:^3.0.2"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/ae349541299c8f66a4d93600c7fb1346c88b484f6890b2264b956160e3e323a31147a7c3bd05f07fb5232a89b90d34db1bb80141a9dea7472fd29df5d04f0672
+  checksum: 10/44ef744256b1e4f79213f823b8a5d745288086607feb00174c9f285de0808de07ebcddba6ecd1573bacbbf150fc4610565aa72fbaa37ec85ae752782b6c8d1a2
   languageName: node
   linkType: hard
 
@@ -5699,7 +5766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-node@npm:^0.2.4":
+"@backstage/plugin-kubernetes-node@npm:0.2.4":
   version: 0.2.4
   resolution: "@backstage/plugin-kubernetes-node@npm:0.2.4"
   dependencies:
@@ -5714,13 +5781,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-react@npm:0.5.6-next.0":
-  version: 0.5.6-next.0
-  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.6-next.0"
+"@backstage/plugin-kubernetes-react@npm:0.5.6-next.1":
+  version: 0.5.6-next.1
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.6-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-kubernetes-common": "npm:0.9.4"
     "@backstage/types": "npm:1.2.1"
@@ -5747,23 +5814,23 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a69a8403e185d890ce0a26fac4195a74d3d38bf9975c8cdc78f3b1e4accd8f895f56b56d095ae32562dad87bbd286656fa55868cc79f0778f9145800df0237e2
+  checksum: 10/4e7990041ea2991010fa252ea66108f5148240a3d4b097c9c2323051702edaac0aabf79c3208448526ea32014e84efc22e094dbb4d49aba75d7326906691b2e9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@npm:^0.12.6-next.1":
-  version: 0.12.6-next.1
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.6-next.1"
+"@backstage/plugin-kubernetes@npm:^0.12.6-next.2":
+  version: 0.12.6-next.2
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.6-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
     "@backstage/plugin-kubernetes-common": "npm:0.9.4"
-    "@backstage/plugin-kubernetes-react": "npm:0.5.6-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.32"
+    "@backstage/plugin-kubernetes-react": "npm:0.5.6-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.33-next.0"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
     "@kubernetes/client-node": "npm:1.0.0-rc7"
@@ -5784,13 +5851,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d9ae0ce9db8d513a9c09b1d5c1872b7e864eccaa87d84b46f380e55f50f1e557c01f70845012660c0da2bfcd41b84807b7f513334aaa4a3ad7e89718216b5895
+  checksum: 10/bf28d8935c631423ad1cdf8057dc2bbbc099788dca290ac026789f5c536ed22f10b758348e4ad8b56a097b0c133dd6f63677ec1d7077ab0a059b0e8bfb5aa228
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@npm:^0.5.5-next.0":
-  version: 0.5.5-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.5.5-next.0"
+"@backstage/plugin-notifications-backend@npm:^0.5.5-next.1":
+  version: 0.5.5-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.5.5-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-client": "npm:1.9.1"
@@ -5798,7 +5865,7 @@ __metadata:
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-auth-node": "npm:0.6.1"
-    "@backstage/plugin-catalog-node": "npm:1.16.1"
+    "@backstage/plugin-catalog-node": "npm:1.16.3-next.0"
     "@backstage/plugin-events-node": "npm:0.4.9"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
     "@backstage/plugin-notifications-node": "npm:0.2.13"
@@ -5811,7 +5878,7 @@ __metadata:
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/437785b18477df2b4f2d035ecea062874a61d390e99caa232ba887e2ba2c5adbfc8f1358a4b896bf94b069e086df7cd496cc743bf2d70179b33813778d2ddad5
+  checksum: 10/75efdcd20380ed093c0b872874a76707675c14ca2d01c07af07729897d320d959520b05da99f0e78e11a67ca52ca49103f1b30aa7afda0b5a20cdef5de5127f7
   languageName: node
   linkType: hard
 
@@ -5840,18 +5907,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@npm:^0.5.4-next.1":
-  version: 0.5.4-next.1
-  resolution: "@backstage/plugin-notifications@npm:0.5.4-next.1"
+"@backstage/plugin-notifications@npm:^0.5.4-next.2":
+  version: 0.5.4-next.2
+  resolution: "@backstage/plugin-notifications@npm:0.5.4-next.2"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
-    "@backstage/plugin-signals-react": "npm:0.0.11"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/plugin-signals-react": "npm:0.0.12-next.0"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5869,21 +5936,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6406cf9d9e46f95a3075a6223458610387c71dfcc605ed79d3452ed1dc16139e8dbdb3464f62fc63d0ee3c3ff69a7407be73d235050052d66cfe10fdf48fbc0e
+  checksum: 10/91ffe4f8e1f9099d6b998aab0cdc4318b2f79d7f654cf37813906f5b4a359d6822ad41adace5384512b73bf9e4a9a6ae2e53c3f6d5cddcabeb4fd7997c14b292
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@npm:^0.6.38-next.1":
-  version: 0.6.38-next.1
-  resolution: "@backstage/plugin-org@npm:0.6.38-next.1"
+"@backstage/plugin-org@npm:^0.6.38-next.2":
+  version: 0.6.38-next.2
+  resolution: "@backstage/plugin-org@npm:0.6.38-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5900,7 +5967,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/208adf1c06a6002ce0c9338bfcd26e0f0aace25c80c75b04fd47078c4eb1c22bc7bd5686bf0f0a285b6642fbaa2168d4fdafa54c65455ff9f6662f1ca0a91b6b
+  checksum: 10/e662d157125a90979c1c9b64cb4aa07910ba1c92fdd9adb76285f921a8f50161facc75e3de6c9731c13791ee5d7840ae9aca56169694501cdb861ac1efe624a7
   languageName: node
   linkType: hard
 
@@ -5937,7 +6004,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-react@npm:0.4.32, @backstage/plugin-permission-react@npm:^0.4.32":
+"@backstage/plugin-permission-react@npm:0.4.33-next.0":
+  version: 0.4.33-next.0
+  resolution: "@backstage/plugin-permission-react@npm:0.4.33-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4"
+    swr: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/88b21f548c4dabc2e14feaa88ed5fd68d58901e23bff1c713a915eea3bed548c08c44407d6bc3eb1452382202f8dcb527147edbdb7c9181e932fefaf423a2dc9
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-react@npm:^0.4.32":
   version: 0.4.32
   resolution: "@backstage/plugin-permission-react@npm:0.4.32"
   dependencies:
@@ -6072,9 +6159,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@npm:0.6.2-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.6.2-next.1":
-  version: 0.6.2-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.6.2-next.1"
+"@backstage/plugin-scaffolder-backend-module-github@npm:0.6.2-next.2, @backstage/plugin-scaffolder-backend-module-github@npm:^0.6.2-next.2":
+  version: 0.6.2-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.6.2-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-client": "npm:1.9.1"
@@ -6089,7 +6176,7 @@ __metadata:
     octokit: "npm:^3.0.0"
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/0cc1c4b16055575d1555b3b1afb8cd3643e75143ece6a2bb951f5cf403e00bc386badabea738ad78e42d3c1cb97b932bf30bed56f9706d44c111060d337b87b6
+  checksum: 10/b134263b0041d829e11a7a6fa9db423e9d872f6c986cfda3ed0c27f163a24717c45a02cae9ad0986e78304ebc3ce5eeb1e58d3246f331a6ecc420d0a487df188
   languageName: node
   linkType: hard
 
@@ -6125,12 +6212,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@npm:^1.32.0-next.1":
-  version: 1.32.0-next.1
-  resolution: "@backstage/plugin-scaffolder-backend@npm:1.32.0-next.1"
+"@backstage/plugin-scaffolder-backend@npm:^1.32.0-next.2":
+  version: 1.32.0-next.2
+  resolution: "@backstage/plugin-scaffolder-backend@npm:1.32.0-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-defaults": "npm:0.9.0-next.1"
+    "@backstage/backend-defaults": "npm:0.9.0-next.2"
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
@@ -6139,8 +6226,8 @@ __metadata:
     "@backstage/integration": "npm:1.16.3-next.0"
     "@backstage/plugin-auth-node": "npm:0.6.1"
     "@backstage/plugin-bitbucket-cloud-common": "npm:0.2.29-next.0"
-    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.6"
-    "@backstage/plugin-catalog-node": "npm:1.16.1"
+    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.7-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.16.3-next.0"
     "@backstage/plugin-events-node": "npm:0.4.9"
     "@backstage/plugin-permission-common": "npm:0.8.4"
     "@backstage/plugin-permission-node": "npm:0.9.0"
@@ -6150,7 +6237,7 @@ __metadata:
     "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.8-next.1"
     "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.8-next.1"
     "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.8-next.1"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.6.2-next.1"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.6.2-next.2"
     "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.8.2-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.5.10"
     "@backstage/plugin-scaffolder-node": "npm:0.8.1-next.1"
@@ -6183,11 +6270,11 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/f73216aea6e30149c6965fb386574321e6c6b55aa9caf3f764f0e720b22c8f52c4aae751f4f4a248b10f3bcdf5ed8bc3dfd84429a29874e4a3ab086ce30c8989
+  checksum: 10/b10996dc54b3b8035f3affb7b757c614398498d5bf3c1e13e1b53f7be5467015fbb1b02dfc1eee08b96b74e588c06a4471bb3579a9218afaca15a3290cd200b8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-common@npm:1.5.10, @backstage/plugin-scaffolder-common@npm:^1.5.10":
+"@backstage/plugin-scaffolder-common@npm:1.5.10":
   version: 1.5.10
   resolution: "@backstage/plugin-scaffolder-common@npm:1.5.10"
   dependencies:
@@ -6224,19 +6311,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.15.0-next.1":
-  version: 1.15.0-next.1
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.15.0-next.1"
+"@backstage/plugin-scaffolder-react@npm:1.15.0-next.2":
+  version: 1.15.0-next.2
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.15.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
-    "@backstage/plugin-permission-react": "npm:0.4.32"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
+    "@backstage/plugin-permission-react": "npm:0.4.33-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.5.10"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -6272,28 +6359,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/f1aa10dfd1f5f7e3e9aed7b2b4810ac9d8a2ee60afbaa2a3cd77b3da9b49a0d2324bf2b802c7e273cc8bc3c74de65d231ce173ed5c4e440045148d12d5a39efe
+  checksum: 10/f7602ddb8a9c43c5eee1a8bc61caedd5c86af19ba8d7e813f3f3eafc0920ca0f2652fde5592f8e7eba903d9e5bd41bb87592bff1c9dc21fe985cceccefd52ac0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@npm:^1.30.0-next.1":
-  version: 1.30.0-next.1
-  resolution: "@backstage/plugin-scaffolder@npm:1.30.0-next.1"
+"@backstage/plugin-scaffolder@npm:^1.30.0-next.2":
+  version: 1.30.0-next.2
+  resolution: "@backstage/plugin-scaffolder@npm:1.30.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
     "@backstage/integration": "npm:1.16.3-next.0"
-    "@backstage/integration-react": "npm:1.2.6-next.0"
+    "@backstage/integration-react": "npm:1.2.6-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
-    "@backstage/plugin-permission-react": "npm:0.4.32"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
+    "@backstage/plugin-permission-react": "npm:0.4.33-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.5.10"
-    "@backstage/plugin-scaffolder-react": "npm:1.15.0-next.1"
+    "@backstage/plugin-scaffolder-react": "npm:1.15.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
@@ -6333,25 +6420,25 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5c7e866b4517e81bdb68e633bb7dfbaf8df68521f6636293410b5dec224e73c4b6f5b6d68cd627660331518354f0ce28af4797eaac2e7eaaf54ea10b34dca544
+  checksum: 10/111d2364ecf44197ac8a37cac588c8e11170d9818baddeeb9c8e0d3461849fb0a089639c1e12940bdf25c9f94977361e31a7db55dfd199f5de1aa270fc530180
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@npm:0.3.2, @backstage/plugin-search-backend-module-catalog@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.2"
+"@backstage/plugin-search-backend-module-catalog@npm:0.3.3-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.3-next.0":
+  version: 0.3.3-next.0
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.3-next.0"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.2.1"
-    "@backstage/catalog-client": "npm:^1.9.1"
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/config": "npm:^1.3.2"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-catalog-common": "npm:^1.1.3"
-    "@backstage/plugin-catalog-node": "npm:^1.16.1"
-    "@backstage/plugin-permission-common": "npm:^0.8.4"
-    "@backstage/plugin-search-backend-node": "npm:^1.3.9"
-    "@backstage/plugin-search-common": "npm:^1.2.17"
-  checksum: 10/3222d2dc2b64f1342daae3c8e2ea80f37a1fc8a141dddddc1b366ca63a0e10053ad4fea71e975b434ff3e8453652053c0b0ff74e8bbd972f3908936b365e2dda
+    "@backstage/backend-plugin-api": "npm:1.2.1"
+    "@backstage/catalog-client": "npm:1.9.1"
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/plugin-catalog-common": "npm:1.1.3"
+    "@backstage/plugin-catalog-node": "npm:1.16.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4"
+    "@backstage/plugin-search-backend-node": "npm:1.3.9"
+    "@backstage/plugin-search-common": "npm:1.2.17"
+  checksum: 10/9bc45858ca4e56b935bcbab8aa476e7fa694237d53dd4fe64aba4333561d3307fbe5c57c756ba509cf53f2b64fa8c9f48d5fb0b839102ca817bdddcf3eb28f1a
   languageName: node
   linkType: hard
 
@@ -6368,23 +6455,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-techdocs@npm:0.4.1-next.1":
-  version: 0.4.1-next.1
-  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.4.1-next.1"
+"@backstage/plugin-search-backend-module-techdocs@npm:0.4.1-next.2":
+  version: 0.4.1-next.2
+  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.4.1-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.16.1"
+    "@backstage/plugin-catalog-node": "npm:1.16.3-next.0"
     "@backstage/plugin-permission-common": "npm:0.8.4"
     "@backstage/plugin-search-backend-node": "npm:1.3.9"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-techdocs-node": "npm:1.13.2-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.13.2-next.2"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/70473907f77cb9b015cf0a785290a1b66204488cce2054e8f98ea9086582a69303205bcaee3b1485f264737c119a465def0952efbd0734b8ee7b11f47f2540e3
+  checksum: 10/8f89662be96ecbaaf06fc624dbcda48c1f0de79bc92ea1224b67dc7120111b8ea84409e0734cc42b944bd61ad0babfe47dde596b898b802e55b096aa0cfba88e
   languageName: node
   linkType: hard
 
@@ -6406,11 +6493,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@npm:^2.0.1-next.1":
-  version: 2.0.1-next.1
-  resolution: "@backstage/plugin-search-backend@npm:2.0.1-next.1"
+"@backstage/plugin-search-backend@npm:^2.0.1-next.2":
+  version: 2.0.1-next.2
+  resolution: "@backstage/plugin-search-backend@npm:2.0.1-next.2"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.9.0-next.1"
+    "@backstage/backend-defaults": "npm:0.9.0-next.2"
     "@backstage/backend-openapi-utils": "npm:0.5.1"
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/config": "npm:1.3.2"
@@ -6426,7 +6513,7 @@ __metadata:
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/ac3a4f9c21f827c80597f073f2078fdea087a5e22c6c93f8eeec0e5b554e1899afaa900cd7cad9ad10a97425a0c4c1887ac451f63d313956784d52301791478b
+  checksum: 10/74d7251ea261fab880ca454d4313cd7ca1c6eb4443e02af753602843e223d83aa91b7137d829485f4e2d3837382dc4efe68a16a17b0330f01a85f431156bea28
   languageName: node
   linkType: hard
 
@@ -6440,15 +6527,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@npm:1.8.8-next.0, @backstage/plugin-search-react@npm:^1.8.8-next.0":
-  version: 1.8.8-next.0
-  resolution: "@backstage/plugin-search-react@npm:1.8.8-next.0"
+"@backstage/plugin-search-react@npm:1.8.8-next.1, @backstage/plugin-search-react@npm:^1.8.8-next.1":
+  version: 1.8.8-next.1
+  resolution: "@backstage/plugin-search-react@npm:1.8.8-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -6466,7 +6553,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/695cf26e28f902a1bafa715e3a8f47778bd33c94a1955ed145f425fa40947545c3378a16739e64f450542d91db075dd463103b60c46562db4deafc7cad45e5ac
+  checksum: 10/c0ceecda8fc575356ced8472e15456a4487ebfd4a453fe9af1e4c9f9cdad1a2d332fda3f6a9b8f3219c68a3d800521f92eb89c61162f5b031285d93d935fd0a2
   languageName: node
   linkType: hard
 
@@ -6500,18 +6587,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@npm:^1.4.25-next.1":
-  version: 1.4.25-next.1
-  resolution: "@backstage/plugin-search@npm:1.4.25-next.1"
+"@backstage/plugin-search@npm:^1.4.25-next.2":
+  version: 1.4.25-next.2
+  resolution: "@backstage/plugin-search@npm:1.4.25-next.2"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.8-next.0"
+    "@backstage/plugin-search-react": "npm:1.8.8-next.1"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -6526,7 +6613,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/56e0e3fce213f15ae15bddabddb206fd55d83da8b1d2ff6c3d2d22e660fe18a265d6bcc0a4de1dc7cba17079dc2cd3b9f4ee8ac35d564baa2d1e7250178b0797
+  checksum: 10/79845fe65a0e7719b288596e46de19a7abc9b6f6de6ab4068fe591acac6d56e32e092e77600dc4cfcc5b41d8aba75ec9ad537e8c3b6d5baeee9886fd01574565
   languageName: node
   linkType: hard
 
@@ -6567,12 +6654,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-react@npm:0.0.11":
-  version: 0.0.11
-  resolution: "@backstage/plugin-signals-react@npm:0.0.11"
+"@backstage/plugin-signals-react@npm:0.0.12-next.0":
+  version: 0.0.12-next.0
+  resolution: "@backstage/plugin-signals-react@npm:0.0.12-next.0"
   dependencies:
-    "@backstage/core-plugin-api": "npm:^1.10.5"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.4"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -6582,19 +6669,19 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9b67c36bb1db75088d24b95a4f6c26a8bca25c92a1152136e7a03d64604363f7085580190af9acc8aaa741e793119918752e3d9057e734da422273f2667fe15c
+  checksum: 10/36f024a1f4fff0c28e0cbe3e296fd79a14883434807d497436c1e0c449e9f803898713dfd3a62894a9a13b2fa0d92e3956cd94feed7701a8516b78af68a5cc3b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@npm:^0.0.18-next.0":
-  version: 0.0.18-next.0
-  resolution: "@backstage/plugin-signals@npm:0.0.18-next.0"
+"@backstage/plugin-signals@npm:^0.0.18-next.1":
+  version: 0.0.18-next.1
+  resolution: "@backstage/plugin-signals@npm:0.0.18-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-signals-react": "npm:0.0.11"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-signals-react": "npm:0.0.12-next.0"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6609,15 +6696,15 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/546480204050d268872613b5804c1c916112c3c3ef663edbdc054caa7585781967137f22bb7d5f85fa4ce925375eaada0489bf954a134e816b88e121256c29aa
+  checksum: 10/cbe2d1cefeabfdf9dbc332ed7870fbe5a281543dada085705a9212286d2f39b8a19a36398f75c461aeb40218a4b27d2ec3aadb68524021a526131ac64ef12234
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@npm:^2.0.1-next.1":
-  version: 2.0.1-next.1
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.1-next.1"
+"@backstage/plugin-techdocs-backend@npm:^2.0.1-next.2":
+  version: 2.0.1-next.2
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.1-next.2"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.9.0-next.1"
+    "@backstage/backend-defaults": "npm:0.9.0-next.2"
     "@backstage/backend-plugin-api": "npm:1.2.1"
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
@@ -6625,11 +6712,11 @@ __metadata:
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.16.3-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.16.1"
+    "@backstage/plugin-catalog-node": "npm:1.16.3-next.0"
     "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-search-backend-module-techdocs": "npm:0.4.1-next.1"
+    "@backstage/plugin-search-backend-module-techdocs": "npm:0.4.1-next.2"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-node": "npm:1.13.2-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.13.2-next.2"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
@@ -6637,7 +6724,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/704043eeaba0196d4dbf29deeda483840b6b8c1d57678f546ae308c0fda8c921b1274383ce224a0a380c7c7da04b2bba848d6c34e44f52a16fca2b386e57068a
+  checksum: 10/8914c20a66f8251c29267e1d7c137ccd89fb11bd4b52c1eafaf79e220b347bb46a58fa1276478dcbae620d73fba1aa3e204c3db050c95e38fa47e63d73ee9e58
   languageName: node
   linkType: hard
 
@@ -6648,16 +6735,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.23-next.0":
-  version: 1.1.23-next.0
-  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.23-next.0"
+"@backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.23-next.1":
+  version: 1.1.23-next.1
+  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.23-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
     "@backstage/integration": "npm:1.16.3-next.0"
-    "@backstage/integration-react": "npm:1.2.6-next.0"
-    "@backstage/plugin-techdocs-react": "npm:1.2.16-next.0"
+    "@backstage/integration-react": "npm:1.2.6-next.1"
+    "@backstage/plugin-techdocs-react": "npm:1.2.16-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@react-hookz/web": "npm:^24.0.0"
@@ -6671,13 +6758,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c5c1c06ffbb7440edaf6c0b3810eaa846003a30810f41f8206ff5254b4ab26c66d515abe4901755d8d8884822dce583a0fa8c3e5b94d592cf47f946427f16fb7
+  checksum: 10/7ca510027268afbb8530832fbb41ba5dfcd7609f2ed7db99f16238babc2e94cca76b2f0830621f8df437a74fa77f0cb3cbb89e5da2588588dbeec3309f48343e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@npm:1.13.2-next.1, @backstage/plugin-techdocs-node@npm:^1.13.2-next.1":
-  version: 1.13.2-next.1
-  resolution: "@backstage/plugin-techdocs-node@npm:1.13.2-next.1"
+"@backstage/plugin-techdocs-node@npm:1.13.2-next.2, @backstage/plugin-techdocs-node@npm:^1.13.2-next.2":
+  version: 1.13.2-next.2
+  resolution: "@backstage/plugin-techdocs-node@npm:1.13.2-next.2"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -6708,19 +6795,19 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/497ad79ac0599c82ff4e7a9e3f69db7aa688d178408153ef310ab61e7d1b3e3fd7df5071770afc92b073d93be75a372cd4182d553e3f3fbfd667ba90086123b2
+  checksum: 10/341588f40ec978179a5ea281b88c40d98b7a1c1b89fad017ee79fccb2b0b6f6b81d190668d540722aa92692516a2330dd927ba3f8eaa5fb74bdff5468f0107fe
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@npm:1.2.16-next.0, @backstage/plugin-techdocs-react@npm:^1.2.16-next.0":
-  version: 1.2.16-next.0
-  resolution: "@backstage/plugin-techdocs-react@npm:1.2.16-next.0"
+"@backstage/plugin-techdocs-react@npm:1.2.16-next.1, @backstage/plugin-techdocs-react@npm:^1.2.16-next.1":
+  version: 1.2.16-next.1
+  resolution: "@backstage/plugin-techdocs-react@npm:1.2.16-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/styles": "npm:^4.11.0"
@@ -6736,7 +6823,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2e31637361facf6f8805cbce307cf7d73f55f60ebd8733e9bbc7f9ce86a35753a41018f5640961d46d27b485dec9d2ab07045cabca9c2c39c81a48ef951fcea8
+  checksum: 10/e9e234c1319b9a3108993df17a1b37fb73a6ecc57d6a0ac08504922852521727e91bc3a55ab56647eff5f8ac0f197c6290fb0d8386a76eca4f9d370ec04d692d
   languageName: node
   linkType: hard
 
@@ -6768,27 +6855,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@npm:^1.12.5-next.1":
-  version: 1.12.5-next.1
-  resolution: "@backstage/plugin-techdocs@npm:1.12.5-next.1"
+"@backstage/plugin-techdocs@npm:^1.12.5-next.2":
+  version: 1.12.5-next.2
+  resolution: "@backstage/plugin-techdocs@npm:1.12.5-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.9.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
     "@backstage/integration": "npm:1.16.3-next.0"
-    "@backstage/integration-react": "npm:1.2.6-next.0"
-    "@backstage/plugin-auth-react": "npm:0.1.14-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
+    "@backstage/integration-react": "npm:1.2.6-next.1"
+    "@backstage/plugin-auth-react": "npm:0.1.14-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
     "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.8-next.0"
+    "@backstage/plugin-search-react": "npm:1.8.8-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-react": "npm:1.2.16-next.0"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/plugin-techdocs-react": "npm:1.2.16-next.1"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -6808,7 +6895,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/cdd75beaa8c07df50e759d92af0362e4be5bdb6747b9a014f57f59a4be8265b53959980a3a12d14035cd071c2c440cd52604d7d93ff84482fa26fe7ee578b27e
+  checksum: 10/c9edb5e29750a7f4a6abb67eae1fb1634608aefb063f11cf083911b21807c912e288bd62f5ccd58bc905f1565bc272f657c5d3eaa090fab3fc26465e0b02e8d5
   languageName: node
   linkType: hard
 
@@ -6819,21 +6906,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@npm:^0.8.21-next.1":
-  version: 0.8.21-next.1
-  resolution: "@backstage/plugin-user-settings@npm:0.8.21-next.1"
+"@backstage/plugin-user-settings@npm:^0.8.21-next.2":
+  version: 0.8.21-next.2
+  resolution: "@backstage/plugin-user-settings@npm:0.8.21-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-app-api": "npm:1.16.0"
-    "@backstage/core-compat-api": "npm:0.4.1-next.1"
-    "@backstage/core-components": "npm:0.17.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.5"
+    "@backstage/core-app-api": "npm:1.16.1-next.0"
+    "@backstage/core-compat-api": "npm:0.4.1-next.2"
+    "@backstage/core-components": "npm:0.17.1-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.16.1-next.1"
-    "@backstage/plugin-signals-react": "npm:0.0.11"
+    "@backstage/frontend-plugin-api": "npm:0.10.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.17.0-next.2"
+    "@backstage/plugin-signals-react": "npm:0.0.12-next.0"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
-    "@backstage/theme": "npm:0.6.4"
+    "@backstage/theme": "npm:0.6.5-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6848,7 +6935,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2910cfdcf52ba8beeb295d2054a287c666c7000f20a23764bec34e4dad6c4a27586ef167c98025f885c42ae1f0c838c117d5fa21bd7038b998fe778bfc4763c8
+  checksum: 10/38faeeed0a98df5bebd2a289a1c8b11a408afe0565ecbb1bfd8c583e2e310003d42fa8a43253c5164ebe36553f7c1e71a121243f2dc0a65617ea55e91f85622b
   languageName: node
   linkType: hard
 
@@ -6859,7 +6946,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/test-utils@npm:1.7.6, @backstage/test-utils@npm:^1.7.6":
+"@backstage/test-utils@npm:1.7.7-next.0":
+  version: 1.7.7-next.0
+  resolution: "@backstage/test-utils@npm:1.7.7-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-app-api": "npm:1.16.1-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6-next.0"
+    "@backstage/plugin-permission-common": "npm:0.8.4"
+    "@backstage/plugin-permission-react": "npm:0.4.33-next.0"
+    "@backstage/theme": "npm:0.6.5-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    cross-fetch: "npm:^4.0.0"
+    i18next: "npm:^22.4.15"
+    zen-observable: "npm:^0.10.0"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/8e53cef4ce2688facdaffe71f98ed35e7d0254742123eba89f9b0436b254ea984a12dad9288d3c487489cf84a406c6636370a6b98733705604bb1fd79c4734a9
+  languageName: node
+  linkType: hard
+
+"@backstage/test-utils@npm:^1.7.6":
   version: 1.7.6
   resolution: "@backstage/test-utils@npm:1.7.6"
   dependencies:
@@ -6888,9 +7004,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@npm:0.6.4, @backstage/theme@npm:^0.6.4":
-  version: 0.6.4
-  resolution: "@backstage/theme@npm:0.6.4"
+"@backstage/theme@npm:0.6.5-next.0, @backstage/theme@npm:^0.6.5-next.0":
+  version: 0.6.5-next.0
+  resolution: "@backstage/theme@npm:0.6.5-next.0"
   dependencies:
     "@emotion/react": "npm:^11.10.5"
     "@emotion/styled": "npm:^11.10.5"
@@ -6904,7 +7020,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/afa4a94a60136b48da5f3e994017e5a65248fa22942034831f83df0dffb4759e80c5aa9690606a8913e35a7d093747a3e50e56b5bdf2a58cb8f77d3d25ff8c70
+  checksum: 10/2489a5c87d358f7fdb6df05680b23e9ef89fb83b41b03f8f443e8d8d52c89c74ad4694892a660497066fdd9e6f3fe6aea4bca4c03bbb832d8ce2220f5591ada4
   languageName: node
   linkType: hard
 
@@ -6921,6 +7037,26 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
   checksum: 10/b826aabc3f483e7f0dd2285c1510c4a59797433a2884a2423b22bfce6627aefabcd258aac23edecb58edb8275a87deb4ef212646d1832721a56862d46d8b4001
+  languageName: node
+  linkType: hard
+
+"@backstage/theme@npm:^0.6.4":
+  version: 0.6.4
+  resolution: "@backstage/theme@npm:0.6.4"
+  dependencies:
+    "@emotion/react": "npm:^11.10.5"
+    "@emotion/styled": "npm:^11.10.5"
+    "@mui/material": "npm:^5.12.2"
+  peerDependencies:
+    "@material-ui/core": ^4.12.2
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/afa4a94a60136b48da5f3e994017e5a65248fa22942034831f83df0dffb4759e80c5aa9690606a8913e35a7d093747a3e50e56b5bdf2a58cb8f77d3d25ff8c70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.38.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.38.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.38.0-next.2-changelog.md)
- Upgrade Helper: [From 1.38.0-next.1 to 1.38.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.38.0-next.1&to=1.38.0-next.2)
 
Created by [Version Bump 14354506649](https://github.com/backstage/demo/actions/runs/14354506649)
 