### PR TITLE
Group Community Plugins and Fix Lock File

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,11 @@
       "matchManagers": ["npm"],
       "enabled": false,
       "matchPackageNames": ["@backstage/**"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@backstage-community/**"],
+      "groupName": "community-plugins"
     }
   ],
   "osvVulnerabilityAlerts": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4559,7 +4559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:0.10.1, @backstage/frontend-plugin-api@npm:^0.10.0, @backstage/frontend-plugin-api@npm:^0.10.1":
+"@backstage/frontend-plugin-api@npm:0.10.1, @backstage/frontend-plugin-api@npm:^0.10.1":
   version: 0.10.1
   resolution: "@backstage/frontend-plugin-api@npm:0.10.1"
   dependencies:
@@ -6496,7 +6496,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.39.0-next.0&npm=1.2.16, @backstage/plugin-techdocs-react@npm:1.2.16, @backstage/plugin-techdocs-react@npm:^1.2.15, @backstage/plugin-techdocs-react@npm:^1.2.16":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.39.0-next.0&npm=1.2.16, @backstage/plugin-techdocs-react@npm:1.2.16, @backstage/plugin-techdocs-react@npm:^1.2.16":
   version: 1.2.16
   resolution: "@backstage/plugin-techdocs-react@npm:1.2.16"
   dependencies:


### PR DESCRIPTION
Recently have been running into issue where I merge the various individual Community Plugins Renovate PRs and then somewhere in that process the `yarn.lock` files gets into a bad state. 

This PR groups the Community Plugins Renovate PRs to help void this issue and also fixes the lock file.