### PR TITLE
v1.39.0-next.1 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 2eda215600fa289952383d999f87e6fa46a333fd737a8a221a1e2326d4c95a2d694510b5e6aa5a3ef5b8927b48ce7ea1d5783efc4be18d5f87cf57d5fa16b966
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.39.0-next.0/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.39.0-next.1/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.39.0-next.0"
+  "version": "1.39.0-next.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3503,15 +3503,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.39.0-next.0&npm=1.6.1, @backstage/app-defaults@npm:^1.6.1":
-  version: 1.6.1
-  resolution: "@backstage/app-defaults@npm:1.6.1"
+"@backstage/app-defaults@backstage:^::backstage=1.39.0-next.1&npm=1.6.2-next.0, @backstage/app-defaults@npm:^1.6.2-next.0":
+  version: 1.6.2-next.0
+  resolution: "@backstage/app-defaults@npm:1.6.2-next.0"
   dependencies:
-    "@backstage/core-app-api": "npm:^1.16.1"
-    "@backstage/core-components": "npm:^0.17.1"
-    "@backstage/core-plugin-api": "npm:^1.10.6"
-    "@backstage/plugin-permission-react": "npm:^0.4.33"
-    "@backstage/theme": "npm:^0.6.5"
+    "@backstage/core-app-api": "npm:1.16.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/theme": "npm:0.6.6-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -3522,18 +3522,18 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9367d24422d3bc4738d163fe5e4b4c500741ddbfc71aaa111815c162ad9be807f96617e13043c9ebb4f98fd3ec971de8a83199d534364542ed591b9ad9f3516a
+  checksum: 10/fb755444295d6b303c6af45c320b8bc00a92f5c3d2e114a69fe0504fe6507741415e014bab533ae2d111f545ee1039c7fe6515a7c284d56b17fec8dc07d3e0ec
   languageName: node
   linkType: hard
 
-"@backstage/backend-app-api@npm:1.2.3-next.0":
-  version: 1.2.3-next.0
-  resolution: "@backstage/backend-app-api@npm:1.2.3-next.0"
+"@backstage/backend-app-api@npm:1.2.3-next.1":
+  version: 1.2.3-next.1
+  resolution: "@backstage/backend-app-api@npm:1.2.3-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-  checksum: 10/845d6d61dcbc2cd4b4c7fc17f6f0b576f717b9ab21b409679e75e0fcb9a7381e764f5bed1851f1e14042e58027e344b538ac4077caa56f487e46672272d4534e
+  checksum: 10/3d21f4169247eb5f549895feb18bfc9eb0851a883967870129fbc1a6eaacd1b30914e4ca2737361c4f19ea68ed14fdd84b52ac3c9df5c0a62f150a75b0231463
   languageName: node
   linkType: hard
 
@@ -3701,9 +3701,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.39.0-next.0&npm=0.9.1-next.0, @backstage/backend-defaults@npm:0.9.1-next.0, @backstage/backend-defaults@npm:^0.9.1-next.0":
-  version: 0.9.1-next.0
-  resolution: "@backstage/backend-defaults@npm:0.9.1-next.0"
+"@backstage/backend-defaults@backstage:^::backstage=1.39.0-next.1&npm=0.10.0-next.1, @backstage/backend-defaults@npm:0.10.0-next.1, @backstage/backend-defaults@npm:^0.10.0-next.1":
+  version: 0.10.0-next.1
+  resolution: "@backstage/backend-defaults@npm:0.10.0-next.1"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -3711,22 +3711,23 @@ __metadata:
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-app-api": "npm:1.2.3-next.0"
+    "@backstage/backend-app-api": "npm:1.2.3-next.1"
     "@backstage/backend-dev-utils": "npm:0.1.5"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/cli-node": "npm:0.2.13"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/config-loader": "npm:1.10.0"
+    "@backstage/config-loader": "npm:1.10.1-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
     "@backstage/integration-aws-node": "npm:0.1.15"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.11-next.0"
-    "@backstage/plugin-permission-node": "npm:0.9.2-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.11-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@google-cloud/storage": "npm:^7.0.0"
     "@keyv/memcache": "npm:^2.0.1"
     "@keyv/redis": "npm:^4.0.1"
+    "@keyv/valkey": "npm:^1.0.1"
     "@manypkg/get-packages": "npm:^1.1.3"
     "@octokit/rest": "npm:^19.0.3"
     "@opentelemetry/api": "npm:^1.9.0"
@@ -3775,7 +3776,7 @@ __metadata:
   peerDependenciesMeta:
     "@google-cloud/cloud-sql-connector":
       optional: true
-  checksum: 10/405a2291a8138eb936b59f5d12538af5c8f2a4ab312c3d882e470a2799e4c958bc78b6779764a4679c3c44421651644bf69e695960e916c1c229938e80f3c885
+  checksum: 10/72d4a7db1fc19cf9724bdf8248200a9b2e40ced70a83492cf0ce334c5839f33c81a67bac96720a2fcba0017633cd3a3a3c3c91bc0ff2916b5dcbc77a92958dc1
   languageName: node
   linkType: hard
 
@@ -3864,12 +3865,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-openapi-utils@npm:0.5.3-next.0":
-  version: 0.5.3-next.0
-  resolution: "@backstage/backend-openapi-utils@npm:0.5.3-next.0"
+"@backstage/backend-openapi-utils@npm:0.5.3-next.1":
+  version: 0.5.3-next.1
+  resolution: "@backstage/backend-openapi-utils@npm:0.5.3-next.1"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/types": "npm:1.2.1"
     "@types/express": "npm:^4.17.6"
@@ -3884,7 +3885,7 @@ __metadata:
     mockttp: "npm:^3.13.0"
     openapi-merge: "npm:^1.3.2"
     openapi3-ts: "npm:^3.1.2"
-  checksum: 10/85f37c0cb65402060c7e766ea177b50f5b87ae39a1d7527e2fa0267fadffb70c419c64048ecf35ba206bd963d6c070e70fc02f54fb195a8457df1f59f9235c18
+  checksum: 10/43351a25897c4f1e3f0dce9d461810bc0055e83ca78b514f76ded68435bff56e8b20899555d39ee9ca0d7f247f2eddf0791c9f0d34ec940e5b56f8b402d3556c
   languageName: node
   linkType: hard
 
@@ -3912,22 +3913,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.39.0-next.0&npm=1.3.1-next.0, @backstage/backend-plugin-api@npm:1.3.1-next.0, @backstage/backend-plugin-api@npm:^1.3.1-next.0":
-  version: 1.3.1-next.0
-  resolution: "@backstage/backend-plugin-api@npm:1.3.1-next.0"
+"@backstage/backend-plugin-api@backstage:^::backstage=1.39.0-next.1&npm=1.3.1-next.1, @backstage/backend-plugin-api@npm:1.3.1-next.1, @backstage/backend-plugin-api@npm:^1.3.1-next.1":
+  version: 1.3.1-next.1
+  resolution: "@backstage/backend-plugin-api@npm:1.3.1-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.1.15"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.9.2-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@types/express": "npm:^4.17.6"
     "@types/luxon": "npm:^3.0.0"
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
-  checksum: 10/e583517db54956e16bb94b013cdbf66d1110ae60995edb1adc10542773caf1fe25027573097bf406c8cb2d3f68bff599eec62511dd60dddadd34988efb28a19a
+  checksum: 10/8f675ed9ed1bdee95bf70703f25fb3cecb749ea76d5ada00b6f3825cb3db4a69d58251be72cede9c6125d24e314ae8c207426b9c3f3f9d6839f1c582213aa54d
   languageName: node
   linkType: hard
 
@@ -3969,9 +3970,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/canon@backstage:^::backstage=1.39.0-next.0&npm=0.3.2-next.0, @backstage/canon@npm:^0.3.2-next.0":
-  version: 0.3.2-next.0
-  resolution: "@backstage/canon@npm:0.3.2-next.0"
+"@backstage/canon@backstage:^::backstage=1.39.0-next.1&npm=0.4.0-next.1, @backstage/canon@npm:^0.4.0-next.1":
+  version: 0.4.0-next.1
+  resolution: "@backstage/canon@npm:0.4.0-next.1"
   dependencies:
     "@base-ui-components/react": "npm:^1.0.0-alpha.7"
     "@remixicon/react": "npm:^4.6.0"
@@ -3985,7 +3986,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/82030206a4265d02b856e98e7d4a8b0e74fd3d36f255024d4a820e4705a2029db36f0a404ebe87f7e80b7e03715f349ed23464546e9a0b3954a5c8ff636c36d0
+  checksum: 10/fadb1e1de7fd4ed8422206ea9dd24812c471c24301128a6285acc0317aca212718f1f9ed7206fe470cde1a3778bd5a51caac86b9e9a8c5b3ebc11f46de122c51
   languageName: node
   linkType: hard
 
@@ -4013,7 +4014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.39.0-next.0&npm=1.7.3, @backstage/catalog-model@npm:1.7.3, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.3":
+"@backstage/catalog-model@backstage:^::backstage=1.39.0-next.1&npm=1.7.3, @backstage/catalog-model@npm:1.7.3, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.3":
   version: 1.7.3
   resolution: "@backstage/catalog-model@npm:1.7.3"
   dependencies:
@@ -4048,18 +4049,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.39.0-next.0&npm=0.32.1-next.0, @backstage/cli@npm:^0.32.1-next.0":
-  version: 0.32.1-next.0
-  resolution: "@backstage/cli@npm:0.32.1-next.0"
+"@backstage/cli@backstage:^::backstage=1.39.0-next.1&npm=0.32.1-next.1, @backstage/cli@npm:^0.32.1-next.1":
+  version: 0.32.1-next.1
+  resolution: "@backstage/cli@npm:0.32.1-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/cli-common": "npm:0.1.15"
     "@backstage/cli-node": "npm:0.2.13"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/config-loader": "npm:1.10.0"
+    "@backstage/config-loader": "npm:1.10.1-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/eslint-plugin": "npm:0.1.10"
-    "@backstage/integration": "npm:1.16.4-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
     "@backstage/release-manifests": "npm:0.0.12"
     "@backstage/types": "npm:1.2.1"
     "@manypkg/get-packages": "npm:^1.1.3"
@@ -4067,7 +4068,7 @@ __metadata:
     "@octokit/graphql": "npm:^5.0.0"
     "@octokit/graphql-schema": "npm:^13.7.0"
     "@octokit/oauth-app": "npm:^4.2.0"
-    "@octokit/request": "npm:^6.0.0"
+    "@octokit/request": "npm:^8.0.0"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.7"
     "@rollup/plugin-commonjs": "npm:^26.0.0"
     "@rollup/plugin-json": "npm:^6.0.0"
@@ -4180,11 +4181,34 @@ __metadata:
   bin:
     backstage-cli: bin/backstage-cli
     backstage-cli-alpha: bin/backstage-cli-alpha
-  checksum: 10/b0917c285d0bb226b5d06ef8f17dbf451eb39ec48e6c57660da0a8f2b5daeac5e98ebc8849e9d85da69d298db88c1c6c65626ca7704730e4c12ca0c1ba7183d2
+  checksum: 10/1ab5a92043f2a183fa55bdd2956a2b2f378cc41b14da5d6a7a64694afca69e8b940596ea00de62ca9be83822ca049f98e8c3e7d419e680e923bb83a5913c8ca1
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:1.10.0, @backstage/config-loader@npm:^1.10.0, @backstage/config-loader@npm:^1.8.1, @backstage/config-loader@npm:^1.9.1":
+"@backstage/config-loader@npm:1.10.1-next.0":
+  version: 1.10.1-next.0
+  resolution: "@backstage/config-loader@npm:1.10.1-next.0"
+  dependencies:
+    "@backstage/cli-common": "npm:0.1.15"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.1"
+    "@types/json-schema": "npm:^7.0.6"
+    ajv: "npm:^8.10.0"
+    chokidar: "npm:^3.5.2"
+    fs-extra: "npm:^11.2.0"
+    json-schema: "npm:^0.4.0"
+    json-schema-merge-allof: "npm:^0.8.1"
+    json-schema-traverse: "npm:^1.0.0"
+    lodash: "npm:^4.17.21"
+    minimist: "npm:^1.2.5"
+    typescript-json-schema: "npm:^0.65.0"
+    yaml: "npm:^2.0.0"
+  checksum: 10/4e2ae6a16cf4f698874ea590ee0c257bd91de01c6f254d747e8556fbb1efe8b05a11c85d71bde35402f97cf44382e76e712dc624fd0197498f99577fe67edae4
+  languageName: node
+  linkType: hard
+
+"@backstage/config-loader@npm:^1.10.0, @backstage/config-loader@npm:^1.8.1, @backstage/config-loader@npm:^1.9.1":
   version: 1.10.0
   resolution: "@backstage/config-loader@npm:1.10.0"
   dependencies:
@@ -4207,7 +4231,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.39.0-next.0&npm=1.3.2, @backstage/config@npm:1.3.2, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2":
+"@backstage/config@backstage:^::backstage=1.39.0-next.1&npm=1.3.2, @backstage/config@npm:1.3.2, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2":
   version: 1.3.2
   resolution: "@backstage/config@npm:1.3.2"
   dependencies:
@@ -4218,7 +4242,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.39.0-next.0&npm=1.16.1, @backstage/core-app-api@npm:1.16.1, @backstage/core-app-api@npm:^1.16.1":
+"@backstage/core-app-api@backstage:^::backstage=1.39.0-next.1&npm=1.16.1, @backstage/core-app-api@npm:1.16.1, @backstage/core-app-api@npm:^1.16.1":
   version: 1.16.1
   resolution: "@backstage/core-app-api@npm:1.16.1"
   dependencies:
@@ -4246,13 +4270,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@npm:0.4.2-next.0":
-  version: 0.4.2-next.0
-  resolution: "@backstage/core-compat-api@npm:0.4.2-next.0"
+"@backstage/core-compat-api@npm:0.4.2-next.1":
+  version: 0.4.2-next.1
+  resolution: "@backstage/core-compat-api@npm:0.4.2-next.1"
   dependencies:
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
     "@backstage/version-bridge": "npm:1.0.11"
     lodash: "npm:^4.17.21"
   peerDependencies:
@@ -4263,7 +4287,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/43980eb622698e54fbd02f3f452c7ed1133558dcf020756e7b0f735b6bbe3ba8e7222618c38404aa5c4db0780266f4899bc3cecf6b35279c80c31ccf90ee6696
+  checksum: 10/8d7a6b451b7647bfee8f1601f477b2f971bfa4fcfc13a666fed4b09e19698e5e2ead373dcbd5fa03079cfe4f8f05c9a4ea4d9bdd435a0e146460a254f716f6fa
   languageName: node
   linkType: hard
 
@@ -4304,7 +4328,110 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.39.0-next.0&npm=0.17.1, @backstage/core-components@npm:0.17.1, @backstage/core-components@npm:^0.17.0, @backstage/core-components@npm:^0.17.1":
+"@backstage/core-components@backstage:^::backstage=1.39.0-next.1&npm=0.17.2-next.0, @backstage/core-components@npm:0.17.2-next.0, @backstage/core-components@npm:^0.17.2-next.0":
+  version: 0.17.2-next.0
+  resolution: "@backstage/core-components@npm:0.17.2-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/theme": "npm:0.6.6-next.0"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.1.3"
+    linkifyjs: "npm:4.1.3"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/f7ced2165d2bc8bc498dacd6c0300b83f989c4e6c4652b393e217b5aac51791ab874a25be07b10ac71efbf4ad9bcadfcccb468f7f94778cfdd42c9182efedf35
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:^0.14.10":
+  version: 0.14.10
+  resolution: "@backstage/core-components@npm:0.14.10"
+  dependencies:
+    "@backstage/config": "npm:^1.2.0"
+    "@backstage/core-plugin-api": "npm:^1.9.3"
+    "@backstage/errors": "npm:^1.2.4"
+    "@backstage/theme": "npm:^0.5.6"
+    "@backstage/version-bridge": "npm:^1.0.8"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    dagre: "npm:^0.8.5"
+    linkify-react: "npm:4.1.3"
+    linkifyjs: "npm:4.1.3"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  checksum: 10/870f4c58e490c13b043f855c101f23e0155497a755677e84b9e6accf0f829343dc5f702de6382fdaf73a34f7540562f0842393feb7e83e498483256c3425da8c
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:^0.17.0, @backstage/core-components@npm:^0.17.1":
   version: 0.17.1
   resolution: "@backstage/core-components@npm:0.17.1"
   dependencies:
@@ -4358,56 +4485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:^0.14.10":
-  version: 0.14.10
-  resolution: "@backstage/core-components@npm:0.14.10"
-  dependencies:
-    "@backstage/config": "npm:^1.2.0"
-    "@backstage/core-plugin-api": "npm:^1.9.3"
-    "@backstage/errors": "npm:^1.2.4"
-    "@backstage/theme": "npm:^0.5.6"
-    "@backstage/version-bridge": "npm:^1.0.8"
-    "@date-io/core": "npm:^1.3.13"
-    "@material-table/core": "npm:^3.1.0"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@react-hookz/web": "npm:^24.0.0"
-    "@types/react": "npm:^16.13.1 || ^17.0.0 || ^18.0.0"
-    "@types/react-sparklines": "npm:^1.7.0"
-    ansi-regex: "npm:^6.0.1"
-    classnames: "npm:^2.2.6"
-    d3-selection: "npm:^3.0.0"
-    d3-shape: "npm:^3.0.0"
-    d3-zoom: "npm:^3.0.0"
-    dagre: "npm:^0.8.5"
-    linkify-react: "npm:4.1.3"
-    linkifyjs: "npm:4.1.3"
-    lodash: "npm:^4.17.21"
-    pluralize: "npm:^8.0.0"
-    qs: "npm:^6.9.4"
-    rc-progress: "npm:3.5.1"
-    react-helmet: "npm:6.1.0"
-    react-hook-form: "npm:^7.12.2"
-    react-idle-timer: "npm:5.7.2"
-    react-markdown: "npm:^8.0.0"
-    react-sparklines: "npm:^1.7.0"
-    react-syntax-highlighter: "npm:^15.4.5"
-    react-use: "npm:^17.3.2"
-    react-virtualized-auto-sizer: "npm:^1.0.11"
-    react-window: "npm:^1.8.6"
-    remark-gfm: "npm:^3.0.1"
-    zen-observable: "npm:^0.10.0"
-    zod: "npm:^3.22.4"
-  peerDependencies:
-    react: ^16.13.1 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
-    react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 10/870f4c58e490c13b043f855c101f23e0155497a755677e84b9e6accf0f829343dc5f702de6382fdaf73a34f7540562f0842393feb7e83e498483256c3425da8c
-  languageName: node
-  linkType: hard
-
-"@backstage/core-plugin-api@backstage:^::backstage=1.39.0-next.0&npm=1.10.6, @backstage/core-plugin-api@npm:1.10.6, @backstage/core-plugin-api@npm:^1.10.5, @backstage/core-plugin-api@npm:^1.10.6, @backstage/core-plugin-api@npm:^1.9.3":
+"@backstage/core-plugin-api@backstage:^::backstage=1.39.0-next.1&npm=1.10.6, @backstage/core-plugin-api@npm:1.10.6, @backstage/core-plugin-api@npm:^1.10.5, @backstage/core-plugin-api@npm:^1.10.6, @backstage/core-plugin-api@npm:^1.9.3":
   version: 1.10.6
   resolution: "@backstage/core-plugin-api@npm:1.10.6"
   dependencies:
@@ -4428,7 +4506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.39.0-next.0&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.39.0-next.1&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -4463,16 +4541,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-app-api@npm:0.11.2-next.0":
-  version: 0.11.2-next.0
-  resolution: "@backstage/frontend-app-api@npm:0.11.2-next.0"
+"@backstage/frontend-app-api@npm:0.11.2-next.1":
+  version: 0.11.2-next.1
+  resolution: "@backstage/frontend-app-api@npm:0.11.2-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
     "@backstage/core-app-api": "npm:1.16.1"
     "@backstage/core-plugin-api": "npm:1.10.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-defaults": "npm:0.2.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
+    "@backstage/frontend-defaults": "npm:0.2.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     lodash: "npm:^4.17.21"
@@ -4485,7 +4563,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/cf58a141487b9931be72b3cead68ffa8d55a994b9e1007bba23929586a4a449210c7514f3d6cc69b86f8f1aad21e5e4b22c853985ac279b5098887419d73ab1b
+  checksum: 10/d087ca981b061adfb491f3e8e3bce4a9e48ad27d8adcd6c99ab9299c44b686baa075335854ee1e4263bb3ea28166474bd0ce66caed190ed4672ba7932bd8436d
   languageName: node
   linkType: hard
 
@@ -4515,15 +4593,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@npm:0.2.2-next.0":
-  version: 0.2.2-next.0
-  resolution: "@backstage/frontend-defaults@npm:0.2.2-next.0"
+"@backstage/frontend-defaults@npm:0.2.2-next.1":
+  version: 0.2.2-next.1
+  resolution: "@backstage/frontend-defaults@npm:0.2.2-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-app-api": "npm:0.11.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-app": "npm:0.1.9-next.0"
+    "@backstage/frontend-app-api": "npm:0.11.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-app": "npm:0.1.9-next.1"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -4533,7 +4611,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/da6d18999b6b8e3081cd3934ca761d80f1f9205b6f3b0376d2b6e5f75856574ff5ace7981447cba196a3638449e4ad645227ccd50014f6399a945bf2eac145b3
+  checksum: 10/0ae95f01a2d9b2ceef693caa389c5b4e4473e3fb5c190c16bcfea46a221640728f8ec11b481dc6d8cc665f34cb0fd02239c35a7e8e86f36947a6975452477164
   languageName: node
   linkType: hard
 
@@ -4559,7 +4637,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:0.10.1, @backstage/frontend-plugin-api@npm:^0.10.1":
+"@backstage/frontend-plugin-api@npm:0.10.2-next.0":
+  version: 0.10.2-next.0
+  resolution: "@backstage/frontend-plugin-api@npm:0.10.2-next.0"
+  dependencies:
+    "@backstage/core-components": "npm:0.17.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.4"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.21.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/f083de03eef1bfa78bc6cf2595257cf0ba96b8fc5f540d7d73348f874c06450feaad5c0de534669222a39fd2f6ffc3dd8bcbb3d6b5dffcf7de8631bbc0f50a9b
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:^0.10.1":
   version: 0.10.1
   resolution: "@backstage/frontend-plugin-api@npm:0.10.1"
   dependencies:
@@ -4603,15 +4705,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-test-utils@npm:0.3.2-next.0":
-  version: 0.3.2-next.0
-  resolution: "@backstage/frontend-test-utils@npm:0.3.2-next.0"
+"@backstage/frontend-test-utils@npm:0.3.2-next.1":
+  version: 0.3.2-next.1
+  resolution: "@backstage/frontend-test-utils@npm:0.3.2-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/frontend-app-api": "npm:0.11.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-app": "npm:0.1.9-next.0"
-    "@backstage/test-utils": "npm:1.7.7"
+    "@backstage/frontend-app-api": "npm:0.11.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-app": "npm:0.1.9-next.1"
+    "@backstage/test-utils": "npm:1.7.8-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     zod: "npm:^3.22.4"
@@ -4624,7 +4726,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3e0fab9b90540c599477e2af350cf2676cd3c9f95af1aa0c99b5066691a8a6d025547cea1d9e0109e7abb222eeef90bd538f54159d39a258a166860aae5bc898
+  checksum: 10/9e17b617c8005a18735bc09ad0bc5cc1cff6bdfbb498e14251eb3da2906f7b0bf5a8b25f073eef78ada7f3c9b56702fb5763e37d9e0dda086f797a36f7afec8b
   languageName: node
   linkType: hard
 
@@ -4668,13 +4770,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.39.0-next.0&npm=1.2.7-next.0, @backstage/integration-react@npm:1.2.7-next.0, @backstage/integration-react@npm:^1.2.7-next.0":
-  version: 1.2.7-next.0
-  resolution: "@backstage/integration-react@npm:1.2.7-next.0"
+"@backstage/integration-react@backstage:^::backstage=1.39.0-next.1&npm=1.2.7-next.1, @backstage/integration-react@npm:1.2.7-next.1, @backstage/integration-react@npm:^1.2.7-next.1":
+  version: 1.2.7-next.1
+  resolution: "@backstage/integration-react@npm:1.2.7-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/integration": "npm:1.16.4-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -4685,7 +4787,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3ae063f07b953405d4c9661ff7dfa584dd922d41ca4b83d5a44a33cbe5d92b5c3c4a42368aed3e804e059212ccbf2bbb7337a06f2158c2e8729a17da9d268f2b
+  checksum: 10/1874bf444124811db79d492bac2a60e43a22fe70edfb74fcf407e73d17bd6740304b744da31f9b835a41d52728c9c238a54c46bbc4de3ed49a4000c56fbe81c7
   languageName: node
   linkType: hard
 
@@ -4710,9 +4812,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration@backstage:^::backstage=1.39.0-next.0&npm=1.16.4-next.0, @backstage/integration@npm:1.16.4-next.0, @backstage/integration@npm:^1.16.4-next.0":
-  version: 1.16.4-next.0
-  resolution: "@backstage/integration@npm:1.16.4-next.0"
+"@backstage/integration@backstage:^::backstage=1.39.0-next.1&npm=1.16.4-next.1, @backstage/integration@npm:1.16.4-next.1, @backstage/integration@npm:^1.16.4-next.1":
+  version: 1.16.4-next.1
+  resolution: "@backstage/integration@npm:1.16.4-next.1"
   dependencies:
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
@@ -4724,7 +4826,7 @@ __metadata:
     git-url-parse: "npm:^15.0.0"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-  checksum: 10/169eff82e59ecefda3c3102ff1d444340b7f093fe07719f497e06d19f8611d0183568d1bcf8570c71532a8be8d10d56bf853c2e95e9c4c5a75f3a754947fdc49
+  checksum: 10/d515c79f54a664347937d2b2f297308b7f4b68e959a45f92db5c477ffd989a81b5c351c254a9ae57059705fd4153d857e8d7a9f9d33e37696e43c2e38fa1dd24
   languageName: node
   linkType: hard
 
@@ -4746,20 +4848,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.39.0-next.0&npm=0.12.7-next.0, @backstage/plugin-api-docs@npm:^0.12.7-next.0":
-  version: 0.12.7-next.0
-  resolution: "@backstage/plugin-api-docs@npm:0.12.7-next.0"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.39.0-next.1&npm=0.12.7-next.1, @backstage/plugin-api-docs@npm:^0.12.7-next.1":
+  version: 0.12.7-next.1
+  resolution: "@backstage/plugin-api-docs@npm:0.12.7-next.1"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-catalog": "npm:1.29.1-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.33"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-catalog": "npm:1.29.1-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4778,20 +4880,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fc0679119b2d7a68590d559c254ae8c055afd5ce1e658fdc2a4736ad01cbd0771a837b8d282a683be384307d0a2165c87ae373c535eb242532216d81f747e51d
+  checksum: 10/d642aea3b51101abf99a8268211734848a3b09c0cd190330a9768b320603210e9711e5984982424fca345dcf16fc7684c98e9e9e85d483c8cd0ddc4125d13e41
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.39.0-next.0&npm=0.5.2-next.0, @backstage/plugin-app-backend@npm:^0.5.2-next.0":
-  version: 0.5.2-next.0
-  resolution: "@backstage/plugin-app-backend@npm:0.5.2-next.0"
+"@backstage/plugin-app-backend@backstage:^::backstage=1.39.0-next.1&npm=0.5.2-next.1, @backstage/plugin-app-backend@npm:^0.5.2-next.1":
+  version: 0.5.2-next.1
+  resolution: "@backstage/plugin-app-backend@npm:0.5.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/config-loader": "npm:1.10.0"
+    "@backstage/config-loader": "npm:1.10.1-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-app-node": "npm:0.1.33-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
+    "@backstage/plugin-app-node": "npm:0.1.33-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
     "@backstage/types": "npm:1.2.1"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -4802,33 +4904,33 @@ __metadata:
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     yn: "npm:^4.0.0"
-  checksum: 10/b0f47b31214245a5207d0189e708c183c1e4b285afc87108b3d1b50019b25d176861ff7dcdd87cbeae92ddff7c3318be7a16718643bcf0125f1f77aab742cc0b
+  checksum: 10/7e19ac5d7798127bbb862e0166411bfe0cad4815e2996eb41741f58cc504d6957262c734f522e20ced5c3793b6707cff3230da199771ad9d6d0a41990960a901
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-node@npm:0.1.33-next.0":
-  version: 0.1.33-next.0
-  resolution: "@backstage/plugin-app-node@npm:0.1.33-next.0"
+"@backstage/plugin-app-node@npm:0.1.33-next.1":
+  version: 0.1.33-next.1
+  resolution: "@backstage/plugin-app-node@npm:0.1.33-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
-    "@backstage/config-loader": "npm:1.10.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
+    "@backstage/config-loader": "npm:1.10.1-next.0"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     fs-extra: "npm:^11.2.0"
-  checksum: 10/9a4af2b80fa33bec3fb392e022c17efe144b3bf3fc05e1d6e38c09655aea8b32a3716babe310a63c98d32530bea3de64554881b21a686866691390b1bb54ed8c
+  checksum: 10/5c910cb179b7ae6b2fad9bd8435343e8b8652d81cb285e9cca64ca36025c6c8b9d38da87079314fbf6cd5e1459c4c118154b2f4afe1b77184c889ed32bb8df71
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@npm:0.1.9-next.0":
-  version: 0.1.9-next.0
-  resolution: "@backstage/plugin-app@npm:0.1.9-next.0"
+"@backstage/plugin-app@npm:0.1.9-next.1":
+  version: 0.1.9-next.1
+  resolution: "@backstage/plugin-app@npm:0.1.9-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/integration-react": "npm:1.2.7-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.33"
-    "@backstage/theme": "npm:0.6.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/integration-react": "npm:1.2.7-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4842,7 +4944,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4db24f7ab6c076679d55da6d7d8918bd5083b831e6c6bc32f74d3730f04bcc6703ef424cd1e2043892a11755d776ed87e3415ca475c2104b992b00ba2c4b22b4
+  checksum: 10/402cb9fe2475fd8e4257f2e76c1be93055453ad0e03cc9bab07f029706343797c8485b9411db7797320b326a268b365dd5243c1f36a31c62c47f35831627d06d
   languageName: node
   linkType: hard
 
@@ -4873,40 +4975,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.39.0-next.0&npm=0.3.3-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.3-next.0":
-  version: 0.3.3-next.0
-  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.3-next.0"
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.39.0-next.1&npm=0.3.3-next.1, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.3-next.1":
+  version: 0.3.3-next.1
+  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.3-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
     passport-github2: "npm:^0.1.12"
-  checksum: 10/3174f69ce9507a267841269ee61e280021e7322a73c1cc716ce45b2754b7dd23c88fe6d3dd5dc1a9df302eb270dea2960c8cc6bdf95ee8a7df64af23bcd8e697
+  checksum: 10/29a5418e6677d7fc8825846c7eedc9a6388b3328ce4532e6d85dcd73fee2f1ae5e9561646d1892f2fcfadca83de595ddab00d7b7213962ee08fb87df1ff3bac2
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.39.0-next.0&npm=0.2.8-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.8-next.0":
-  version: 0.2.8-next.0
-  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.8-next.0"
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.39.0-next.1&npm=0.2.8-next.1, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.8-next.1":
+  version: 0.2.8-next.1
+  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.8-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
     passport-oauth2: "npm:^1.7.0"
-  checksum: 10/bc90c80907c21ec27597604cf43dbf78eac2b62062bfd059f63b86c30904016c68e309f59b5e1e42f6d4febdff268818c942e201eacfb51561d4dc481de00143
+  checksum: 10/973c3edcdae4bb040c303abf56025e18ba57b0fae9769bfd364ce2d63405bda752780e8808b32ff272113aefbbbf5c53e20f3d5fab9680ff4b141d53e5d509a8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.39.0-next.0&npm=0.25.0-next.0, @backstage/plugin-auth-backend@npm:^0.25.0-next.0":
-  version: 0.25.0-next.0
-  resolution: "@backstage/plugin-auth-backend@npm:0.25.0-next.0"
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.39.0-next.1&npm=0.25.0-next.1, @backstage/plugin-auth-backend@npm:^0.25.0-next.1":
+  version: 0.25.0-next.1
+  resolution: "@backstage/plugin-auth-backend@npm:0.25.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.17.0-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@google-cloud/firestore": "npm:^7.0.0"
     connect-session-knex: "npm:^4.0.0"
@@ -4921,15 +5023,15 @@ __metadata:
     minimatch: "npm:^9.0.0"
     passport: "npm:^0.7.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/03939209aea7f27e8428ce3697c9cbe1a08de4936f78e3ea12691f83d659f0289d99f4994557421b7e81f14b228e5eae8534264270169ec70cdeeed04ed3bac2
+  checksum: 10/cca8bf707fadb7617779d6b7a6adc78ae089623c244ccff97bae7e4e1e12261adf1bab6ac8364bb4cd6761b94951d6beff0d030c02d41a103ea7ddb2fc3f6728
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:0.6.3-next.0":
-  version: 0.6.3-next.0
-  resolution: "@backstage/plugin-auth-node@npm:0.6.3-next.0"
+"@backstage/plugin-auth-node@npm:0.6.3-next.1":
+  version: 0.6.3-next.1
+  resolution: "@backstage/plugin-auth-node@npm:0.6.3-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
@@ -4944,7 +5046,7 @@ __metadata:
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.21.4"
     zod-validation-error: "npm:^3.4.0"
-  checksum: 10/ce15f6ae85e4a2d8679c3be2e01376ddd35af32a600eb66a27291adca448f9e0aecbbcf917142134e66b8814ac5befb5d708cb9496e44c0da9861ef32f65297c
+  checksum: 10/7221312e2b443798ddd68f6512c8d792f37df5742c3003bb2845e83fa1541322579c1b648a85a01266e3c6170e4cbb0403478b256207852f14674b8d626bcf91
   languageName: node
   linkType: hard
 
@@ -5021,13 +5123,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-react@npm:0.1.14":
-  version: 0.1.14
-  resolution: "@backstage/plugin-auth-react@npm:0.1.14"
+"@backstage/plugin-auth-react@npm:0.1.15-next.0":
+  version: 0.1.15-next.0
+  resolution: "@backstage/plugin-auth-react@npm:0.1.15-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.17.1"
-    "@backstage/core-plugin-api": "npm:^1.10.6"
-    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/core-components": "npm:0.17.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/errors": "npm:1.2.7"
     "@material-ui/core": "npm:^4.9.13"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
@@ -5038,66 +5140,62 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e423779594392fc9fddece064697e5e6a9fce1f9fce1872e7ac9280f422c84ee11db912d7f1b7c1d75384eab8f188a90e7e05f05d5fd05d46c65d27249034a25
+  checksum: 10/7693638ef87ad01cd3bfc8f5c3700c084fd16b87c132e755a685ab5d7c21b51909242e7678dfc4e05d63da56c744de247c5a22fee947146ef5736f0d3579e673
   languageName: node
   linkType: hard
 
-"@backstage/plugin-bitbucket-cloud-common@npm:0.3.0-next.0":
-  version: 0.3.0-next.0
-  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.3.0-next.0"
+"@backstage/plugin-bitbucket-cloud-common@npm:0.3.0-next.1":
+  version: 0.3.0-next.1
+  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.3.0-next.1"
   dependencies:
-    "@backstage/integration": "npm:1.16.4-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
     cross-fetch: "npm:^4.0.0"
-  checksum: 10/5e6103f8cb00c38b15beef9fbb740ed5acd10009f311041d97a7ca4a6a6696ac3b7f0bd0bf7681356e0f80a867509b99db1d7c8210fb3160b5049a1cfa28758a
+  checksum: 10/ef8ff7c767caf048747d3f7ec105c0c6b3d5a0977ff89d80fc7c99806bfebd8c10c3a97758b83392ca54386938b38140774d3440a1278300b14a58de304f1460
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.39.0-next.0&npm=0.1.10-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.10-next.0":
-  version: 0.1.10-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.10-next.0"
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.39.0-next.1&npm=0.1.10-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.10-next.1":
+  version: 0.1.10-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.10-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
-    "@backstage/plugin-catalog-backend": "npm:1.32.2-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.11-next.0"
-  checksum: 10/bbd0a99b43be4ff3b0c14a41da32f192f257a9cb625388e899e19340a80bc13455d14c3b937b411e0ff948099be09f9cd264c8794883e5bde1eee1071b0e73a9
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
+    "@backstage/plugin-catalog-backend": "npm:2.0.0-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.11-next.1"
+  checksum: 10/6495f0aef14e74a790097a2cd78d39961096438036e17293f59f06968d6c88ca1c7feb3214a2db4f1300d53d0a7b696b0d49ab64dc658822d47b70a48f46db4f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.39.0-next.0&npm=0.2.8-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.8-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.8-next.0":
-  version: 0.2.8-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.8-next.0"
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.39.0-next.1&npm=0.2.8-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.8-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.8-next.1":
+  version: 0.2.8-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.8-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.17.0-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.10"
-  checksum: 10/afa030d942c7698ee51355bda5c66e6a1f0382233902de71d2e44150303996efa2ac24c64581597140207f20989ddd04b1319b9965acba52808afe10ac68ee96
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
+  checksum: 10/7fbfc7fdfef9d42c4110e689faaed6dbb67b92271d8d9c735d4ed3b24e233b0ab08540ee23c6d164184276f5cbb097d4274cd7156273e27cfe3ae47bf5235e9c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.39.0-next.0&npm=1.32.2-next.0, @backstage/plugin-catalog-backend@npm:1.32.2-next.0, @backstage/plugin-catalog-backend@npm:^1.32.2-next.0":
-  version: 1.32.2-next.0
-  resolution: "@backstage/plugin-catalog-backend@npm:1.32.2-next.0"
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.39.0-next.1&npm=2.0.0-next.1, @backstage/plugin-catalog-backend@npm:2.0.0-next.1, @backstage/plugin-catalog-backend@npm:^2.0.0-next.1":
+  version: 2.0.0-next.1
+  resolution: "@backstage/plugin-catalog-backend@npm:2.0.0-next.1"
   dependencies:
-    "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-openapi-utils": "npm:0.5.3-next.0"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-openapi-utils": "npm:0.5.3-next.1"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.17.0-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.11-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.9.2-next.0"
-    "@backstage/plugin-search-backend-module-catalog": "npm:0.3.4-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.17"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.11-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@opentelemetry/api": "npm:^1.9.0"
-    "@types/express": "npm:^4.17.6"
     codeowners-utils: "npm:^1.0.2"
     core-js: "npm:^3.6.5"
     express: "npm:^4.17.1"
@@ -5115,11 +5213,22 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/d7f7fb8007c3f12b00839fdce596669591156aaabb4c23acba95a2b4a95e882d7994b58eba23ff9ae1f20103180b70c18991b29efa5371eb69771fdad63300da
+  checksum: 10/d532cbf9f5a8d07474ecc6513081c7cd2cb9faab6a5f47fff20fd889f9b886fa83a8a9474c2c42cfb142b4ae58d46da3f169835c26be1fefb2efe9e1d40f0792
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@npm:1.1.3, @backstage/plugin-catalog-common@npm:^1.1.3":
+"@backstage/plugin-catalog-common@npm:1.1.4-next.0":
+  version: 1.1.4-next.0
+  resolution: "@backstage/plugin-catalog-common@npm:1.1.4-next.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
+  checksum: 10/f1eedfe1a2d3740fdfd943ed660bdc95c2e7832436307c749f0eb06ec6bb6ea77a65065f3172933216b085c68a084d748d554d753fee13f5899904c61a3b78d8
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-common@npm:^1.1.3":
   version: 1.1.3
   resolution: "@backstage/plugin-catalog-common@npm:1.1.3"
   dependencies:
@@ -5130,17 +5239,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.39.0-next.0&npm=0.4.19-next.0, @backstage/plugin-catalog-graph@npm:^0.4.19-next.0":
-  version: 0.4.19-next.0
-  resolution: "@backstage/plugin-catalog-graph@npm:0.4.19-next.0"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.39.0-next.1&npm=0.4.19-next.1, @backstage/plugin-catalog-graph@npm:^0.4.19-next.1":
+  version: 0.4.19-next.1
+  resolution: "@backstage/plugin-catalog-graph@npm:0.4.19-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5158,23 +5267,25 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/14a23f5c3762ad6c01347a35cc41dbb86f37bf31178267ea987e742200537f953bc702caec75ddbfec890fa39b5782017db35f2fa85dfb28f5481797b6a425d3
+  checksum: 10/9a4b7569fc69a632da0778b364026083d477512991d381cd7cf090c80cc041c1a0dcdcfb0cfc42162f842761d13a580f1746344b2ec22949aed7c9e06a1cfca9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.39.0-next.0&npm=1.17.0-next.0, @backstage/plugin-catalog-node@npm:1.17.0-next.0, @backstage/plugin-catalog-node@npm:^1.17.0-next.0":
-  version: 1.17.0-next.0
-  resolution: "@backstage/plugin-catalog-node@npm:1.17.0-next.0"
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.39.0-next.1&npm=1.17.0-next.1, @backstage/plugin-catalog-node@npm:1.17.0-next.1, @backstage/plugin-catalog-node@npm:^1.17.0-next.1":
+  version: 1.17.0-next.1
+  resolution: "@backstage/plugin-catalog-node@npm:1.17.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.9.2-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.0-next.1"
     "@backstage/types": "npm:1.2.1"
-  checksum: 10/f9823e8d2fd96fc35a9bb4594c9df3d67ed7d28f2616450be495c50865ec5f46ab8be5bdcf8bfc3786a7e64eb46cf53701baa7cd40f4fd200bdbf15336ff81e8
+    lodash: "npm:^4.17.21"
+    yaml: "npm:^2.0.0"
+  checksum: 10/977fabda13a7c742741ecaa6905894d698804114cb33757f2ff761ed1d9d6ddc032e7f8b262e972efb0b3f8170c73c69e96407ce602f90871d354acf7d14cf49
   languageName: node
   linkType: hard
 
@@ -5194,22 +5305,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.39.0-next.0&npm=1.18.0-next.0, @backstage/plugin-catalog-react@npm:1.18.0-next.0, @backstage/plugin-catalog-react@npm:^1.18.0-next.0":
-  version: 1.18.0-next.0
-  resolution: "@backstage/plugin-catalog-react@npm:1.18.0-next.0"
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.39.0-next.1&npm=1.18.0-next.1, @backstage/plugin-catalog-react@npm:1.18.0-next.1, @backstage/plugin-catalog-react@npm:^1.18.0-next.1":
+  version: 1.18.0-next.1
+  resolution: "@backstage/plugin-catalog-react@npm:1.18.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/frontend-test-utils": "npm:0.3.2-next.0"
-    "@backstage/integration-react": "npm:1.2.7-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-react": "npm:0.4.33"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/frontend-test-utils": "npm:0.3.2-next.1"
+    "@backstage/integration-react": "npm:1.2.7-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -5231,7 +5342,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b19546303c0096a8e4b12980589c664d00d1e98d8802c984592fa559ffc7a84c105279d59c3041f12590d9b3bef5b4f4fbd701c50c3beb482fa5aed2b1fcbeb7
+  checksum: 10/0ed4f24e44417c76abceb5b6cc0e659309ef10c21401fe633cc4df906e45f12e7c4c3b12fa88573cde596bdc1d4cfb07bae55b52629badae4a7aebe1da81d168
   languageName: node
   linkType: hard
 
@@ -5276,24 +5387,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.39.0-next.0&npm=1.29.1-next.0, @backstage/plugin-catalog@npm:1.29.1-next.0, @backstage/plugin-catalog@npm:^1.29.1-next.0":
-  version: 1.29.1-next.0
-  resolution: "@backstage/plugin-catalog@npm:1.29.1-next.0"
+"@backstage/plugin-catalog@backstage:^::backstage=1.39.0-next.1&npm=1.29.1-next.1, @backstage/plugin-catalog@npm:1.29.1-next.1, @backstage/plugin-catalog@npm:^1.29.1-next.1":
+  version: 1.29.1-next.1
+  resolution: "@backstage/plugin-catalog@npm:1.29.1-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/integration-react": "npm:1.2.7-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.33"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.10"
-    "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.8"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/integration-react": "npm:1.2.7-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.0-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -5316,34 +5427,34 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b961214a2a50b44ec5b345aaaa505e0ef2aae3530b8dd7a81b7b785d0b154a9a540f1d2692af5b746bebe97beb6f9da594e8d3219027a6ffb1cddd48d4f6dd50
+  checksum: 10/afc7c936ac7642f054433e9001ddf2067f20241b95d68c55d8075f1f2c8390b585650f5e34fb1c0d5c627c61685e6acb2e236a9c91275b72e060e49ff4a3da44
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.39.0-next.0&npm=0.5.2-next.0, @backstage/plugin-events-backend@npm:^0.5.2-next.0":
-  version: 0.5.2-next.0
-  resolution: "@backstage/plugin-events-backend@npm:0.5.2-next.0"
+"@backstage/plugin-events-backend@backstage:^::backstage=1.39.0-next.1&npm=0.5.2-next.1, @backstage/plugin-events-backend@npm:^0.5.2-next.1":
+  version: 0.5.2-next.1
+  resolution: "@backstage/plugin-events-backend@npm:0.5.2-next.1"
   dependencies:
-    "@backstage/backend-openapi-utils": "npm:0.5.3-next.0"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-openapi-utils": "npm:0.5.3-next.1"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-events-node": "npm:0.4.11-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.11-next.1"
     "@backstage/types": "npm:1.2.1"
     "@types/express": "npm:^4.17.6"
     content-type: "npm:^1.0.5"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
-  checksum: 10/d07e8a72312dbc95cdd879507f5f45a55c557d5c42eb23d8f39be1283be005f8845944f3cbf7dd34e30a6e9454807cab65445349e6b34294b4998e540f132d6b
+  checksum: 10/1739a724bc509b21509b32443a413cd6e0b4fa92a8a9570e3429126a92a9e21d4a19fe2feeca57efaec3c0ccc7a77460e2ecd56abf2c6d994562572381f4d96c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-node@npm:0.4.11-next.0":
-  version: 0.4.11-next.0
-  resolution: "@backstage/plugin-events-node@npm:0.4.11-next.0"
+"@backstage/plugin-events-node@npm:0.4.11-next.1":
+  version: 0.4.11-next.1
+  resolution: "@backstage/plugin-events-node@npm:0.4.11-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/types": "npm:1.2.1"
     "@types/content-type": "npm:^1.1.8"
@@ -5352,7 +5463,7 @@ __metadata:
     cross-fetch: "npm:^4.0.0"
     express: "npm:^4.17.1"
     uri-template: "npm:^2.0.0"
-  checksum: 10/e862008c8310acde1a63793c76a4d21422e056ff3dc1189af83d39cd1eef0a322c391a7f94f72f798db61c1b3a59258267c6bb19128cb95bbbf0035176f93796
+  checksum: 10/da25be9896217912bbbf9691301900ac47bdc8bfb6abdddf26c7805211ca9207ddb652f4265deefd7ec1a1e1b0ded23dde6a63c0601205cd2b25d4bfdc29a160
   languageName: node
   linkType: hard
 
@@ -5373,12 +5484,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@npm:0.1.25":
-  version: 0.1.25
-  resolution: "@backstage/plugin-home-react@npm:0.1.25"
+"@backstage/plugin-home-react@npm:0.1.26-next.0":
+  version: 0.1.26-next.0
+  resolution: "@backstage/plugin-home-react@npm:0.1.26-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.17.1"
-    "@backstage/core-plugin-api": "npm:^1.10.6"
+    "@backstage/core-components": "npm:0.17.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@rjsf/utils": "npm:5.23.2"
@@ -5390,25 +5501,25 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5833dc6955266e1a82ea52657518592de2f918b23d54f4bb6132c968da0b42920eef7aa0d21989b3c9f78e47c80236fb18078fdc2fa105cd757bd7f168aea2b4
+  checksum: 10/3cde77f26e55893daf835d9ddb64a9d9d75554ea536a49eb53eee50c53cad46467d96c40a937591288364c1987264c36c13f4573b61d214fd6bcc43ddb651035
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.39.0-next.0&npm=0.8.8-next.0, @backstage/plugin-home@npm:^0.8.8-next.0":
-  version: 0.8.8-next.0
-  resolution: "@backstage/plugin-home@npm:0.8.8-next.0"
+"@backstage/plugin-home@backstage:^::backstage=1.39.0-next.1&npm=0.8.8-next.1, @backstage/plugin-home@npm:^0.8.8-next.1":
+  version: 0.8.8-next.1
+  resolution: "@backstage/plugin-home@npm:0.8.8-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/core-app-api": "npm:1.16.1"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
-    "@backstage/plugin-home-react": "npm:0.1.25"
-    "@backstage/theme": "npm:0.6.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/plugin-home-react": "npm:0.1.26-next.0"
+    "@backstage/theme": "npm:0.6.6-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5430,35 +5541,35 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7dc21e86187dd16ceb20b902c1380c5118b67985affa92174f163a5af85123a91ed4cf80590d63dd9bb118e19fb77e7b3b9b515814a10510e38d120e9d1bf030
+  checksum: 10/ef2541dee17ae40c9e463d9cf78073ae0a717c2c3d3432204400fa9ee26031bbf3f8c548d973023147ded189060bdcfb0570cb89f776040ffb68cea384b7e978
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.39.0-next.0&npm=0.19.6-next.0, @backstage/plugin-kubernetes-backend@npm:^0.19.6-next.0":
-  version: 0.19.6-next.0
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.6-next.0"
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.39.0-next.1&npm=0.19.6-next.1, @backstage/plugin-kubernetes-backend@npm:^0.19.6-next.1":
+  version: 0.19.6-next.1
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.6-next.1"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@aws-sdk/signature-v4": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration-aws-node": "npm:0.1.15"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.17.0-next.0"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.4"
-    "@backstage/plugin-kubernetes-node": "npm:0.2.6-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.9.2-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.5-next.0"
+    "@backstage/plugin-kubernetes-node": "npm:0.3.0-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@google-cloud/container": "npm:^5.0.0"
     "@jest-mock/express": "npm:^2.0.1"
-    "@kubernetes/client-node": "npm:1.0.0-rc7"
+    "@kubernetes/client-node": "npm:1.1.2"
     "@types/express": "npm:^4.17.6"
     "@types/http-proxy-middleware": "npm:^1.0.0"
     "@types/luxon": "npm:^3.0.0"
@@ -5476,53 +5587,53 @@ __metadata:
     stream-buffers: "npm:^3.0.2"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/b584bdd6469850cf2ffb96916cb615065d40f0eee81cba787bb764e3b5f75e16cfc12313210bf68b514e8dcb3b7747d4334dcd272e11a87f70961f4cf78e44a6
+  checksum: 10/3ce45a73234e147d09f6219840e8b8bdd954100647fea4f30acacf46f68d5f5e9796abd689dcf91d21acb04f0481ee37c18f7309bf6e3b09bf6ea44419551fc1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-common@npm:0.9.4, @backstage/plugin-kubernetes-common@npm:^0.9.4":
-  version: 0.9.4
-  resolution: "@backstage/plugin-kubernetes-common@npm:0.9.4"
+"@backstage/plugin-kubernetes-common@npm:0.9.5-next.0":
+  version: 0.9.5-next.0
+  resolution: "@backstage/plugin-kubernetes-common@npm:0.9.5-next.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/plugin-permission-common": "npm:^0.8.4"
-    "@backstage/types": "npm:^1.2.1"
-    "@kubernetes/client-node": "npm:1.0.0-rc7"
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@kubernetes/client-node": "npm:1.1.2"
     kubernetes-models: "npm:^4.3.1"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-  checksum: 10/40ca604f3b1b2f804e10618772612065b4afd5e67bac0acfc6ab6ff92cd93dd614658b6eefe442fe9aaea99b4a3c32e00e0fa017c83e31b58b2c324b1fa91cd6
+  checksum: 10/301781d2c7ef3c3e14e0b9bb9927148fc84cde9f2fd3072a0b5011fe956cedb8385976b06e6095ec1dad4a9f38e2998def8489f947a13ed3865e0e491ee8aeb5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-node@npm:0.2.6-next.0":
-  version: 0.2.6-next.0
-  resolution: "@backstage/plugin-kubernetes-node@npm:0.2.6-next.0"
+"@backstage/plugin-kubernetes-node@npm:0.3.0-next.1":
+  version: 0.3.0-next.1
+  resolution: "@backstage/plugin-kubernetes-node@npm:0.3.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.4"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.5-next.0"
     "@backstage/types": "npm:1.2.1"
-    "@kubernetes/client-node": "npm:1.0.0-rc7"
+    "@kubernetes/client-node": "npm:1.1.2"
     node-fetch: "npm:^2.7.0"
     winston: "npm:^3.2.1"
-  checksum: 10/13049feb315ba821542e40888cc3f84a74915089da971d52a0eb3948a364f3b3adc530becc1e3a0511dee9897906dcd50e76677f6c4d65d8e96008ae29729ccf
+  checksum: 10/32be98c1c8dbfec587a3dc4ecb768dd2e807a770c7577d0372b24064cffe3dd50d82e317497e5e6053c1e1e084616eb164006a41dd681d3c10721f16d10795d3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-react@npm:0.5.6":
-  version: 0.5.6
-  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.6"
+"@backstage/plugin-kubernetes-react@npm:0.5.7-next.0":
+  version: 0.5.7-next.0
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.7-next.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/core-components": "npm:^0.17.1"
-    "@backstage/core-plugin-api": "npm:^1.10.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-kubernetes-common": "npm:^0.9.4"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/core-components": "npm:0.17.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.5-next.0"
+    "@backstage/types": "npm:1.2.1"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
-    "@kubernetes/client-node": "npm:1.0.0-rc7"
+    "@kubernetes/client-node": "npm:1.1.2"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.11.3"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
@@ -5543,26 +5654,26 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/63ede985abefc84e31f747873936794dc9f76cc18505848b516528c2f0b585a9c41b9a10c0f93d4414a4d78a01dab7a5c0b8e6cf262d0fcea85adc1f9a4cf379
+  checksum: 10/035b448e29410a7961738cb5f17405a394757959aa56ddd5cdc238c4b681077e8f957b441bf340f124a79dd329b4c5b17a99aa869be9a980082099c57b21dc1b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.39.0-next.0&npm=0.12.7-next.0, @backstage/plugin-kubernetes@npm:^0.12.7-next.0":
-  version: 0.12.7-next.0
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.7-next.0"
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.39.0-next.1&npm=0.12.7-next.1, @backstage/plugin-kubernetes@npm:^0.12.7-next.1":
+  version: 0.12.7-next.1
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.7-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.4"
-    "@backstage/plugin-kubernetes-react": "npm:0.5.6"
-    "@backstage/plugin-permission-react": "npm:0.4.33"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.5-next.0"
+    "@backstage/plugin-kubernetes-react": "npm:0.5.7-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
-    "@kubernetes/client-node": "npm:1.0.0-rc7"
+    "@kubernetes/client-node": "npm:1.1.2"
     "@material-ui/core": "npm:^4.12.2"
     cronstrue: "npm:^2.2.0"
     js-yaml: "npm:^4.0.0"
@@ -5580,25 +5691,25 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ae5c419d07b85d9a3921f9166d369ff3ba555befc7c3af31bd9011fc2daa192c66bd12677172ea08dc77ad47e8c656d6261fce341e4af88cdb96f62e88a97401
+  checksum: 10/8858f240dbb60781d1bf0388b3d2824fb57a1f8b1199a7d842628ecdc74f0d4c02730652a78614fddbf9406b8911fbdd9f6a71c05135d83438400a9860a07344
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.39.0-next.0&npm=0.5.6-next.0, @backstage/plugin-notifications-backend@npm:^0.5.6-next.0":
-  version: 0.5.6-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.5.6-next.0"
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.39.0-next.1&npm=0.5.6-next.1, @backstage/plugin-notifications-backend@npm:^0.5.6-next.1":
+  version: 0.5.6-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.5.6-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.17.0-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.11-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.11-next.1"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
-    "@backstage/plugin-notifications-node": "npm:0.2.15-next.0"
-    "@backstage/plugin-signals-node": "npm:0.1.20-next.0"
+    "@backstage/plugin-notifications-node": "npm:0.2.15-next.1"
+    "@backstage/plugin-signals-node": "npm:0.1.20-next.1"
     "@backstage/types": "npm:1.2.1"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -5607,7 +5718,7 @@ __metadata:
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/b42c8dc50efd7130873e9c6cdb04acab7b113ab2626749f8d312078a4957532590df70dcf73f0ca5dbeb52111ddb3546e902aa94d1a4dc36e2d292e8df7399da
+  checksum: 10/cd740b8f603a238e234c0d6bb1545670375bfd0c8b8be0b8098d0e34d6faae2f3ed5f69c733f32a84184e9fe68dfa6a374755baadb12668b5b258ba70775bde3
   languageName: node
   linkType: hard
 
@@ -5621,33 +5732,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.39.0-next.0&npm=0.2.15-next.0, @backstage/plugin-notifications-node@npm:0.2.15-next.0, @backstage/plugin-notifications-node@npm:^0.2.15-next.0":
-  version: 0.2.15-next.0
-  resolution: "@backstage/plugin-notifications-node@npm:0.2.15-next.0"
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.39.0-next.1&npm=0.2.15-next.1, @backstage/plugin-notifications-node@npm:0.2.15-next.1, @backstage/plugin-notifications-node@npm:^0.2.15-next.1":
+  version: 0.2.15-next.1
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.15-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
-    "@backstage/plugin-signals-node": "npm:0.1.20-next.0"
+    "@backstage/plugin-signals-node": "npm:0.1.20-next.1"
     knex: "npm:^3.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/a87c19df2dac9c6a1e70e000f938acf053f0255328780759793bc8f4d67856567ec9e1bf0748d297bfa2d2d2559e86b47080b6caf787a53192686e4152df035c
+  checksum: 10/61d1c8f50da8d52afc6f549826f5a9cd371f453780485a8733977920ac32e8d1c95a443d43d5e6ea71f35e46df9470b32c6a7ed891f7abded4e678b0ddfb114a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.39.0-next.0&npm=0.5.5-next.0, @backstage/plugin-notifications@npm:^0.5.5-next.0":
-  version: 0.5.5-next.0
-  resolution: "@backstage/plugin-notifications@npm:0.5.5-next.0"
+"@backstage/plugin-notifications@backstage:^::backstage=1.39.0-next.1&npm=0.5.5-next.1, @backstage/plugin-notifications@npm:^0.5.5-next.1":
+  version: 0.5.5-next.1
+  resolution: "@backstage/plugin-notifications@npm:0.5.5-next.1"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
     "@backstage/plugin-signals-react": "npm:0.0.12"
-    "@backstage/theme": "npm:0.6.5"
+    "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5665,21 +5776,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/45cfeb2de23ef3657a67e49dc34e9758d924824e0cc01514c8feead995dcc45cfa2dfeae77889d161f073809425d7c010d12cdce499a364d8d89315cb5723f45
+  checksum: 10/3aea309afbdfb281f960bf5f2ed6eb52fcc8afaba5608f7b5a84d323daed36e5b8c3852569c025fdedf6c7fe08e636503b5e74c08e9f095d33ab116501482b61
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.39.0-next.0&npm=0.6.39-next.0, @backstage/plugin-org@npm:^0.6.39-next.0":
-  version: 0.6.39-next.0
-  resolution: "@backstage/plugin-org@npm:0.6.39-next.0"
+"@backstage/plugin-org@backstage:^::backstage=1.39.0-next.1&npm=0.6.39-next.1, @backstage/plugin-org@npm:^0.6.39-next.1":
+  version: 0.6.39-next.1
+  resolution: "@backstage/plugin-org@npm:0.6.39-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5696,11 +5807,26 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/42c66025ae9c277c40fecce662989efe4df22076edfc8a6581445482fb451c3b9e5f797777cb54896e93b4d0e80723a7447e923bd1d46bea0d74136402b96ce4
+  checksum: 10/5ee8e6f70204c7e194a77cf6883fc0949c43245232e2d7a55a44851350801518fece5fb1c3aaf473769c2235aa6948aee06f1dc75f73cfa6f688977a0f554bc8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-common@npm:0.8.4, @backstage/plugin-permission-common@npm:^0.8.0, @backstage/plugin-permission-common@npm:^0.8.4":
+"@backstage/plugin-permission-common@npm:0.9.0-next.0":
+  version: 0.9.0-next.0
+  resolution: "@backstage/plugin-permission-common@npm:0.9.0-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.1"
+    cross-fetch: "npm:^4.0.0"
+    uuid: "npm:^11.0.0"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.20.4"
+  checksum: 10/3c0b2e8b843c333496ef9eb7cd3e77cf6f6f9ce32d7f376b1b8e80405e7965ef0c4d41b1f0865953e35eae9d8f3206ec2e0832b32129f634315c57be77e29bac
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-common@npm:^0.8.0, @backstage/plugin-permission-common@npm:^0.8.4":
   version: 0.8.4
   resolution: "@backstage/plugin-permission-common@npm:0.8.4"
   dependencies:
@@ -5715,21 +5841,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:0.9.2-next.0":
-  version: 0.9.2-next.0
-  resolution: "@backstage/plugin-permission-node@npm:0.9.2-next.0"
+"@backstage/plugin-permission-node@npm:0.10.0-next.1":
+  version: 0.10.0-next.1
+  resolution: "@backstage/plugin-permission-node@npm:0.10.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/fa3bbfade03c6f52b3e7d9202671d0ade1088c9484eaa782745be32d0ada8f90a64be450a2d8065f973c387f7c5dd912aed4898c30293beb815367d840778d73
+  checksum: 10/616a409ba8f55807256b9bfba2418ef266574504bf0878aebffa9a931fe9d238beaee8f4f220bd24c3b96375eb9c5cd4f4789a6afb2f6c649821940693b90774
   languageName: node
   linkType: hard
 
@@ -5751,7 +5877,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-react@npm:0.4.33, @backstage/plugin-permission-react@npm:^0.4.33":
+"@backstage/plugin-permission-react@npm:0.4.34-next.0":
+  version: 0.4.34-next.0
+  resolution: "@backstage/plugin-permission-react@npm:0.4.34-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    swr: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/7c82e4c345c59df095a7588b5fda5f7f20436a6a41b6a12503e316fcec775019f205c523e7727419d0c6caaaa9818e28bf80cc62034f70129a0d793711a9a77e
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-react@npm:^0.4.33":
   version: 0.4.33
   resolution: "@backstage/plugin-permission-react@npm:0.4.33"
   dependencies:
@@ -5771,203 +5917,203 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.39.0-next.0&npm=0.6.2-next.0, @backstage/plugin-proxy-backend@npm:^0.6.2-next.0":
-  version: 0.6.2-next.0
-  resolution: "@backstage/plugin-proxy-backend@npm:0.6.2-next.0"
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.39.0-next.1&npm=0.6.2-next.1, @backstage/plugin-proxy-backend@npm:^0.6.2-next.1":
+  version: 0.6.2-next.1
+  resolution: "@backstage/plugin-proxy-backend@npm:0.6.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
-    "@backstage/plugin-proxy-node": "npm:0.1.4-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
+    "@backstage/plugin-proxy-node": "npm:0.1.4-next.1"
     "@backstage/types": "npm:1.2.1"
     express-promise-router: "npm:^4.1.0"
     http-proxy-middleware: "npm:^2.0.0"
-  checksum: 10/7102ab38f1dbd4abde26b1c969c20e263d35115020452c80ce4821c3c70f8d22690896eee42a8bfae5b627c40dcaf3a4f3d008c23a2860bd4a0e51a2f9d34747
+  checksum: 10/a4c3e03b8bb3a26c72a4c92407e8ee41a9957a0bb091de0fa8ee824c0813ae1629aa601dbf54468d3e5a4d3a6b27e0344343a2a95b7abc5ba7ffe2719275053a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-node@npm:0.1.4-next.0":
-  version: 0.1.4-next.0
-  resolution: "@backstage/plugin-proxy-node@npm:0.1.4-next.0"
+"@backstage/plugin-proxy-node@npm:0.1.4-next.1":
+  version: 0.1.4-next.1
+  resolution: "@backstage/plugin-proxy-node@npm:0.1.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     http-proxy-middleware: "npm:^2.0.0"
-  checksum: 10/ce1d9cd6e585e12817e36de781cf680d36437d18a363a0022f39162f3c3e37704386575c018ff134d1c952bffcb92fe268d7d745dc96b602df2d9411759b7c35
+  checksum: 10/d84835393e6e02d906dcf1c5fd7190814c526ae4fc21433c6f64bcdeda05982e35e4abe72e447ec237864f80776b51bdb5c5830107b764c9bf7e166a96b57550
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.9-next.0":
-  version: 0.2.9-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.9-next.0"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.9-next.1":
+  version: 0.2.9-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     azure-devops-node-api: "npm:^14.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/6085be12cd79b8fdcbf4f3cce23e3aa4cf7589e83bfe9e9fa6eebe1d3b05cf0da42d419e941b02415899726132e802e5a1626ef139fd52dadfaa8f2fccb9eecd
+  checksum: 10/b1a1fc0b0bdd0df10d4580a053212005b81caa2ce0d4d4d90a292a004e3752ee9716bb8abdd45b49380ba9640a4d037d43ee10bb82c5b547efde943ac2fab28c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.9-next.0":
-  version: 0.2.9-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.9-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.9-next.1":
+  version: 0.2.9-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.0-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     bitbucket: "npm:^2.12.0"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/64bbad8451ecd2adeb024bd26cdc24023e2971cafc1850b08a0fcb8bd146105445ae18ae9552fff1bdf194c7f3a3ae95931e4bbd89e003140f3de015b83251bc
+  checksum: 10/36122132bbf23ee64f3b9753a93aed7e2dce027980db973ba029ec5b04e80123552267632f2e1be29706225921f1cb951943e4dfcff57d435eaf32a0d6109906
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.9-next.0":
-  version: 0.2.9-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.9-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.9-next.1":
+  version: 0.2.9-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/8bf9ae4a63d088f8774004fae1e5c1738dba4e0896df1eb0fef8a3b3f29d60129572471fd8e30465b6d4319496c1520b8fe2d54347cb6d719b416217609cabb6
+  checksum: 10/f8589b1e01dd93b7035d17c1c8f3c745934d4bd9faf9f8405ff40a1fbd19c46da8780b7f8894f649a31ad8ef06b7d6f25b5b8495e418f80c1604328c983aab63
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.10-next.0":
-  version: 0.3.10-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.10-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.10-next.1":
+  version: 0.3.10-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.10-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.9-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.9-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.9-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.9-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/fafcd2e1fec4a36b410df9a42b6e20ca591dede5f74c2e82d396d0a8d929e117e167955b7abe331b24fa411afa774ce62713c73ca5597b70c85bdcb12f1db7ff
+  checksum: 10/f3552235e5f01cf4a57b0cc5ea95a58ee9401f3c581a9d98753006a9ef5877eef5d19c583465d78a22992ad1988c354fde48f07dd31aafdfb01b24337dd09e92
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.9-next.0":
-  version: 0.2.9-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.9-next.0"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.9-next.1":
+  version: 0.2.9-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/e67129219bba2231f8822ec415c7fc84271d5c62a7af161d7ffdfb6d7862313552111c1025a71c43183c18c0d0c8283002ec34f9f8764b11497eefc3187ef35b
+  checksum: 10/603a31466f1b859fdb1c378bf765cfe42c5229f35e594c04721c63023538089fea7a27a8266644df246e65f394a3de1689731e9b4271a92e2feb86684263592a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.9-next.0":
-  version: 0.2.9-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.9-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.9-next.1":
+  version: 0.2.9-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/cbb3ad589215a8168835baf872909373c80c90b597ae7a01cf08c358a95fde9bbe9743cb756eb3f73192d4a55fd99e31b882ec6473bf6f7b59d73226494c9437
+  checksum: 10/fd6e79bd6c14cc97298547fd75328cf0ac823059c0ac16b1609ee82960f85d717c8218d60b5b9328c90e95a40ae8629b498c014808d4106da49b633aa596b75e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.39.0-next.0&npm=0.7.1-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.7.1-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.7.1-next.0":
-  version: 0.7.1-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.7.1-next.0"
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.39.0-next.1&npm=0.7.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:0.7.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.7.1-next.1":
+  version: 0.7.1-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.7.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     "@backstage/types": "npm:1.2.1"
     "@octokit/webhooks": "npm:^10.9.2"
     libsodium-wrappers: "npm:^0.7.11"
     octokit: "npm:^3.0.0"
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/6f7657aadd62435b0270e7b8fbf387600f34b33ec61a8ff0eea3f3a57cd6ba964b536398b6475c8b02aeabf8a47199580182b7ff420a523f241a9372e49d9112
+  checksum: 10/323c6c7827e9334f56a9588ea9604d46a593f489b78e2cd80d7718eab5bc221b1deaea7476d337d581b65858d0417d8f134aa714207ad888a9925ab659612f8c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.1-next.0":
-  version: 0.9.1-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.1-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.1-next.1":
+  version: 0.9.1-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     winston: "npm:^3.2.1"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/f412e78f34c84d8792317401f87e56c64a7683113156709e1b6f6fa63557aeb73e8ee369c915d7cc115eb77c79f6adb71baedd1b273b977dd607e4e7abfcb27d
+  checksum: 10/33e223d7efd315099475541bed5df6385f7f8815643d23abe72beb3bea6c82b32ae66a26c05967086ffc600b91a32730b7a801ce8646d61c97d2aa604c69f2b1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.39.0-next.0&npm=0.1.10-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.10-next.0":
-  version: 0.1.10-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.10-next.0"
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.39.0-next.1&npm=0.1.10-next.1, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.10-next.1":
+  version: 0.1.10-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.10-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
-    "@backstage/plugin-notifications-node": "npm:0.2.15-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/plugin-notifications-node": "npm:0.2.15-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     octokit: "npm:^3.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/01a4cffd8b7c709af519b42e546c65f8455f51100d513bfc23c8ce673bb406f63cff66f660df981a9e2d09870dfecb1bb721306c1212970a5c30f0ef26ab0be6
+  checksum: 10/643267d95143328df8d322f96b382109d027bd3c8369c592be6aafea11201f120dd3ae1b3d6fa720f3e881b544d245508b194de47aa03a698e5d6159245e4ac8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.39.0-next.0&npm=1.32.2-next.0, @backstage/plugin-scaffolder-backend@npm:^1.32.2-next.0":
-  version: 1.32.2-next.0
-  resolution: "@backstage/plugin-scaffolder-backend@npm:1.32.2-next.0"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.39.0-next.1&npm=1.33.0-next.1, @backstage/plugin-scaffolder-backend@npm:^1.33.0-next.1":
+  version: 1.33.0-next.1
+  resolution: "@backstage/plugin-scaffolder-backend@npm:1.33.0-next.1"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-defaults": "npm:0.9.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-defaults": "npm:0.10.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.0-next.0"
-    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.8-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.17.0-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.11-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.9.2-next.0"
-    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.9-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.10-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.9-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.9-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.9-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.9-next.0"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.7.1-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.9.1-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.10"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.0-next.1"
+    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.8-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.11-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.0-next.1"
+    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.9-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.10-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.9-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.9-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.9-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.9-next.1"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.7.1-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
     "@backstage/types": "npm:1.2.1"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/express": "npm:^4.17.6"
@@ -5997,30 +6143,30 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/5dab4ed9db4b624d1f62c8b160bd6edf789341ba025194317145ec163fe4a0f0f4d290c216bebf7296a559808090988f58d772843881f0f571184e0d5636dac9
+  checksum: 10/f97d1ffff5422879952af78db39b319dce061e6497c6b0e5b445864a0e010119408dca5dc39ded7053ce57c47751549d27444f41b94aa86e7ddfc73e76c4843d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-common@npm:1.5.10":
-  version: 1.5.10
-  resolution: "@backstage/plugin-scaffolder-common@npm:1.5.10"
+"@backstage/plugin-scaffolder-common@npm:1.5.11-next.0":
+  version: 1.5.11-next.0
+  resolution: "@backstage/plugin-scaffolder-common@npm:1.5.11-next.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.3"
-    "@backstage/plugin-permission-common": "npm:^0.8.4"
-    "@backstage/types": "npm:^1.2.1"
-  checksum: 10/12e62c8fb0635a4351bd196ffce48649f14591c48d0ba668e119d6410795aaf12e8d2558423d43b86159d401c154abde2ab555daf6620f03f7638ba33cfa1cde
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/types": "npm:1.2.1"
+  checksum: 10/c578fdeda76b7b5749a1cafed51f781f496df152fe37a5762371ebc407951e69ecf5485f2e64f37c8876b445eaeeb1751070157b0c32a82fbebd5a4e191dac1e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:0.8.2-next.0":
-  version: 0.8.2-next.0
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.8.2-next.0"
+"@backstage/plugin-scaffolder-node@npm:0.8.2-next.1":
+  version: 0.8.2-next.1
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.8.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.10"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
     "@backstage/types": "npm:1.2.1"
     "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
     concat-stream: "npm:^2.0.0"
@@ -6034,23 +6180,23 @@ __metadata:
     winston-transport: "npm:^4.7.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/31ce33f1745bb0772ed1efe2a7536ff6e5487923633929356ff4a03dbce6f20a7e8d1980050a3dafc1a0878ff0a8d0d758bfc91733a44d84a4413eb7d5378687
+  checksum: 10/86e89d706d0376c25751ad10d2db0b708d47e7ab16e69bc049c0ec8610f8ab9e3fa18e8647c23a83061c12e252c9ea671f43225ede0ad4c0869a174e630bd0c9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.16.0-next.0":
-  version: 1.16.0-next.0
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.16.0-next.0"
+"@backstage/plugin-scaffolder-react@npm:1.16.0-next.1":
+  version: 1.16.0-next.1
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.16.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.33"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.10"
-    "@backstage/theme": "npm:0.6.5"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
+    "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -6086,28 +6232,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7fa842bf821a17c3b8e35f5bdbe1d8035877db4934c5f7d493b0850144d3ca162808ae712f71589ef601a5ca89fdb91240b09f022a8bcda6ab93ada350a1e878
+  checksum: 10/e2a856db5a24a89fe9bfd02cd045cb69847bd5974ee1ee364ed992c6b3e140295dfcd7ff74cf9c7f5f84b18e1a9217aa4021cd64da3f96006b66572f71d4a037
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.39.0-next.0&npm=1.31.0-next.0, @backstage/plugin-scaffolder@npm:^1.31.0-next.0":
-  version: 1.31.0-next.0
-  resolution: "@backstage/plugin-scaffolder@npm:1.31.0-next.0"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.39.0-next.1&npm=1.31.0-next.1, @backstage/plugin-scaffolder@npm:^1.31.0-next.1":
+  version: 1.31.0-next.1
+  resolution: "@backstage/plugin-scaffolder@npm:1.31.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/integration-react": "npm:1.2.7-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.33"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.10"
-    "@backstage/plugin-scaffolder-react": "npm:1.16.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/integration-react": "npm:1.2.7-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
+    "@backstage/plugin-scaffolder-react": "npm:1.16.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
@@ -6147,92 +6293,92 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2faf3eaac78e74ada3dcb15a90d47e23fc2f1a2c3868d552642404fd81e62cd75721b0412e034757357c60834f8637ebc0e7220492581e3b249ddfd13a422265
+  checksum: 10/fc80b4c19357dacf24eee7cd02e28755a494ae66631c4889387bf761c31460def9f1ca66acd8481cb5d69af5f1d1a58407f2036c050eee682960ce68d25ef8fd
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.39.0-next.0&npm=0.3.4-next.0, @backstage/plugin-search-backend-module-catalog@npm:0.3.4-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.4-next.0":
-  version: 0.3.4-next.0
-  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.4-next.0"
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.39.0-next.1&npm=0.3.4-next.1, @backstage/plugin-search-backend-module-catalog@npm:^0.3.4-next.1":
+  version: 0.3.4-next.1
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.17.0-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-search-backend-node": "npm:1.3.11-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.17"
-  checksum: 10/3e97d3f037b4d7885c8c5028ba3746c4ba2b0c0d2575beab1865c6625b174d079c628a7f1c237b7984c2546b3e592da7a154766100670ba876d96580b3654438
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-search-backend-node": "npm:1.3.11-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
+  checksum: 10/5d21786f5d1dcbfae016c841e6592ff9e929c2ef1e57e0b7d07da15d92c1dbef6834cfd76dc002a46b3725297097fec9d34fad858629d820aa7aa8371284d7a9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-explore@backstage:^::backstage=1.39.0-next.0&npm=0.3.2-next.0, @backstage/plugin-search-backend-module-explore@npm:^0.3.2-next.0":
-  version: 0.3.2-next.0
-  resolution: "@backstage/plugin-search-backend-module-explore@npm:0.3.2-next.0"
+"@backstage/plugin-search-backend-module-explore@backstage:^::backstage=1.39.0-next.1&npm=0.3.2-next.1, @backstage/plugin-search-backend-module-explore@npm:^0.3.2-next.1":
+  version: 0.3.2-next.1
+  resolution: "@backstage/plugin-search-backend-module-explore@npm:0.3.2-next.1"
   dependencies:
     "@backstage-community/plugin-explore-common": "npm:^0.0.7"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-search-backend-node": "npm:1.3.11-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.17"
-  checksum: 10/bf3ecfec739c6d50ed8dcd7bac4c8082622faee2850a19a842da55f23026a04db23dccf87aebf4951228df292122b3edf7fff5d11fa55cc32062e06a83a0cde6
+    "@backstage/plugin-search-backend-node": "npm:1.3.11-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
+  checksum: 10/a447d17cfc47001a2639f40ca6cb6b8941d5e87b204867f1a39c616939faec3a5a7e844dcb3c2ae221034d60a46aa13c8cb839919e6561174201d7918425e101
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-techdocs@npm:0.4.2-next.0":
-  version: 0.4.2-next.0
-  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.4.2-next.0"
+"@backstage/plugin-search-backend-module-techdocs@npm:0.4.2-next.1":
+  version: 0.4.2-next.1
+  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.4.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.17.0-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-search-backend-node": "npm:1.3.11-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-techdocs-node": "npm:1.13.3-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-search-backend-node": "npm:1.3.11-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
+    "@backstage/plugin-techdocs-node": "npm:1.13.3-next.1"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/dafc19114e032211a4e5722c8f7c732e4e7402bdcb07621ba39975943eb0f9708ebf14cd9858ea3f56bf4dfffa11734e9d067ddf1c9da90d1be4314ee400cee3
+  checksum: 10/bf9b98438d7d80c48ed17b8f70e11694c3c0b3cf35a7107e742b37e1c7b16e3d3bed6d31d367b580c2ef4741687860ec9906c505e4ed84813873f275688dc3cc
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-node@npm:1.3.11-next.0":
-  version: 1.3.11-next.0
-  resolution: "@backstage/plugin-search-backend-node@npm:1.3.11-next.0"
+"@backstage/plugin-search-backend-node@npm:1.3.11-next.1":
+  version: 1.3.11-next.1
+  resolution: "@backstage/plugin-search-backend-node@npm:1.3.11-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-search-common": "npm:1.2.17"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
     "@types/lunr": "npm:^2.3.3"
     lodash: "npm:^4.17.21"
     lunr: "npm:^2.3.9"
     ndjson: "npm:^2.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/1a2dade5fcda1d3a2d6d20a7b6e548583658dd49f69ef8795c3fedc28a5d67ba45f0da9177a0c0c436af697f53f39c791f785b2ff6baa2cc9435a2f5a7141f3f
+  checksum: 10/fdb22656f8f3e25ec12fc6faf5da3d45eb32342c1b95bd0812e0e6dbfa148e888681f30de3df45d28a1d175c9582e06bf2b053857ec01f3bb9a6c90ea550be48
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.39.0-next.0&npm=2.0.2-next.0, @backstage/plugin-search-backend@npm:^2.0.2-next.0":
-  version: 2.0.2-next.0
-  resolution: "@backstage/plugin-search-backend@npm:2.0.2-next.0"
+"@backstage/plugin-search-backend@backstage:^::backstage=1.39.0-next.1&npm=2.0.2-next.1, @backstage/plugin-search-backend@npm:^2.0.2-next.1":
+  version: 2.0.2-next.1
+  resolution: "@backstage/plugin-search-backend@npm:2.0.2-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.9.1-next.0"
-    "@backstage/backend-openapi-utils": "npm:0.5.3-next.0"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-defaults": "npm:0.10.0-next.1"
+    "@backstage/backend-openapi-utils": "npm:0.5.3-next.1"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-permission-node": "npm:0.9.2-next.0"
-    "@backstage/plugin-search-backend-node": "npm:1.3.11-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.17"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.0-next.1"
+    "@backstage/plugin-search-backend-node": "npm:1.3.11-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
     "@backstage/types": "npm:1.2.1"
     dataloader: "npm:^2.0.0"
     express: "npm:^4.17.1"
@@ -6240,11 +6386,21 @@ __metadata:
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/02797f678bf0f86391f518d16551a204f505daabd3419979d0b5cee13c8418faf4f42672b2fa4e436fca781c53b6e1e3fee476f8ada6e2ae1323b9b988bffe03
+  checksum: 10/ebc57bbc45fbb936583e0a472a87bf620a483fd9d729d60b3beec477243b778ec8a0a433490b135d785398488660ec2cac0561cbe8a5ab26673fc58fc15fdb2e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-common@npm:1.2.17, @backstage/plugin-search-common@npm:^1.2.17":
+"@backstage/plugin-search-common@npm:1.2.18-next.0":
+  version: 1.2.18-next.0
+  resolution: "@backstage/plugin-search-common@npm:1.2.18-next.0"
+  dependencies:
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/types": "npm:1.2.1"
+  checksum: 10/d33ce7f487164cbd443e5e2a3da0e480351abcba6448d932a28e014e3f820058ca4616e75802c78e892aad5b0bd801ef32e5f3f4004c4f55964d86417613a82d
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-common@npm:^1.2.17":
   version: 1.2.17
   resolution: "@backstage/plugin-search-common@npm:1.2.17"
   dependencies:
@@ -6254,7 +6410,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.39.0-next.0&npm=1.8.8, @backstage/plugin-search-react@npm:1.8.8, @backstage/plugin-search-react@npm:^1.8.8":
+"@backstage/plugin-search-react@backstage:^::backstage=1.39.0-next.1&npm=1.9.0-next.0, @backstage/plugin-search-react@npm:1.9.0-next.0, @backstage/plugin-search-react@npm:^1.9.0-next.0":
+  version: 1.9.0-next.0
+  resolution: "@backstage/plugin-search-react@npm:1.9.0-next.0"
+  dependencies:
+    "@backstage/core-components": "npm:0.17.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
+    "@backstage/theme": "npm:0.6.6-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    lodash: "npm:^4.17.21"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.3.2"
+    uuid: "npm:^11.0.2"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/cbc435869d1691b28ed96585672be58dcb7b5c51c5e75663b22217be89c0d708dae40391d4175af2719003e9242e0c3bf7b6f11864dc26e7b755f660c378e957
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-react@npm:^1.8.8":
   version: 1.8.8
   resolution: "@backstage/plugin-search-react@npm:1.8.8"
   dependencies:
@@ -6284,18 +6470,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.39.0-next.0&npm=1.4.26-next.0, @backstage/plugin-search@npm:^1.4.26-next.0":
-  version: 1.4.26-next.0
-  resolution: "@backstage/plugin-search@npm:1.4.26-next.0"
+"@backstage/plugin-search@backstage:^::backstage=1.39.0-next.1&npm=1.4.26-next.1, @backstage/plugin-search@npm:^1.4.26-next.1":
+  version: 1.4.26-next.1
+  resolution: "@backstage/plugin-search@npm:1.4.26-next.1"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.8"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.0-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -6310,19 +6496,19 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/f200b328233b484ae24cc0f71a7f554958421579387fe58663b3b7e17bd4c550774535e5bbfe55e78b6f87093291269b8fb186ac66f434d12292c62ef7f05b7a
+  checksum: 10/34c5a24bbbd0499297582cb568c7671243199fcde4db127807379146cbd1137175b2cc311f8b4c2264486bb76ae7ea4e859aeaa908a1bf4d4c04d72a16e6d480
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.39.0-next.0&npm=0.3.4-next.0, @backstage/plugin-signals-backend@npm:^0.3.4-next.0":
-  version: 0.3.4-next.0
-  resolution: "@backstage/plugin-signals-backend@npm:0.3.4-next.0"
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.39.0-next.1&npm=0.3.4-next.1, @backstage/plugin-signals-backend@npm:^0.3.4-next.1":
+  version: 0.3.4-next.1
+  resolution: "@backstage/plugin-signals-backend@npm:0.3.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.11-next.0"
-    "@backstage/plugin-signals-node": "npm:0.1.20-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.11-next.1"
+    "@backstage/plugin-signals-node": "npm:0.1.20-next.1"
     "@backstage/types": "npm:1.2.1"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -6331,27 +6517,27 @@ __metadata:
     winston: "npm:^3.2.1"
     ws: "npm:^8.18.0"
     yn: "npm:^4.0.0"
-  checksum: 10/8ed88d53a009e76d22e18cfd73c23f51ea8793f061b48dccdb0301c4d13b67eb24649233d0da5d50b1109e85e8d0352c951fe04d23590ede179e49417017cf02
+  checksum: 10/b5f834ce2d6557c33359eaf89345644ecbc481c16edd0d55b015a0789d5b9054033e487c28146c30eeadf627605ad9f745d5780ec0f51b3c7b001c5840435fe2
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-node@npm:0.1.20-next.0":
-  version: 0.1.20-next.0
-  resolution: "@backstage/plugin-signals-node@npm:0.1.20-next.0"
+"@backstage/plugin-signals-node@npm:0.1.20-next.1":
+  version: 0.1.20-next.1
+  resolution: "@backstage/plugin-signals-node@npm:0.1.20-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/plugin-auth-node": "npm:0.6.3-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.11-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.11-next.1"
     "@backstage/types": "npm:1.2.1"
     express: "npm:^4.17.1"
     uuid: "npm:^11.0.0"
     ws: "npm:^8.18.0"
-  checksum: 10/7e8ea61cc179c5f77247bc639324dfdb1660d0637348f87743313833284fc6b8f134433c71763a023be93a17dbd8371af4a6d1def9d26abccdfc6112532a08da
+  checksum: 10/88dc541663eb6480b66c3a8cce99fefb306dad3cf3b2ca0f92eb7f6e52a46d230684b3d24ec659192e71aef2852cd38824d8ea0f34b403498a9e380a5b6e16bf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-react@npm:0.0.12, @backstage/plugin-signals-react@npm:^0.0.12":
+"@backstage/plugin-signals-react@npm:0.0.12":
   version: 0.0.12
   resolution: "@backstage/plugin-signals-react@npm:0.0.12"
   dependencies:
@@ -6370,16 +6556,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.39.0-next.0&npm=0.0.18, @backstage/plugin-signals@npm:^0.0.18":
-  version: 0.0.18
-  resolution: "@backstage/plugin-signals@npm:0.0.18"
+"@backstage/plugin-signals@backstage:^::backstage=1.39.0-next.1&npm=0.0.19-next.0, @backstage/plugin-signals@npm:^0.0.19-next.0":
+  version: 0.0.19-next.0
+  resolution: "@backstage/plugin-signals@npm:0.0.19-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.17.1"
-    "@backstage/core-plugin-api": "npm:^1.10.6"
-    "@backstage/frontend-plugin-api": "npm:^0.10.1"
-    "@backstage/plugin-signals-react": "npm:^0.0.12"
-    "@backstage/theme": "npm:^0.6.5"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-signals-react": "npm:0.0.12"
+    "@backstage/theme": "npm:0.6.6-next.0"
+    "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
@@ -6393,27 +6579,27 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0da877b34b7a0f1676a313bfb8140c29e2b1387cae285527ca7c63a8cdcfe3c732b8f8a218f7af0b18d8341a55af5e735014ada58e058589d15553127badaed5
+  checksum: 10/5bc2c1104004a8eed8a18a12ca0211d1df40e7ff9cadf57710b5f71914eb1ac474a78d575fc3fa46d2e1415d9d8c7ffe63353cfb5db82c65a7ed043f979de39e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.39.0-next.0&npm=2.0.2-next.0, @backstage/plugin-techdocs-backend@npm:^2.0.2-next.0":
-  version: 2.0.2-next.0
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.2-next.0"
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.39.0-next.1&npm=2.0.2-next.1, @backstage/plugin-techdocs-backend@npm:^2.0.2-next.1":
+  version: 2.0.2-next.1
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.2-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.9.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-defaults": "npm:0.10.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.3"
-    "@backstage/plugin-catalog-node": "npm:1.17.0-next.0"
-    "@backstage/plugin-permission-common": "npm:0.8.4"
-    "@backstage/plugin-search-backend-module-techdocs": "npm:0.4.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-search-backend-module-techdocs": "npm:0.4.2-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-node": "npm:1.13.3-next.0"
+    "@backstage/plugin-techdocs-node": "npm:1.13.3-next.1"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
@@ -6421,7 +6607,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/53f5d94ce3c8de291be216552df5fc8f13c69d8db0603e3a8f133aa1b83baef88e7c257a66df7902b8f6c092c7158526ca5b651852c704f8153aa26e88683be1
+  checksum: 10/3198aee55f0ddf9c4f5f885de66303054c65a60738241d5133a1594e523b5cac7448da2e3b39ddf97659432161b3fc2fd1ced3a0c926604df32c8658f642897e
   languageName: node
   linkType: hard
 
@@ -6432,16 +6618,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.39.0-next.0&npm=1.1.24-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.24-next.0":
-  version: 1.1.24-next.0
-  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.24-next.0"
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.39.0-next.1&npm=1.1.24-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.24-next.1":
+  version: 1.1.24-next.1
+  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.24-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/integration-react": "npm:1.2.7-next.0"
-    "@backstage/plugin-techdocs-react": "npm:1.2.16"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/integration-react": "npm:1.2.7-next.1"
+    "@backstage/plugin-techdocs-react": "npm:1.2.17-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@react-hookz/web": "npm:^24.0.0"
@@ -6455,13 +6641,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ecd70ca041b99979be4437dedadbd584c241f2b52351c1a05ca8d390d2fd02c6e7561d37af6bc7a15eb566ff371fdda0c33392fdd10cc951d0c13f3a25a74d0e
+  checksum: 10/98fd9f3b287baa55c652d116fbb4a0e617382672e0e4a11e20b9ea875f8e3a53be073ac5d943b2aa799c50a4f086be6e5a8a534dfcd85e01a93f47585dda7c07
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.39.0-next.0&npm=1.13.3-next.0, @backstage/plugin-techdocs-node@npm:1.13.3-next.0, @backstage/plugin-techdocs-node@npm:^1.13.3-next.0":
-  version: 1.13.3-next.0
-  resolution: "@backstage/plugin-techdocs-node@npm:1.13.3-next.0"
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.39.0-next.1&npm=1.13.3-next.1, @backstage/plugin-techdocs-node@npm:1.13.3-next.1, @backstage/plugin-techdocs-node@npm:^1.13.3-next.1":
+  version: 1.13.3-next.1
+  resolution: "@backstage/plugin-techdocs-node@npm:1.13.3-next.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -6469,13 +6655,13 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-plugin-api": "npm:1.3.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
     "@backstage/integration-aws-node": "npm:0.1.15"
-    "@backstage/plugin-search-common": "npm:1.2.17"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
     "@google-cloud/storage": "npm:^7.0.0"
     "@smithy/node-http-handler": "npm:^3.0.0"
@@ -6492,11 +6678,39 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/d4f993aafe04a507de1bbc188d955bec01c8bc89e1a0a0771f386e66e8b624c0732ab8c9af47761fee20ca126b11fb7ffc9272c94cb2b0761b876b3e01559e76
+  checksum: 10/d123be0f2fc3d2d83d472fc46d122f4465625947460705b8e17edc5c2e998b74cbad8ac02ec24dfed5f9cfee5aa76ed319d97e2d7b5d58f0489b35ee2d4cb197
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.39.0-next.0&npm=1.2.16, @backstage/plugin-techdocs-react@npm:1.2.16, @backstage/plugin-techdocs-react@npm:^1.2.16":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.39.0-next.1&npm=1.2.17-next.0, @backstage/plugin-techdocs-react@npm:1.2.17-next.0, @backstage/plugin-techdocs-react@npm:^1.2.17-next.0":
+  version: 1.2.17-next.0
+  resolution: "@backstage/plugin-techdocs-react@npm:1.2.17-next.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.7.3"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-components": "npm:0.17.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/styles": "npm:^4.11.0"
+    jss: "npm:~10.10.0"
+    lodash: "npm:^4.17.21"
+    react-helmet: "npm:6.1.0"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/741267d9fe46cee5d6723299501bef3e71c61cedf925b60fc56894ec394d8170c5cc15169bcbdaee7943a5ef841575bf94a0410410e1619da8260d78b03a1527
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs-react@npm:^1.2.16":
   version: 1.2.16
   resolution: "@backstage/plugin-techdocs-react@npm:1.2.16"
   dependencies:
@@ -6524,27 +6738,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.39.0-next.0&npm=1.12.6-next.0, @backstage/plugin-techdocs@npm:^1.12.6-next.0":
-  version: 1.12.6-next.0
-  resolution: "@backstage/plugin-techdocs@npm:1.12.6-next.0"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.39.0-next.1&npm=1.12.6-next.1, @backstage/plugin-techdocs@npm:^1.12.6-next.1":
+  version: 1.12.6-next.1
+  resolution: "@backstage/plugin-techdocs@npm:1.12.6-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/integration": "npm:1.16.4-next.0"
-    "@backstage/integration-react": "npm:1.2.7-next.0"
-    "@backstage/plugin-auth-react": "npm:0.1.14"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.17"
-    "@backstage/plugin-search-react": "npm:1.8.8"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/integration-react": "npm:1.2.7-next.1"
+    "@backstage/plugin-auth-react": "npm:0.1.15-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.18-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.0-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-react": "npm:1.2.16"
-    "@backstage/theme": "npm:0.6.5"
+    "@backstage/plugin-techdocs-react": "npm:1.2.17-next.0"
+    "@backstage/theme": "npm:0.6.6-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -6564,7 +6778,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c16b0363a0da5e60dab70dd8c6581536f0a4db403f1428483daba654b9f66786cf718d27ff5a4ed0194d2196fe331e25a3e57472daa34f208dccd24c28f8f81b
+  checksum: 10/b88a5cf6a993e1c8adadfd931ce3e8ccbe3c02ba9b8f1d043068789dbbfd77e75e339442ee2690bd5add608c392ddc7eaafa036ebb2e05aaecf301e014a5c1ef
   languageName: node
   linkType: hard
 
@@ -6575,21 +6789,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.39.0-next.0&npm=0.8.22-next.0, @backstage/plugin-user-settings@npm:^0.8.22-next.0":
-  version: 0.8.22-next.0
-  resolution: "@backstage/plugin-user-settings@npm:0.8.22-next.0"
+"@backstage/plugin-user-settings@backstage:^::backstage=1.39.0-next.1&npm=0.8.22-next.1, @backstage/plugin-user-settings@npm:^0.8.22-next.1":
+  version: 0.8.22-next.1
+  resolution: "@backstage/plugin-user-settings@npm:0.8.22-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/core-app-api": "npm:1.16.1"
-    "@backstage/core-compat-api": "npm:0.4.2-next.0"
-    "@backstage/core-components": "npm:0.17.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.1"
+    "@backstage/core-components": "npm:0.17.2-next.0"
     "@backstage/core-plugin-api": "npm:1.10.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.1"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.12"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
-    "@backstage/theme": "npm:0.6.5"
+    "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6604,7 +6818,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0711c6db731ceb083838febdba928d716154a4d4420e5eb63da528a6ccc4b6c4af134070ce7b7c5b2c3ec33dab9a0154f387784e16c7c9c798fa17ef4bbe7bfa
+  checksum: 10/a64cbca3abc376d8d5d43f918f052df2a3887da82f3613f4e05c5c7b8d9bd66de1d85b1a0b1c0dd858534f2035c69e170d0474f885acbd0d7e8eaa70d022ffb0
   languageName: node
   linkType: hard
 
@@ -6615,7 +6829,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/test-utils@npm:1.7.7, @backstage/test-utils@npm:^1.7.7":
+"@backstage/test-utils@npm:1.7.8-next.0":
+  version: 1.7.8-next.0
+  resolution: "@backstage/test-utils@npm:1.7.8-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-app-api": "npm:1.16.1"
+    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/theme": "npm:0.6.6-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    cross-fetch: "npm:^4.0.0"
+    i18next: "npm:^22.4.15"
+    zen-observable: "npm:^0.10.0"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/46085ddb19c5ff926da92648dc815d3875bbe8a527fe480112e40825dd18707a0f451928d0a197ea2433a40c567acfdef8d1301390c6d69947cdbdc2b92e069f
+  languageName: node
+  linkType: hard
+
+"@backstage/test-utils@npm:^1.7.7":
   version: 1.7.7
   resolution: "@backstage/test-utils@npm:1.7.7"
   dependencies:
@@ -6644,9 +6887,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.39.0-next.0&npm=0.6.5, @backstage/theme@npm:0.6.5, @backstage/theme@npm:^0.6.4, @backstage/theme@npm:^0.6.5":
-  version: 0.6.5
-  resolution: "@backstage/theme@npm:0.6.5"
+"@backstage/theme@backstage:^::backstage=1.39.0-next.1&npm=0.6.6-next.0, @backstage/theme@npm:0.6.6-next.0, @backstage/theme@npm:^0.6.6-next.0":
+  version: 0.6.6-next.0
+  resolution: "@backstage/theme@npm:0.6.6-next.0"
   dependencies:
     "@emotion/react": "npm:^11.10.5"
     "@emotion/styled": "npm:^11.10.5"
@@ -6660,7 +6903,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/242ccb2af6e2d1c64d4084c568c31d696d6abfdbbbd0ba35b2a9dabaae9c196b4610e2124f2c23fff16de082701901627f85b180f8a3ea2a8bcb865beb982829
+  checksum: 10/7c57bc134eac0eb4cc929385de081c31e7a5081e6427a6021b466214df5807e5f0a5116c561f04182c36a47d0f38d2791c0b5b25b9e760154ee2a60e3ad7f0cb
   languageName: node
   linkType: hard
 
@@ -6677,6 +6920,26 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
   checksum: 10/b826aabc3f483e7f0dd2285c1510c4a59797433a2884a2423b22bfce6627aefabcd258aac23edecb58edb8275a87deb4ef212646d1832721a56862d46d8b4001
+  languageName: node
+  linkType: hard
+
+"@backstage/theme@npm:^0.6.4, @backstage/theme@npm:^0.6.5":
+  version: 0.6.5
+  resolution: "@backstage/theme@npm:0.6.5"
+  dependencies:
+    "@emotion/react": "npm:^11.10.5"
+    "@emotion/styled": "npm:^11.10.5"
+    "@mui/material": "npm:^5.12.2"
+  peerDependencies:
+    "@material-ui/core": ^4.12.2
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/242ccb2af6e2d1c64d4084c568c31d696d6abfdbbbd0ba35b2a9dabaae9c196b4610e2124f2c23fff16de082701901627f85b180f8a3ea2a8bcb865beb982829
   languageName: node
   linkType: hard
 
@@ -8485,6 +8748,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@iovalkey/commands@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@iovalkey/commands@npm:0.1.0"
+  checksum: 10/9226ad4b26b8b3bf8446f4aa95bc0ae45bef0d15af7f087a3484e7f4f50f3f8741ba03f4355ebc3b2982d47a2960cb7f39bb83f33256c258fe1ae34bccbc71e1
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -8911,21 +9181,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsep-plugin/assignment@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@jsep-plugin/assignment@npm:1.2.1"
+"@jsep-plugin/assignment@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@jsep-plugin/assignment@npm:1.3.0"
   peerDependencies:
     jsep: ^0.4.0||^1.0.0
-  checksum: 10/d8db45f052fd95b33207ded7f49af9ae48ff5ce10cb898e28a6fca722863f4a3330892c3a2c355a1a8c94fd230eef3db9be0c45324cb526e5edff7085c1f7a37
+  checksum: 10/0c93b703d84af95b4be9fb6c23fbdbe7c7b6985b41c98fd10386cd54686ed1eb751cb39f5d54abcb621e4da2a0900a3b2a852e5bf7f2d322b756db3b22e42a45
   languageName: node
   linkType: hard
 
-"@jsep-plugin/regex@npm:^1.0.1, @jsep-plugin/regex@npm:^1.0.3":
+"@jsep-plugin/regex@npm:^1.0.1":
   version: 1.0.3
   resolution: "@jsep-plugin/regex@npm:1.0.3"
   peerDependencies:
     jsep: ^0.4.0||^1.0.0
   checksum: 10/c08c7bd79a164995923ea799949b9f6b18dcf2bd314522ed0dcfc669fd249a06fea200606086c7d54b12d39ce3cfa61d910229e5184c667ead135f6da6997532
+  languageName: node
+  linkType: hard
+
+"@jsep-plugin/regex@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "@jsep-plugin/regex@npm:1.0.4"
+  peerDependencies:
+    jsep: ^0.4.0||^1.0.0
+  checksum: 10/0ea6ba81f03955972b762fd9fbc8e3fd7e1c1c12e52ce3d4366e23c0a63c8bff8528687b8b3d8f641cf9f626f8bf5a7841efcd31a2489fe967e1900e5738ee3a
   languageName: node
   linkType: hard
 
@@ -8991,6 +9270,15 @@ __metadata:
   dependencies:
     buffer: "npm:^6.0.3"
   checksum: 10/b47418bed4fb17e16e136d1071f71d12de6f566bbf4d484a611a2d7063e0e79aedb3164b51153054101b6b7eb2a2b349469d438f70a5fbac22a68f136a535ec4
+  languageName: node
+  linkType: hard
+
+"@keyv/valkey@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "@keyv/valkey@npm:1.0.3"
+  dependencies:
+    iovalkey: "npm:^0.3.1"
+  checksum: 10/ff6ba62e4d19c426e45a1437fe215ed2baddc58e811d97507dd75ead0058c3105d679c8c7c4241ddf732abe56320357c2e568c014620e50d7c0eaef1f2528b88
   languageName: node
   linkType: hard
 
@@ -9094,9 +9382,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kubernetes/client-node@npm:1.0.0-rc7":
-  version: 1.0.0-rc7
-  resolution: "@kubernetes/client-node@npm:1.0.0-rc7"
+"@kubernetes/client-node@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@kubernetes/client-node@npm:1.1.2"
   dependencies:
     "@types/js-yaml": "npm:^4.0.1"
     "@types/node": "npm:^22.0.0"
@@ -9105,19 +9393,19 @@ __metadata:
     "@types/tar": "npm:^6.1.1"
     "@types/ws": "npm:^8.5.4"
     form-data: "npm:^4.0.0"
+    hpagent: "npm:^1.2.0"
     isomorphic-ws: "npm:^5.0.0"
     js-yaml: "npm:^4.1.0"
-    jsonpath-plus: "npm:^10.0.0"
+    jsonpath-plus: "npm:^10.3.0"
     node-fetch: "npm:^2.6.9"
-    openid-client: "npm:^5.6.5"
+    openid-client: "npm:^6.1.3"
     rfc4648: "npm:^1.3.0"
+    socks-proxy-agent: "npm:^8.0.4"
     stream-buffers: "npm:^3.0.2"
     tar: "npm:^7.0.0"
     tmp-promise: "npm:^3.0.2"
-    tslib: "npm:^2.5.0"
-    url-parse: "npm:^1.4.3"
     ws: "npm:^8.18.0"
-  checksum: 10/dad4432c97d24410f3af293b64e3e261d3807d2e23d5b2e022e34d59b0fddd1e26087900695b13917941b40dda02dc6af3e04f08ffb3a6a28b1b23a8dc7543bb
+  checksum: 10/3dd193dc8c0eb86bceb8a184e178e39c72278c4c6cccad25c595c4b3d1f56ac36778a845abd18c013971db9d8a7ed1febd88dab8791e0819bbd74a2850f0e2ca
   languageName: node
   linkType: hard
 
@@ -23240,6 +23528,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iovalkey@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "iovalkey@npm:0.3.1"
+  dependencies:
+    "@iovalkey/commands": "npm:^0.1.0"
+    cluster-key-slot: "npm:^1.1.0"
+    debug: "npm:^4.3.4"
+    denque: "npm:^2.1.0"
+    lodash.defaults: "npm:^4.2.0"
+    lodash.isarguments: "npm:^3.1.0"
+    redis-errors: "npm:^1.2.0"
+    redis-parser: "npm:^3.0.0"
+    standard-as-callback: "npm:^2.1.0"
+  checksum: 10/afe5e0218810d902263dca2b22dd4501fb74698111f1850804d0948bd6a97793a7f5006757f9b6e8c8131bac6bd532d07ad971e7776bed7f6dc1f6e471706c53
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -24584,6 +24889,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^6.0.10":
+  version: 6.0.10
+  resolution: "jose@npm:6.0.10"
+  checksum: 10/8ba0d1aca94bdf780247c737328114fab3e394e1531e881dfe3fdd1d4a293b08cf7c0242769e72c8c8eee15c95761b542cf10730c3dfbb108084762df7d25cec
+  languageName: node
+  linkType: hard
+
 "js-cookie@npm:^2.2.1":
   version: 2.2.1
   resolution: "js-cookie@npm:2.2.1"
@@ -24722,10 +25034,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsep@npm:^1.1.2, jsep@npm:^1.2.0, jsep@npm:^1.3.9":
+"jsep@npm:^1.1.2, jsep@npm:^1.2.0":
   version: 1.3.9
   resolution: "jsep@npm:1.3.9"
   checksum: 10/c60d7064c3b5047f58345e65e7618bbaecf2f46338e56689244db057b0550bf8fb7c1457a7384dfd38aca9acde3ff851d062c3f182cc1fbc66c13cb2ca0b579d
+  languageName: node
+  linkType: hard
+
+"jsep@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "jsep@npm:1.4.0"
+  checksum: 10/935824fe6ac28fcff3cd13878f508f99f6c13e7f0f53ec9fca0d3db465e6dd15f8af030bcdc75a38b07c78359c656647435923a26aceb91607027021f00c17f2
   languageName: node
   linkType: hard
 
@@ -24952,17 +25271,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:^10.0.0":
-  version: 10.1.0
-  resolution: "jsonpath-plus@npm:10.1.0"
+"jsonpath-plus@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "jsonpath-plus@npm:10.3.0"
   dependencies:
-    "@jsep-plugin/assignment": "npm:^1.2.1"
-    "@jsep-plugin/regex": "npm:^1.0.3"
-    jsep: "npm:^1.3.9"
+    "@jsep-plugin/assignment": "npm:^1.3.0"
+    "@jsep-plugin/regex": "npm:^1.0.4"
+    jsep: "npm:^1.4.0"
   bin:
     jsonpath: bin/jsonpath-cli.js
     jsonpath-plus: bin/jsonpath-cli.js
-  checksum: 10/d872af63b667c43e7563095b4c88f61be5b298c1ddc1d019b3684f0ba1addcba24857e78058b00c52511f52044e3dfea16f83869facfd6ced7430ebd6257f7ab
+  checksum: 10/082302334414c7c5ab0cc8239563118f7f14bb2949d001b009f436491d00f94a7a293eed3eaf61ffdaf72f6fda9d25198a4280c4f68a4c403154ca7ed2bd0dc9
   languageName: node
   linkType: hard
 
@@ -27783,6 +28102,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"oauth4webapi@npm:^3.4.1":
+  version: 3.5.0
+  resolution: "oauth4webapi@npm:3.5.0"
+  checksum: 10/7ac858b6edf3701c4752f386788acab01f7567a3e6068316582d80298b8113999bb9062d498ce0ab8bb4c4802d8007c5a1afdcb42974ffcf603af20b6d832993
+  languageName: node
+  linkType: hard
+
 "oauth@npm:0.10.x":
   version: 0.10.0
   resolution: "oauth@npm:0.10.0"
@@ -28085,7 +28411,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openid-client@npm:^5.3.0, openid-client@npm:^5.6.5":
+"openid-client@npm:^5.3.0":
   version: 5.7.0
   resolution: "openid-client@npm:5.7.0"
   dependencies:
@@ -28094,6 +28420,16 @@ __metadata:
     object-hash: "npm:^2.2.0"
     oidc-token-hash: "npm:^5.0.3"
   checksum: 10/d30e70082e8ae5222b29977cd944c3aa6ebaa159bf294348b6ae5cbcc8c5db9e731f21815ce41a6ebe2ebf4c6a697e26cad0ea0fc22d59ee922d3f7d3cd4aa43
+  languageName: node
+  linkType: hard
+
+"openid-client@npm:^6.1.3":
+  version: 6.4.2
+  resolution: "openid-client@npm:6.4.2"
+  dependencies:
+    jose: "npm:^6.0.10"
+    oauth4webapi: "npm:^3.4.1"
+  checksum: 10/798d4c88e6a5e52a37c8d321b92da9a93a431cfc6f909857ae1aadb558d2444d31fde68e03fd59e2779b69cdf46707f5a52e5ba9eaf4ab2e4bd63e621b51ada8
   languageName: node
   linkType: hard
 
@@ -34254,7 +34590,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"url-parse@npm:^1.4.3, url-parse@npm:^1.5.10, url-parse@npm:^1.5.3":
+"url-parse@npm:^1.5.10, url-parse@npm:^1.5.3":
   version: 1.5.10
   resolution: "url-parse@npm:1.5.10"
   dependencies:


### PR DESCRIPTION
Backstage release v1.39.0-next.1 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.39.0-next.1](https://github.com/backstage/backstage/blob/master/docs/releases/v1.39.0-next.1-changelog.md)
- Upgrade Helper: [From 1.39.0-next.0 to 1.39.0-next.1](https://backstage.github.io/upgrade-helper/?from=1.39.0-next.0&to=1.39.0-next.1)
 
Created by [Version Bump 14754519986](https://github.com/backstage/demo/actions/runs/14754519986)
 