### PR TITLE
v1.39.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 2eda215600fa289952383d999f87e6fa46a333fd737a8a221a1e2326d4c95a2d694510b5e6aa5a3ef5b8927b48ce7ea1d5783efc4be18d5f87cf57d5fa16b966
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.39.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.39.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.39.0-next.1"
+  "version": "1.39.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3160,12 +3160,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.27.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.27.0
   resolution: "@babel/runtime@npm:7.27.0"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
   checksum: 10/e6966e03b695feb4c0ac0856a4355231c2580bf9ebd0298f47739f85c0ea658679dd84409daf26378d42c86c1cbe7e33feab709b14e784254b6c441d91606465
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.26.10":
+  version: 7.27.1
+  resolution: "@babel/runtime@npm:7.27.1"
+  checksum: 10/34cefcbf781ea5a4f1b93f8563327b9ac82694bebdae91e8bd9d7f58d084cbe5b9a6e7f94d77076e15b0bcdaa0040a36cb30737584028df6c4673b4c67b2a31d
   languageName: node
   linkType: hard
 
@@ -3503,14 +3510,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.39.0-next.1&npm=1.6.2-next.0, @backstage/app-defaults@npm:^1.6.2-next.0":
-  version: 1.6.2-next.0
-  resolution: "@backstage/app-defaults@npm:1.6.2-next.0"
+"@backstage/app-defaults@backstage:^::backstage=1.39.0-next.2&npm=1.6.2-next.1, @backstage/app-defaults@npm:^1.6.2-next.1":
+  version: 1.6.2-next.1
+  resolution: "@backstage/app-defaults@npm:1.6.2-next.1"
   dependencies:
-    "@backstage/core-app-api": "npm:1.16.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/core-app-api": "npm:1.16.2-next.0"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.1"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -3522,7 +3529,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fb755444295d6b303c6af45c320b8bc00a92f5c3d2e114a69fe0504fe6507741415e014bab533ae2d111f545ee1039c7fe6515a7c284d56b17fec8dc07d3e0ec
+  checksum: 10/f3b922d3fdb138dd0e5a1b9d05bbee994046a85405a2ac36a51a3a896471e0b44d071a4f915da3a14f62d5f666e62bc2df979fbe28e5a64fbce9ebb8b30de548
   languageName: node
   linkType: hard
 
@@ -3701,9 +3708,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.39.0-next.1&npm=0.10.0-next.1, @backstage/backend-defaults@npm:0.10.0-next.1, @backstage/backend-defaults@npm:^0.10.0-next.1":
-  version: 0.10.0-next.1
-  resolution: "@backstage/backend-defaults@npm:0.10.0-next.1"
+"@backstage/backend-defaults@backstage:^::backstage=1.39.0-next.2&npm=0.10.0-next.2, @backstage/backend-defaults@npm:0.10.0-next.2, @backstage/backend-defaults@npm:^0.10.0-next.2":
+  version: 0.10.0-next.2
+  resolution: "@backstage/backend-defaults@npm:0.10.0-next.2"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -3718,8 +3725,8 @@ __metadata:
     "@backstage/config": "npm:1.3.2"
     "@backstage/config-loader": "npm:1.10.1-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/integration-aws-node": "npm:0.1.15"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/integration-aws-node": "npm:0.1.16-next.0"
     "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
     "@backstage/plugin-events-node": "npm:0.4.11-next.1"
     "@backstage/plugin-permission-node": "npm:0.10.0-next.1"
@@ -3776,7 +3783,7 @@ __metadata:
   peerDependenciesMeta:
     "@google-cloud/cloud-sql-connector":
       optional: true
-  checksum: 10/72d4a7db1fc19cf9724bdf8248200a9b2e40ced70a83492cf0ce334c5839f33c81a67bac96720a2fcba0017633cd3a3a3c3c91bc0ff2916b5dcbc77a92958dc1
+  checksum: 10/5faf457b27efb99071b8d4f1902738582cb2fc581aa0812ccc801bf7e3ca65da306aa05f924c99946b66975f43371e6bf60338f7e92dccc7a8c86fc23a7eef8e
   languageName: node
   linkType: hard
 
@@ -3913,7 +3920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.39.0-next.1&npm=1.3.1-next.1, @backstage/backend-plugin-api@npm:1.3.1-next.1, @backstage/backend-plugin-api@npm:^1.3.1-next.1":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.39.0-next.2&npm=1.3.1-next.1, @backstage/backend-plugin-api@npm:1.3.1-next.1, @backstage/backend-plugin-api@npm:^1.3.1-next.1":
   version: 1.3.1-next.1
   resolution: "@backstage/backend-plugin-api@npm:1.3.1-next.1"
   dependencies:
@@ -3970,11 +3977,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/canon@backstage:^::backstage=1.39.0-next.1&npm=0.4.0-next.1, @backstage/canon@npm:^0.4.0-next.1":
-  version: 0.4.0-next.1
-  resolution: "@backstage/canon@npm:0.4.0-next.1"
+"@backstage/canon@backstage:^::backstage=1.39.0-next.2&npm=0.4.0-next.2, @backstage/canon@npm:^0.4.0-next.2":
+  version: 0.4.0-next.2
+  resolution: "@backstage/canon@npm:0.4.0-next.2"
   dependencies:
-    "@base-ui-components/react": "npm:^1.0.0-alpha.7"
+    "@base-ui-components/react": "npm:1.0.0-alpha.7"
     "@remixicon/react": "npm:^4.6.0"
     "@tanstack/react-table": "npm:^8.21.3"
     clsx: "npm:^2.1.1"
@@ -3986,7 +3993,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fadb1e1de7fd4ed8422206ea9dd24812c471c24301128a6285acc0317aca212718f1f9ed7206fe470cde1a3778bd5a51caac86b9e9a8c5b3ebc11f46de122c51
+  checksum: 10/ee74e5d9b109be649c682aef35a775065320cc9c04f155a03f41469cebc2fb66b40b1db00b4fb44bc257cb24b0dc6a188ae3ed5cf664ac66861526927117b42b
   languageName: node
   linkType: hard
 
@@ -4014,7 +4021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.39.0-next.1&npm=1.7.3, @backstage/catalog-model@npm:1.7.3, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.3":
+"@backstage/catalog-model@backstage:^::backstage=1.39.0-next.2&npm=1.7.3, @backstage/catalog-model@npm:1.7.3, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.3":
   version: 1.7.3
   resolution: "@backstage/catalog-model@npm:1.7.3"
   dependencies:
@@ -4049,9 +4056,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.39.0-next.1&npm=0.32.1-next.1, @backstage/cli@npm:^0.32.1-next.1":
-  version: 0.32.1-next.1
-  resolution: "@backstage/cli@npm:0.32.1-next.1"
+"@backstage/cli@backstage:^::backstage=1.39.0-next.2&npm=0.32.1-next.2, @backstage/cli@npm:^0.32.1-next.2":
+  version: 0.32.1-next.2
+  resolution: "@backstage/cli@npm:0.32.1-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/cli-common": "npm:0.1.15"
@@ -4060,7 +4067,7 @@ __metadata:
     "@backstage/config-loader": "npm:1.10.1-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/eslint-plugin": "npm:0.1.10"
-    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
     "@backstage/release-manifests": "npm:0.0.12"
     "@backstage/types": "npm:1.2.1"
     "@manypkg/get-packages": "npm:^1.1.3"
@@ -4181,7 +4188,7 @@ __metadata:
   bin:
     backstage-cli: bin/backstage-cli
     backstage-cli-alpha: bin/backstage-cli-alpha
-  checksum: 10/1ab5a92043f2a183fa55bdd2956a2b2f378cc41b14da5d6a7a64694afca69e8b940596ea00de62ca9be83822ca049f98e8c3e7d419e680e923bb83a5913c8ca1
+  checksum: 10/2d497e4303f67b9bc7e0114ab674f8ad834afc4b8388a241043145d9c74b8f50dc17563a5be9391b8f05ef74050b529d3370392aaaf1db1b0a4dab2f1628e75e
   languageName: node
   linkType: hard
 
@@ -4231,7 +4238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.39.0-next.1&npm=1.3.2, @backstage/config@npm:1.3.2, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2":
+"@backstage/config@backstage:^::backstage=1.39.0-next.2&npm=1.3.2, @backstage/config@npm:1.3.2, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2":
   version: 1.3.2
   resolution: "@backstage/config@npm:1.3.2"
   dependencies:
@@ -4242,7 +4249,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.39.0-next.1&npm=1.16.1, @backstage/core-app-api@npm:1.16.1, @backstage/core-app-api@npm:^1.16.1":
+"@backstage/core-app-api@backstage:^::backstage=1.39.0-next.2&npm=1.16.2-next.0, @backstage/core-app-api@npm:1.16.2-next.0, @backstage/core-app-api@npm:^1.16.2-next.0":
+  version: 1.16.2-next.0
+  resolution: "@backstage/core-app-api@npm:1.16.2-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@types/prop-types": "npm:^15.7.3"
+    history: "npm:^5.0.0"
+    i18next: "npm:^22.4.15"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/b885afda2dc549b7683f573b29884c8432066c671203e45592df682f534db280199252c3b820650c13d6c6e670eec54150311c178fbf52da1ee9e76eabb22ed8
+  languageName: node
+  linkType: hard
+
+"@backstage/core-app-api@npm:^1.16.1":
   version: 1.16.1
   resolution: "@backstage/core-app-api@npm:1.16.1"
   dependencies:
@@ -4270,13 +4305,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@npm:0.4.2-next.1":
-  version: 0.4.2-next.1
-  resolution: "@backstage/core-compat-api@npm:0.4.2-next.1"
+"@backstage/core-compat-api@npm:0.4.2-next.2":
+  version: 0.4.2-next.2
+  resolution: "@backstage/core-compat-api@npm:0.4.2-next.2"
   dependencies:
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
     "@backstage/version-bridge": "npm:1.0.11"
     lodash: "npm:^4.17.21"
   peerDependencies:
@@ -4287,7 +4322,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8d7a6b451b7647bfee8f1601f477b2f971bfa4fcfc13a666fed4b09e19698e5e2ead373dcbd5fa03079cfe4f8f05c9a4ea4d9bdd435a0e146460a254f716f6fa
+  checksum: 10/81a7e296e2bee6382a4525c8b8ae2ef757ab3f09ec64d2dc47546ee289e4cde169a51a64491fbc888b4677fd2a89cc0e12b37a91d86ff945824ece14132a2292
   languageName: node
   linkType: hard
 
@@ -4328,12 +4363,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.39.0-next.1&npm=0.17.2-next.0, @backstage/core-components@npm:0.17.2-next.0, @backstage/core-components@npm:^0.17.2-next.0":
-  version: 0.17.2-next.0
-  resolution: "@backstage/core-components@npm:0.17.2-next.0"
+"@backstage/core-components@backstage:^::backstage=1.39.0-next.2&npm=0.17.2-next.1, @backstage/core-components@npm:0.17.2-next.1, @backstage/core-components@npm:^0.17.2-next.1":
+  version: 0.17.2-next.1
+  resolution: "@backstage/core-components@npm:0.17.2-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/version-bridge": "npm:1.0.11"
@@ -4378,7 +4413,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/f7ced2165d2bc8bc498dacd6c0300b83f989c4e6c4652b393e217b5aac51791ab874a25be07b10ac71efbf4ad9bcadfcccb468f7f94778cfdd42c9182efedf35
+  checksum: 10/886967a7f8917b8508f5145402b83101e8838a3b443e7cca5a80b3a5f2b618cdb9b964adc210dbfc82ea2d177807f462e4d26bcaebd1a5b26fa59a5b6d798fd5
   languageName: node
   linkType: hard
 
@@ -4485,14 +4520,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.39.0-next.1&npm=1.10.6, @backstage/core-plugin-api@npm:1.10.6, @backstage/core-plugin-api@npm:^1.10.6":
-  version: 1.10.6
-  resolution: "@backstage/core-plugin-api@npm:1.10.6"
+"@backstage/core-plugin-api@backstage:^::backstage=1.39.0-next.2&npm=1.10.7-next.0, @backstage/core-plugin-api@npm:1.10.7-next.0, @backstage/core-plugin-api@npm:^1.10.7-next.0":
+  version: 1.10.7-next.0
+  resolution: "@backstage/core-plugin-api@npm:1.10.7-next.0"
   dependencies:
-    "@backstage/config": "npm:^1.3.2"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/types": "npm:^1.2.1"
-    "@backstage/version-bridge": "npm:^1.0.11"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
     history: "npm:^5.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -4502,7 +4537,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1359bb2dc294c6eb0b8de6aa4a0788561c5d43ef2a4464d4f7600c382126398a42724e8ba894925ab02f1d332ef9b87b0eeee31e56a9e9223f8d6504a283d896
+  checksum: 10/2354da0e887e1951c84dda3b0062b977f14d651ce2ffd247f676f4c8f03e8d97c10b425e526775efd9b7bc78d3379982643652da14e2c60e78426074c07ccdc5
   languageName: node
   linkType: hard
 
@@ -4527,7 +4562,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.39.0-next.1&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/core-plugin-api@npm:^1.10.6":
+  version: 1.10.6
+  resolution: "@backstage/core-plugin-api@npm:1.10.6"
+  dependencies:
+    "@backstage/config": "npm:^1.3.2"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/types": "npm:^1.2.1"
+    "@backstage/version-bridge": "npm:^1.0.11"
+    history: "npm:^5.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/1359bb2dc294c6eb0b8de6aa4a0788561c5d43ef2a4464d4f7600c382126398a42724e8ba894925ab02f1d332ef9b87b0eeee31e56a9e9223f8d6504a283d896
+  languageName: node
+  linkType: hard
+
+"@backstage/e2e-test-utils@backstage:^::backstage=1.39.0-next.2&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -4562,16 +4618,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-app-api@npm:0.11.2-next.1":
-  version: 0.11.2-next.1
-  resolution: "@backstage/frontend-app-api@npm:0.11.2-next.1"
+"@backstage/frontend-app-api@npm:0.11.2-next.2":
+  version: 0.11.2-next.2
+  resolution: "@backstage/frontend-app-api@npm:0.11.2-next.2"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-app-api": "npm:1.16.1"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-app-api": "npm:1.16.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-defaults": "npm:0.2.2-next.1"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/frontend-defaults": "npm:0.2.2-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     lodash: "npm:^4.17.21"
@@ -4584,7 +4640,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d087ca981b061adfb491f3e8e3bce4a9e48ad27d8adcd6c99ab9299c44b686baa075335854ee1e4263bb3ea28166474bd0ce66caed190ed4672ba7932bd8436d
+  checksum: 10/3305b2fe46fa8adfa65f205834a90e44353c49107ad2deda872de73107a58a8fa1468e8f058fb76fedd224d0e1e5ced401a17fadcbf7b5e1e6116d549023a0db
   languageName: node
   linkType: hard
 
@@ -4614,15 +4670,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@npm:0.2.2-next.1":
-  version: 0.2.2-next.1
-  resolution: "@backstage/frontend-defaults@npm:0.2.2-next.1"
+"@backstage/frontend-defaults@npm:0.2.2-next.2":
+  version: 0.2.2-next.2
+  resolution: "@backstage/frontend-defaults@npm:0.2.2-next.2"
   dependencies:
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-app-api": "npm:0.11.2-next.1"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-app": "npm:0.1.9-next.1"
+    "@backstage/frontend-app-api": "npm:0.11.2-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-app": "npm:0.1.9-next.2"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -4632,7 +4688,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0ae95f01a2d9b2ceef693caa389c5b4e4473e3fb5c190c16bcfea46a221640728f8ec11b481dc6d8cc665f34cb0fd02239c35a7e8e86f36947a6975452477164
+  checksum: 10/680d913c2bd0baf6eb15ba5cab715803039ef4b88fdeea069d5a19b353b679d586d558d73b6ae49cef935388d2d6eb8e96d1712ba7850f7e822045b57d23e703
   languageName: node
   linkType: hard
 
@@ -4658,12 +4714,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:0.10.2-next.0":
-  version: 0.10.2-next.0
-  resolution: "@backstage/frontend-plugin-api@npm:0.10.2-next.0"
+"@backstage/frontend-plugin-api@npm:0.10.2-next.1":
+  version: 0.10.2-next.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.10.2-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.4"
@@ -4678,7 +4734,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/f083de03eef1bfa78bc6cf2595257cf0ba96b8fc5f540d7d73348f874c06450feaad5c0de534669222a39fd2f6ffc3dd8bcbb3d6b5dffcf7de8631bbc0f50a9b
+  checksum: 10/b844da11fe11c9d717a5b8e18d90b20c4a0f7f08e601626102a44bd1f34eb5dddf86379d6d3af530f1656489f3645696ea623d4587023be3c530e8a16ca605e0
   languageName: node
   linkType: hard
 
@@ -4726,15 +4782,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-test-utils@npm:0.3.2-next.1":
-  version: 0.3.2-next.1
-  resolution: "@backstage/frontend-test-utils@npm:0.3.2-next.1"
+"@backstage/frontend-test-utils@npm:0.3.2-next.2":
+  version: 0.3.2-next.2
+  resolution: "@backstage/frontend-test-utils@npm:0.3.2-next.2"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/frontend-app-api": "npm:0.11.2-next.1"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-app": "npm:0.1.9-next.1"
-    "@backstage/test-utils": "npm:1.7.8-next.0"
+    "@backstage/frontend-app-api": "npm:0.11.2-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-app": "npm:0.1.9-next.2"
+    "@backstage/test-utils": "npm:1.7.8-next.1"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     zod: "npm:^3.22.4"
@@ -4747,7 +4803,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9e17b617c8005a18735bc09ad0bc5cc1cff6bdfbb498e14251eb3da2906f7b0bf5a8b25f073eef78ada7f3c9b56702fb5763e37d9e0dda086f797a36f7afec8b
+  checksum: 10/3cd3f005e49bf3fffa3fab57dd00ab81d5f88b81e89c1bfb538bfa27a45ff729911c18c9b2ea3e0844ad910fa8274115b53de589f974a19ff613e301e255e614
   languageName: node
   linkType: hard
 
@@ -4776,7 +4832,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-aws-node@npm:0.1.15, @backstage/integration-aws-node@npm:^0.1.12, @backstage/integration-aws-node@npm:^0.1.15":
+"@backstage/integration-aws-node@npm:0.1.16-next.0":
+  version: 0.1.16-next.0
+  resolution: "@backstage/integration-aws-node@npm:0.1.16-next.0"
+  dependencies:
+    "@aws-sdk/client-sts": "npm:^3.350.0"
+    "@aws-sdk/credential-provider-node": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@aws-sdk/util-arn-parser": "npm:^3.310.0"
+    "@backstage/config": "npm:1.3.2"
+    "@backstage/errors": "npm:1.2.7"
+  checksum: 10/1cac2c09525bce2d83bee64d173061d9a5f5573dfc2d7c12086a5148e10e40840a82617635eda1f9333e2a94271de363fcc2f259dfdeb6d2e2454b3c17bbd17d
+  languageName: node
+  linkType: hard
+
+"@backstage/integration-aws-node@npm:^0.1.12, @backstage/integration-aws-node@npm:^0.1.15":
   version: 0.1.15
   resolution: "@backstage/integration-aws-node@npm:0.1.15"
   dependencies:
@@ -4791,13 +4862,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.39.0-next.1&npm=1.2.7-next.1, @backstage/integration-react@npm:1.2.7-next.1, @backstage/integration-react@npm:^1.2.7-next.1":
-  version: 1.2.7-next.1
-  resolution: "@backstage/integration-react@npm:1.2.7-next.1"
+"@backstage/integration-react@backstage:^::backstage=1.39.0-next.2&npm=1.2.7-next.2, @backstage/integration-react@npm:1.2.7-next.2, @backstage/integration-react@npm:^1.2.7-next.2":
+  version: 1.2.7-next.2
+  resolution: "@backstage/integration-react@npm:1.2.7-next.2"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/integration": "npm:1.17.0-next.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -4808,7 +4879,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1874bf444124811db79d492bac2a60e43a22fe70edfb74fcf407e73d17bd6740304b744da31f9b835a41d52728c9c238a54c46bbc4de3ed49a4000c56fbe81c7
+  checksum: 10/26b0763a7be1aa7e90d177c561dd95f91e1ebc4950875220ae6f00c77294c4d38237aad321497ce7366cb1b4ba1275dad450a05ae7a10f48a8abc997a49d8ff1
   languageName: node
   linkType: hard
 
@@ -4833,9 +4904,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration@backstage:^::backstage=1.39.0-next.1&npm=1.16.4-next.1, @backstage/integration@npm:1.16.4-next.1, @backstage/integration@npm:^1.16.4-next.1":
-  version: 1.16.4-next.1
-  resolution: "@backstage/integration@npm:1.16.4-next.1"
+"@backstage/integration@backstage:^::backstage=1.39.0-next.2&npm=1.17.0-next.2, @backstage/integration@npm:1.17.0-next.2, @backstage/integration@npm:^1.17.0-next.2":
+  version: 1.17.0-next.2
+  resolution: "@backstage/integration@npm:1.17.0-next.2"
   dependencies:
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
@@ -4847,7 +4918,7 @@ __metadata:
     git-url-parse: "npm:^15.0.0"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-  checksum: 10/d515c79f54a664347937d2b2f297308b7f4b68e959a45f92db5c477ffd989a81b5c351c254a9ae57059705fd4153d857e8d7a9f9d33e37696e43c2e38fa1dd24
+  checksum: 10/4c76ecedc8baf2c1c82c2a154b8e9531d642ab2ad279c14587a4829d01086048f3a0a78249bb73f921c2de9b7951d06f8f82eaad77ef801e52a0d11bd75188e1
   languageName: node
   linkType: hard
 
@@ -4869,20 +4940,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.39.0-next.1&npm=0.12.7-next.1, @backstage/plugin-api-docs@npm:^0.12.7-next.1":
-  version: 0.12.7-next.1
-  resolution: "@backstage/plugin-api-docs@npm:0.12.7-next.1"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.39.0-next.2&npm=0.12.7-next.2, @backstage/plugin-api-docs@npm:^0.12.7-next.2":
+  version: 0.12.7-next.2
+  resolution: "@backstage/plugin-api-docs@npm:0.12.7-next.2"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-catalog": "npm:1.29.1-next.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-catalog": "npm:1.29.1-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
-    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.1"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4901,11 +4972,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d642aea3b51101abf99a8268211734848a3b09c0cd190330a9768b320603210e9711e5984982424fca345dcf16fc7684c98e9e9e85d483c8cd0ddc4125d13e41
+  checksum: 10/9f95e2dc662c1e2a4a07aeada0afe4bffe6ddd6cab58b3c54b8ba73a0762d1abd5f4df3ac1ca7433a1e62dc64e481597ddf3e6147f10306b8fa344260348c52e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.39.0-next.1&npm=0.5.2-next.1, @backstage/plugin-app-backend@npm:^0.5.2-next.1":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.39.0-next.2&npm=0.5.2-next.1, @backstage/plugin-app-backend@npm:^0.5.2-next.1":
   version: 0.5.2-next.1
   resolution: "@backstage/plugin-app-backend@npm:0.5.2-next.1"
   dependencies:
@@ -4942,15 +5013,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@npm:0.1.9-next.1":
-  version: 0.1.9-next.1
-  resolution: "@backstage/plugin-app@npm:0.1.9-next.1"
+"@backstage/plugin-app@npm:0.1.9-next.2":
+  version: 0.1.9-next.2
+  resolution: "@backstage/plugin-app@npm:0.1.9-next.2"
   dependencies:
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/integration-react": "npm:1.2.7-next.1"
-    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/integration-react": "npm:1.2.7-next.2"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.1"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.9.13"
@@ -4965,7 +5036,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/402cb9fe2475fd8e4257f2e76c1be93055453ad0e03cc9bab07f029706343797c8485b9411db7797320b326a268b365dd5243c1f36a31c62c47f35831627d06d
+  checksum: 10/f9d77d2650d8fd62ea812b0962f3144f1232e608c5fba909c0466d99729687c78a92692becd03ff76957b3ae29515fcbd514e77e5616a18169bf5f25ab7dde15
   languageName: node
   linkType: hard
 
@@ -4996,7 +5067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.39.0-next.1&npm=0.3.3-next.1, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.3-next.1":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.39.0-next.2&npm=0.3.3-next.1, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.3-next.1":
   version: 0.3.3-next.1
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.3-next.1"
   dependencies:
@@ -5007,7 +5078,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.39.0-next.1&npm=0.2.8-next.1, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.8-next.1":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.39.0-next.2&npm=0.2.8-next.1, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.8-next.1":
   version: 0.2.8-next.1
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.8-next.1"
   dependencies:
@@ -5020,7 +5091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.39.0-next.1&npm=0.25.0-next.1, @backstage/plugin-auth-backend@npm:^0.25.0-next.1":
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.39.0-next.2&npm=0.25.0-next.1, @backstage/plugin-auth-backend@npm:^0.25.0-next.1":
   version: 0.25.0-next.1
   resolution: "@backstage/plugin-auth-backend@npm:0.25.0-next.1"
   dependencies:
@@ -5144,12 +5215,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-react@npm:0.1.15-next.0":
-  version: 0.1.15-next.0
-  resolution: "@backstage/plugin-auth-react@npm:0.1.15-next.0"
+"@backstage/plugin-auth-react@npm:0.1.15-next.1":
+  version: 0.1.15-next.1
+  resolution: "@backstage/plugin-auth-react@npm:0.1.15-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@material-ui/core": "npm:^4.9.13"
     "@react-hookz/web": "npm:^24.0.0"
@@ -5161,32 +5232,32 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7693638ef87ad01cd3bfc8f5c3700c084fd16b87c132e755a685ab5d7c21b51909242e7678dfc4e05d63da56c744de247c5a22fee947146ef5736f0d3579e673
+  checksum: 10/fe782dd883e9e36031d901bf7042c90ab2f90db9ed4fde9ecf697bba7d351ea2ef51e86be886cd3a5d4b732b03bc1763a92f287c5f56eb77278d865cb73b6592
   languageName: node
   linkType: hard
 
-"@backstage/plugin-bitbucket-cloud-common@npm:0.3.0-next.1":
-  version: 0.3.0-next.1
-  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.3.0-next.1"
+"@backstage/plugin-bitbucket-cloud-common@npm:0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.3.0-next.2"
   dependencies:
-    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
     cross-fetch: "npm:^4.0.0"
-  checksum: 10/ef8ff7c767caf048747d3f7ec105c0c6b3d5a0977ff89d80fc7c99806bfebd8c10c3a97758b83392ca54386938b38140774d3440a1278300b14a58de304f1460
+  checksum: 10/8da378ea4a2082291160d5b0b7901fbbb024e57eb516f58e694896f8e8c0aae23f66d7677e75658b2e77be368566eeda375beb979d29956a78d8f4ce86e6b8d5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.39.0-next.1&npm=0.1.10-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.10-next.1":
-  version: 0.1.10-next.1
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.10-next.1"
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.39.0-next.2&npm=0.1.10-next.2, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.10-next.2":
+  version: 0.1.10-next.2
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.10-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
-    "@backstage/plugin-catalog-backend": "npm:2.0.0-next.1"
+    "@backstage/plugin-catalog-backend": "npm:2.0.0-next.2"
     "@backstage/plugin-events-node": "npm:0.4.11-next.1"
-  checksum: 10/6495f0aef14e74a790097a2cd78d39961096438036e17293f59f06968d6c88ca1c7feb3214a2db4f1300d53d0a7b696b0d49ab64dc658822d47b70a48f46db4f
+  checksum: 10/159cf4454360624ca77f069c50779de69fe980d09dd4235dba411f2619224b200c14a98807552a8791c24cf0fe5d090e66348fafb6da003bb77a531e57bcdffc
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.39.0-next.1&npm=0.2.8-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.8-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.8-next.1":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.39.0-next.2&npm=0.2.8-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.8-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.8-next.1":
   version: 0.2.8-next.1
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.8-next.1"
   dependencies:
@@ -5199,9 +5270,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.39.0-next.1&npm=2.0.0-next.1, @backstage/plugin-catalog-backend@npm:2.0.0-next.1, @backstage/plugin-catalog-backend@npm:^2.0.0-next.1":
-  version: 2.0.0-next.1
-  resolution: "@backstage/plugin-catalog-backend@npm:2.0.0-next.1"
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.39.0-next.2&npm=2.0.0-next.2, @backstage/plugin-catalog-backend@npm:2.0.0-next.2, @backstage/plugin-catalog-backend@npm:^2.0.0-next.2":
+  version: 2.0.0-next.2
+  resolution: "@backstage/plugin-catalog-backend@npm:2.0.0-next.2"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.5.3-next.1"
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
@@ -5209,7 +5280,7 @@ __metadata:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
     "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
     "@backstage/plugin-events-node": "npm:0.4.11-next.1"
@@ -5234,7 +5305,7 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/d532cbf9f5a8d07474ecc6513081c7cd2cb9faab6a5f47fff20fd889f9b886fa83a8a9474c2c42cfb142b4ae58d46da3f169835c26be1fefb2efe9e1d40f0792
+  checksum: 10/137c877a1031cecccec9226478313cc87acb13856a5ae3ed7567b2ee93caea250bb2323255d53214298ec483d49141569a9a456caafc27aa79d344dd945b6756
   languageName: node
   linkType: hard
 
@@ -5260,17 +5331,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.39.0-next.1&npm=0.4.19-next.1, @backstage/plugin-catalog-graph@npm:^0.4.19-next.1":
-  version: 0.4.19-next.1
-  resolution: "@backstage/plugin-catalog-graph@npm:0.4.19-next.1"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.39.0-next.2&npm=0.4.19-next.2, @backstage/plugin-catalog-graph@npm:^0.4.19-next.2":
+  version: 0.4.19-next.2
+  resolution: "@backstage/plugin-catalog-graph@npm:0.4.19-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5288,11 +5359,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9a4b7569fc69a632da0778b364026083d477512991d381cd7cf090c80cc041c1a0dcdcfb0cfc42162f842761d13a580f1746344b2ec22949aed7c9e06a1cfca9
+  checksum: 10/4151144b490543728de547b04cb6a4f5e2c7516c9f5393512965b07096e7e551b0686f9442ee00b5f61b971de78fdcea8f0df30956fe359404795ae4512453d9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.39.0-next.1&npm=1.17.0-next.1, @backstage/plugin-catalog-node@npm:1.17.0-next.1, @backstage/plugin-catalog-node@npm:^1.17.0-next.1":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.39.0-next.2&npm=1.17.0-next.1, @backstage/plugin-catalog-node@npm:1.17.0-next.1, @backstage/plugin-catalog-node@npm:^1.17.0-next.1":
   version: 1.17.0-next.1
   resolution: "@backstage/plugin-catalog-node@npm:1.17.0-next.1"
   dependencies:
@@ -5326,22 +5397,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.39.0-next.1&npm=1.18.0-next.1, @backstage/plugin-catalog-react@npm:1.18.0-next.1, @backstage/plugin-catalog-react@npm:^1.18.0-next.1":
-  version: 1.18.0-next.1
-  resolution: "@backstage/plugin-catalog-react@npm:1.18.0-next.1"
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.39.0-next.2&npm=1.18.0-next.2, @backstage/plugin-catalog-react@npm:1.18.0-next.2, @backstage/plugin-catalog-react@npm:^1.18.0-next.2":
+  version: 1.18.0-next.2
+  resolution: "@backstage/plugin-catalog-react@npm:1.18.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/frontend-test-utils": "npm:0.3.2-next.1"
-    "@backstage/integration-react": "npm:1.2.7-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/frontend-test-utils": "npm:0.3.2-next.2"
+    "@backstage/integration-react": "npm:1.2.7-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
     "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.1"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -5363,7 +5434,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0ed4f24e44417c76abceb5b6cc0e659309ef10c21401fe633cc4df906e45f12e7c4c3b12fa88573cde596bdc1d4cfb07bae55b52629badae4a7aebe1da81d168
+  checksum: 10/9c095d4f3c10de7db34396334633c57247fe0ca41b3a82653b86cd73a477933a6f8687ce6472717f2c35f7a321507777eeb1191bd514ae61ffa918fbdb2af610
   languageName: node
   linkType: hard
 
@@ -5408,24 +5479,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.39.0-next.1&npm=1.29.1-next.1, @backstage/plugin-catalog@npm:1.29.1-next.1, @backstage/plugin-catalog@npm:^1.29.1-next.1":
-  version: 1.29.1-next.1
-  resolution: "@backstage/plugin-catalog@npm:1.29.1-next.1"
+"@backstage/plugin-catalog@backstage:^::backstage=1.39.0-next.2&npm=1.29.1-next.2, @backstage/plugin-catalog@npm:1.29.1-next.2, @backstage/plugin-catalog@npm:^1.29.1-next.2":
+  version: 1.29.1-next.2
+  resolution: "@backstage/plugin-catalog@npm:1.29.1-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/integration-react": "npm:1.2.7-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/integration-react": "npm:1.2.7-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
-    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
     "@backstage/plugin-search-common": "npm:1.2.18-next.0"
-    "@backstage/plugin-search-react": "npm:1.9.0-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -5448,11 +5519,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/afc7c936ac7642f054433e9001ddf2067f20241b95d68c55d8075f1f2c8390b585650f5e34fb1c0d5c627c61685e6acb2e236a9c91275b72e060e49ff4a3da44
+  checksum: 10/ccf5bd3112c5d1223ec45cee033708572a4295a6e56c9a4b6a6c50a646779be76a8d7944450f61d39ec10545e7a391bd4c17563d2a908138c2d8d587d6be6690
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.39.0-next.1&npm=0.5.2-next.1, @backstage/plugin-events-backend@npm:^0.5.2-next.1":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.39.0-next.2&npm=0.5.2-next.1, @backstage/plugin-events-backend@npm:^0.5.2-next.1":
   version: 0.5.2-next.1
   resolution: "@backstage/plugin-events-backend@npm:0.5.2-next.1"
   dependencies:
@@ -5505,12 +5576,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@npm:0.1.26-next.0":
-  version: 0.1.26-next.0
-  resolution: "@backstage/plugin-home-react@npm:0.1.26-next.0"
+"@backstage/plugin-home-react@npm:0.1.26-next.1":
+  version: 0.1.26-next.1
+  resolution: "@backstage/plugin-home-react@npm:0.1.26-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@rjsf/utils": "npm:5.23.2"
@@ -5522,24 +5593,24 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3cde77f26e55893daf835d9ddb64a9d9d75554ea536a49eb53eee50c53cad46467d96c40a937591288364c1987264c36c13f4573b61d214fd6bcc43ddb651035
+  checksum: 10/dc484bdb36835dda5ea855668f19e6b5ec725cf90461053bd00865e9363b0e7e4d637300147165457612dbfd5b6cb57337639fadb019d2d312988a16bcd3ebb1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.39.0-next.1&npm=0.8.8-next.1, @backstage/plugin-home@npm:^0.8.8-next.1":
-  version: 0.8.8-next.1
-  resolution: "@backstage/plugin-home@npm:0.8.8-next.1"
+"@backstage/plugin-home@backstage:^::backstage=1.39.0-next.2&npm=0.8.8-next.2, @backstage/plugin-home@npm:^0.8.8-next.2":
+  version: 0.8.8-next.2
+  resolution: "@backstage/plugin-home@npm:0.8.8-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-app-api": "npm:1.16.1"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
-    "@backstage/plugin-home-react": "npm:0.1.26-next.0"
+    "@backstage/core-app-api": "npm:1.16.2-next.0"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
+    "@backstage/plugin-home-react": "npm:0.1.26-next.1"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5562,13 +5633,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ef2541dee17ae40c9e463d9cf78073ae0a717c2c3d3432204400fa9ee26031bbf3f8c548d973023147ded189060bdcfb0570cb89f776040ffb68cea384b7e978
+  checksum: 10/0a48f97e084fd115a6766118e74dbd7d1e59891b502fed65c65e29c01dcd4535388bd3aeac98a30adfa4901a600203d4684863c354e01fba105c836ab2cc8b35
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.39.0-next.1&npm=0.19.6-next.1, @backstage/plugin-kubernetes-backend@npm:^0.19.6-next.1":
-  version: 0.19.6-next.1
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.6-next.1"
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.39.0-next.2&npm=0.19.6-next.2, @backstage/plugin-kubernetes-backend@npm:^0.19.6-next.2":
+  version: 0.19.6-next.2
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.6-next.2"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -5580,7 +5651,7 @@ __metadata:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration-aws-node": "npm:0.1.15"
+    "@backstage/integration-aws-node": "npm:0.1.16-next.0"
     "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
     "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
     "@backstage/plugin-kubernetes-common": "npm:0.9.5-next.0"
@@ -5608,7 +5679,7 @@ __metadata:
     stream-buffers: "npm:^3.0.2"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/3ce45a73234e147d09f6219840e8b8bdd954100647fea4f30acacf46f68d5f5e9796abd689dcf91d21acb04f0481ee37c18f7309bf6e3b09bf6ea44419551fc1
+  checksum: 10/72d3913883bcc929ffc68284443a4db919ea3af8d8edbaf4ad0cd7c1c3fe10679d936962e54d3f3e45e7bec02f8553c70276e6749902369d06e40873ad42e376
   languageName: node
   linkType: hard
 
@@ -5642,13 +5713,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-react@npm:0.5.7-next.0":
-  version: 0.5.7-next.0
-  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.7-next.0"
+"@backstage/plugin-kubernetes-react@npm:0.5.7-next.1":
+  version: 0.5.7-next.1
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.7-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-kubernetes-common": "npm:0.9.5-next.0"
     "@backstage/types": "npm:1.2.1"
@@ -5675,23 +5746,23 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/035b448e29410a7961738cb5f17405a394757959aa56ddd5cdc238c4b681077e8f957b441bf340f124a79dd329b4c5b17a99aa869be9a980082099c57b21dc1b
+  checksum: 10/c435bfa324ceef422808a2fff43ecd68a2e19ba082b1670681d9d89d052de2eec19eac340e307e9b83b61a3ac5b35ff8ed47cc9d7ac42bf67630374a5284d493
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.39.0-next.1&npm=0.12.7-next.1, @backstage/plugin-kubernetes@npm:^0.12.7-next.1":
-  version: 0.12.7-next.1
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.7-next.1"
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.39.0-next.2&npm=0.12.7-next.2, @backstage/plugin-kubernetes@npm:^0.12.7-next.2":
+  version: 0.12.7-next.2
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.7-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
     "@backstage/plugin-kubernetes-common": "npm:0.9.5-next.0"
-    "@backstage/plugin-kubernetes-react": "npm:0.5.7-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/plugin-kubernetes-react": "npm:0.5.7-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.1"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
     "@kubernetes/client-node": "npm:1.1.2"
@@ -5712,11 +5783,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8858f240dbb60781d1bf0388b3d2824fb57a1f8b1199a7d842628ecdc74f0d4c02730652a78614fddbf9406b8911fbdd9f6a71c05135d83438400a9860a07344
+  checksum: 10/bc68a5e2a8f3eebc991762255d067aab23a7fcb1bc5ab5dfc122248483cf6b6f3bf2caf1a18ff3a94610f7ae139f090228ae2b9295885ffd345b71a48ff683b3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.39.0-next.1&npm=0.5.6-next.1, @backstage/plugin-notifications-backend@npm:^0.5.6-next.1":
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.39.0-next.2&npm=0.5.6-next.1, @backstage/plugin-notifications-backend@npm:^0.5.6-next.1":
   version: 0.5.6-next.1
   resolution: "@backstage/plugin-notifications-backend@npm:0.5.6-next.1"
   dependencies:
@@ -5753,7 +5824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.39.0-next.1&npm=0.2.15-next.1, @backstage/plugin-notifications-node@npm:0.2.15-next.1, @backstage/plugin-notifications-node@npm:^0.2.15-next.1":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.39.0-next.2&npm=0.2.15-next.1, @backstage/plugin-notifications-node@npm:0.2.15-next.1, @backstage/plugin-notifications-node@npm:^0.2.15-next.1":
   version: 0.2.15-next.1
   resolution: "@backstage/plugin-notifications-node@npm:0.2.15-next.1"
   dependencies:
@@ -5768,17 +5839,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.39.0-next.1&npm=0.5.5-next.1, @backstage/plugin-notifications@npm:^0.5.5-next.1":
-  version: 0.5.5-next.1
-  resolution: "@backstage/plugin-notifications@npm:0.5.5-next.1"
+"@backstage/plugin-notifications@backstage:^::backstage=1.39.0-next.2&npm=0.5.5-next.2, @backstage/plugin-notifications@npm:^0.5.5-next.2":
+  version: 0.5.5-next.2
+  resolution: "@backstage/plugin-notifications@npm:0.5.5-next.2"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
-    "@backstage/plugin-signals-react": "npm:0.0.12"
+    "@backstage/plugin-signals-react": "npm:0.0.13-next.0"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.9.13"
@@ -5797,21 +5868,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3aea309afbdfb281f960bf5f2ed6eb52fcc8afaba5608f7b5a84d323daed36e5b8c3852569c025fdedf6c7fe08e636503b5e74c08e9f095d33ab116501482b61
+  checksum: 10/88d6e5a12e1aaaf1cbbb2d025f17fbdbf1428bd53c0ec6dbb27a4d768cf863419572742b2a2996a0a5c34b7d236c9b1354a344000ad7e6cb71ef16150e8d9fde
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.39.0-next.1&npm=0.6.39-next.1, @backstage/plugin-org@npm:^0.6.39-next.1":
-  version: 0.6.39-next.1
-  resolution: "@backstage/plugin-org@npm:0.6.39-next.1"
+"@backstage/plugin-org@backstage:^::backstage=1.39.0-next.2&npm=0.6.39-next.2, @backstage/plugin-org@npm:^0.6.39-next.2":
+  version: 0.6.39-next.2
+  resolution: "@backstage/plugin-org@npm:0.6.39-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5828,7 +5899,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5ee8e6f70204c7e194a77cf6883fc0949c43245232e2d7a55a44851350801518fece5fb1c3aaf473769c2235aa6948aee06f1dc75f73cfa6f688977a0f554bc8
+  checksum: 10/b4dfafec918b74b7d1bebbb75c6ebbcfc6c3f2bb1de9d620cadf8f809ad6157bc625115ee2f7e82d194478f2105e05b24a299e41aa04fb97d87dbe76e5cf03c9
   languageName: node
   linkType: hard
 
@@ -5898,12 +5969,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-react@npm:0.4.34-next.0":
-  version: 0.4.34-next.0
-  resolution: "@backstage/plugin-permission-react@npm:0.4.34-next.0"
+"@backstage/plugin-permission-react@npm:0.4.34-next.1":
+  version: 0.4.34-next.1
+  resolution: "@backstage/plugin-permission-react@npm:0.4.34-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
     swr: "npm:^2.0.0"
   peerDependencies:
@@ -5914,7 +5985,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7c82e4c345c59df095a7588b5fda5f7f20436a6a41b6a12503e316fcec775019f205c523e7727419d0c6caaaa9818e28bf80cc62034f70129a0d793711a9a77e
+  checksum: 10/e1be443ac31394e58e9b6c9170e2717af22aeeb7a964cc4357c6a24e23c5485a8c241ea4324e57ab4720790076b50a394ce6e30de20bf95c42cb2d3f65338484
   languageName: node
   linkType: hard
 
@@ -5938,7 +6009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.39.0-next.1&npm=0.6.2-next.1, @backstage/plugin-proxy-backend@npm:^0.6.2-next.1":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.39.0-next.2&npm=0.6.2-next.1, @backstage/plugin-proxy-backend@npm:^0.6.2-next.1":
   version: 0.6.2-next.1
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.2-next.1"
   dependencies:
@@ -5961,180 +6032,180 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.9-next.1":
-  version: 0.2.9-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.9-next.1"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.9-next.2":
+  version: 0.2.9-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.9-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     azure-devops-node-api: "npm:^14.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/b1a1fc0b0bdd0df10d4580a053212005b81caa2ce0d4d4d90a292a004e3752ee9716bb8abdd45b49380ba9640a4d037d43ee10bb82c5b547efde943ac2fab28c
+  checksum: 10/543c41fabfcfa2d4042dcda81df71e7f74235f20b99c57f70497605af6703a19054549ffa4ca0f782187c299a7d0f5731fe643a66cb05235e7e56c121c721d17
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.9-next.1":
-  version: 0.2.9-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.9-next.1"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.9-next.2":
+  version: 0.2.9-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.9-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.0-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.0-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     bitbucket: "npm:^2.12.0"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/36122132bbf23ee64f3b9753a93aed7e2dce027980db973ba029ec5b04e80123552267632f2e1be29706225921f1cb951943e4dfcff57d435eaf32a0d6109906
+  checksum: 10/a53ed62d142d8ff748412165fc9ff76f0a419d964528456a66ab472a0e56c77ca1a1d6d7cf1aecebd3a9f10e352625ca26fa0520fa76c87c24017c05001d8dbe
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.9-next.1":
-  version: 0.2.9-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.9-next.1"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.9-next.2":
+  version: 0.2.9-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.9-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/f8589b1e01dd93b7035d17c1c8f3c745934d4bd9faf9f8405ff40a1fbd19c46da8780b7f8894f649a31ad8ef06b7d6f25b5b8495e418f80c1604328c983aab63
+  checksum: 10/c72d1d985c793d1078185a6e88a581e7aae1583af3e99d52e1e3d81c31dae1f6b1a2c68a66a687f1ef7e8403cb72d7cc3981499816fc0c87a59c5630157b91f0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.10-next.1":
-  version: 0.3.10-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.10-next.1"
+"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.10-next.2":
+  version: 0.3.10-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.10-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.9-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.9-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.9-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.9-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/f3552235e5f01cf4a57b0cc5ea95a58ee9401f3c581a9d98753006a9ef5877eef5d19c583465d78a22992ad1988c354fde48f07dd31aafdfb01b24337dd09e92
+  checksum: 10/40d9fdc71c7a5df5aee99105868471ac1adccea688fc38a34a9041bf32b2594edfac3c4f37c3cfef55bd17fd663c91ce0db599c1a2875ee6e800f7c639e0843b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.9-next.1":
-  version: 0.2.9-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.9-next.1"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.9-next.2":
+  version: 0.2.9-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.9-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     yaml: "npm:^2.0.0"
-  checksum: 10/603a31466f1b859fdb1c378bf765cfe42c5229f35e594c04721c63023538089fea7a27a8266644df246e65f394a3de1689731e9b4271a92e2feb86684263592a
+  checksum: 10/9a30072b793812ea86dc4cc4365132598709f687712bb2e6b0bcd738d23878865ef39042edf64fd0755cb7d2ca424a1c7a26835f772106e9a30f4bc4eddcf02e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.9-next.1":
-  version: 0.2.9-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.9-next.1"
+"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.9-next.2":
+  version: 0.2.9-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.9-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     yaml: "npm:^2.0.0"
-  checksum: 10/fd6e79bd6c14cc97298547fd75328cf0ac823059c0ac16b1609ee82960f85d717c8218d60b5b9328c90e95a40ae8629b498c014808d4106da49b633aa596b75e
+  checksum: 10/e17c9968cfe0ffe347d1cb880733e93d5933637b37902164c0f355df4e6a2273329ef5fbb986cb9b72c385bbc559e9b9b3be33bdf643260bd2349be5969b8e24
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.39.0-next.1&npm=0.7.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:0.7.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.7.1-next.1":
-  version: 0.7.1-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.7.1-next.1"
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.39.0-next.2&npm=0.7.1-next.2, @backstage/plugin-scaffolder-backend-module-github@npm:0.7.1-next.2, @backstage/plugin-scaffolder-backend-module-github@npm:^0.7.1-next.2":
+  version: 0.7.1-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.7.1-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     "@backstage/types": "npm:1.2.1"
     "@octokit/webhooks": "npm:^10.9.2"
     libsodium-wrappers: "npm:^0.7.11"
     octokit: "npm:^3.0.0"
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/323c6c7827e9334f56a9588ea9604d46a593f489b78e2cd80d7718eab5bc221b1deaea7476d337d581b65858d0417d8f134aa714207ad888a9925ab659612f8c
+  checksum: 10/b8c62283c76889ce25052fe1ba7ef2bd49c7a4775aeae350ad22276432fbfca5cbe2842a91bfc1ccf168a6130f17f0fd462ed73505303d9b9eed969a7e6a8df4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.1-next.1":
-  version: 0.9.1-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.1-next.1"
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.1-next.2":
+  version: 0.9.1-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.1-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     winston: "npm:^3.2.1"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/33e223d7efd315099475541bed5df6385f7f8815643d23abe72beb3bea6c82b32ae66a26c05967086ffc600b91a32730b7a801ce8646d61c97d2aa604c69f2b1
+  checksum: 10/c9f43c07f7aed20f6be0c3c09f3f9ee49ce03491337b570a4ccbc6a4cdf939fdcdd9a0fc7fd4ee8a1caa2c4ca0d9ceed44314ff889b9da4805c479c1afaf0951
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.39.0-next.1&npm=0.1.10-next.1, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.10-next.1":
-  version: 0.1.10-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.10-next.1"
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.39.0-next.2&npm=0.1.10-next.2, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.10-next.2":
+  version: 0.1.10-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.10-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/plugin-notifications-common": "npm:0.0.8"
     "@backstage/plugin-notifications-node": "npm:0.2.15-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     octokit: "npm:^3.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/643267d95143328df8d322f96b382109d027bd3c8369c592be6aafea11201f120dd3ae1b3d6fa720f3e881b544d245508b194de47aa03a698e5d6159245e4ac8
+  checksum: 10/33d050f91d636422163e4160d33f3b1bc9122799a95f634f6e1fa6f8640e336c6bf328e2b1f416d414bdada18b71f2ecaa98c087b4e870c071d40398862a4c8d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.39.0-next.1&npm=1.33.0-next.1, @backstage/plugin-scaffolder-backend@npm:^1.33.0-next.1":
-  version: 1.33.0-next.1
-  resolution: "@backstage/plugin-scaffolder-backend@npm:1.33.0-next.1"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.39.0-next.2&npm=1.33.0-next.2, @backstage/plugin-scaffolder-backend@npm:^1.33.0-next.2":
+  version: 1.33.0-next.2
+  resolution: "@backstage/plugin-scaffolder-backend@npm:1.33.0-next.2"
   dependencies:
     "@backstage/backend-common": "npm:^0.25.0"
-    "@backstage/backend-defaults": "npm:0.10.0-next.1"
+    "@backstage/backend-defaults": "npm:0.10.0-next.2"
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
     "@backstage/plugin-auth-node": "npm:0.6.3-next.1"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.0-next.1"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.0-next.2"
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.8-next.1"
     "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
     "@backstage/plugin-events-node": "npm:0.4.11-next.1"
     "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
     "@backstage/plugin-permission-node": "npm:0.10.0-next.1"
-    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.9-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.10-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.9-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.9-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.9-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.9-next.1"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.7.1-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.9-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.10-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.9-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.9-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.9-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.9-next.2"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.7.1-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.9.1-next.2"
     "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.8.2-next.2"
     "@backstage/types": "npm:1.2.1"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/express": "npm:^4.17.6"
@@ -6164,7 +6235,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/f97d1ffff5422879952af78db39b319dce061e6497c6b0e5b445864a0e010119408dca5dc39ded7053ce57c47751549d27444f41b94aa86e7ddfc73e76c4843d
+  checksum: 10/75300d7217e968706ab063f6b2300d2aa1aa71fecba510370c85a8f47822a208ca589005a2fa0c2f8485453ea6a179b3a8324ddebd8cc463122b789d4e17a89a
   languageName: node
   linkType: hard
 
@@ -6179,14 +6250,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:0.8.2-next.1":
-  version: 0.8.2-next.1
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.8.2-next.1"
+"@backstage/plugin-scaffolder-node@npm:0.8.2-next.2":
+  version: 0.8.2-next.2
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.8.2-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
     "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
     "@backstage/types": "npm:1.2.1"
     "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
@@ -6201,21 +6272,21 @@ __metadata:
     winston-transport: "npm:^4.7.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/86e89d706d0376c25751ad10d2db0b708d47e7ab16e69bc049c0ec8610f8ab9e3fa18e8647c23a83061c12e252c9ea671f43225ede0ad4c0869a174e630bd0c9
+  checksum: 10/f8c8fe5f7374ef548d3ee38fa0f9872f4f52e2122a3f5cbeeb83f4678d0a827e129bc98520e09e9485436b9033016bff2c8f590695c044c10c17b0815c07b98f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.16.0-next.1":
-  version: 1.16.0-next.1
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.16.0-next.1"
+"@backstage/plugin-scaffolder-react@npm:1.16.0-next.2":
+  version: 1.16.0-next.2
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.16.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
-    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
@@ -6253,28 +6324,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e2a856db5a24a89fe9bfd02cd045cb69847bd5974ee1ee364ed992c6b3e140295dfcd7ff74cf9c7f5f84b18e1a9217aa4021cd64da3f96006b66572f71d4a037
+  checksum: 10/007e2328087d819bd85ed174113a9c25f75a22960709821244ac934ece39c7f662a03827438c40324c31af80afe9f681e8807e5271ed0d3c89c2057a112decf9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.39.0-next.1&npm=1.31.0-next.1, @backstage/plugin-scaffolder@npm:^1.31.0-next.1":
-  version: 1.31.0-next.1
-  resolution: "@backstage/plugin-scaffolder@npm:1.31.0-next.1"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.39.0-next.2&npm=1.31.0-next.2, @backstage/plugin-scaffolder@npm:^1.31.0-next.2":
+  version: 1.31.0-next.2
+  resolution: "@backstage/plugin-scaffolder@npm:1.31.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/integration-react": "npm:1.2.7-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/integration-react": "npm:1.2.7-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
-    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.5.11-next.0"
-    "@backstage/plugin-scaffolder-react": "npm:1.16.0-next.1"
+    "@backstage/plugin-scaffolder-react": "npm:1.16.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
@@ -6314,11 +6385,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fc80b4c19357dacf24eee7cd02e28755a494ae66631c4889387bf761c31460def9f1ca66acd8481cb5d69af5f1d1a58407f2036c050eee682960ce68d25ef8fd
+  checksum: 10/cf202d6b9936d585c411d34e55a34d6070800643510bee89a5764a3fa7ff1dfe0f7746526a0d5bf33f7aba6b9c4e6d9fc82b20908f2b6657af24d6c4a6690431
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.39.0-next.1&npm=0.3.4-next.1, @backstage/plugin-search-backend-module-catalog@npm:^0.3.4-next.1":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.39.0-next.2&npm=0.3.4-next.1, @backstage/plugin-search-backend-module-catalog@npm:^0.3.4-next.1":
   version: 0.3.4-next.1
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.4-next.1"
   dependencies:
@@ -6336,7 +6407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-explore@backstage:^::backstage=1.39.0-next.1&npm=0.3.2-next.1, @backstage/plugin-search-backend-module-explore@npm:^0.3.2-next.1":
+"@backstage/plugin-search-backend-module-explore@backstage:^::backstage=1.39.0-next.2&npm=0.3.2-next.1, @backstage/plugin-search-backend-module-explore@npm:^0.3.2-next.1":
   version: 0.3.2-next.1
   resolution: "@backstage/plugin-search-backend-module-explore@npm:0.3.2-next.1"
   dependencies:
@@ -6349,9 +6420,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-techdocs@npm:0.4.2-next.1":
-  version: 0.4.2-next.1
-  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.4.2-next.1"
+"@backstage/plugin-search-backend-module-techdocs@npm:0.4.2-next.2":
+  version: 0.4.2-next.2
+  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.4.2-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
@@ -6362,10 +6433,10 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
     "@backstage/plugin-search-backend-node": "npm:1.3.11-next.1"
     "@backstage/plugin-search-common": "npm:1.2.18-next.0"
-    "@backstage/plugin-techdocs-node": "npm:1.13.3-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.13.3-next.2"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/bf9b98438d7d80c48ed17b8f70e11694c3c0b3cf35a7107e742b37e1c7b16e3d3bed6d31d367b580c2ef4741687860ec9906c505e4ed84813873f275688dc3cc
+  checksum: 10/9a30515be95016000c1086084252dc366ad82db185c76c29446de0f6a216c8e1e450a3a0f755ac4fe5a1fb9590d1834e19974c316c12481fee4574adf1f136df
   languageName: node
   linkType: hard
 
@@ -6387,11 +6458,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.39.0-next.1&npm=2.0.2-next.1, @backstage/plugin-search-backend@npm:^2.0.2-next.1":
-  version: 2.0.2-next.1
-  resolution: "@backstage/plugin-search-backend@npm:2.0.2-next.1"
+"@backstage/plugin-search-backend@backstage:^::backstage=1.39.0-next.2&npm=2.0.2-next.2, @backstage/plugin-search-backend@npm:^2.0.2-next.2":
+  version: 2.0.2-next.2
+  resolution: "@backstage/plugin-search-backend@npm:2.0.2-next.2"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.10.0-next.1"
+    "@backstage/backend-defaults": "npm:0.10.0-next.2"
     "@backstage/backend-openapi-utils": "npm:0.5.3-next.1"
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/config": "npm:1.3.2"
@@ -6407,7 +6478,7 @@ __metadata:
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/ebc57bbc45fbb936583e0a472a87bf620a483fd9d729d60b3beec477243b778ec8a0a433490b135d785398488660ec2cac0561cbe8a5ab26673fc58fc15fdb2e
+  checksum: 10/e2f204a66dc74baf8b0d01724831c577db8f616320cd7d29f621ba998cdca8f5aaac987ec0b706788cf4b5e7bd96b5277ef8642d7db87b0b1992cf05d4e7b90c
   languageName: node
   linkType: hard
 
@@ -6431,13 +6502,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.39.0-next.1&npm=1.9.0-next.0, @backstage/plugin-search-react@npm:1.9.0-next.0, @backstage/plugin-search-react@npm:^1.9.0-next.0":
-  version: 1.9.0-next.0
-  resolution: "@backstage/plugin-search-react@npm:1.9.0-next.0"
+"@backstage/plugin-search-react@backstage:^::backstage=1.39.0-next.2&npm=1.9.0-next.1, @backstage/plugin-search-react@npm:1.9.0-next.1, @backstage/plugin-search-react@npm:^1.9.0-next.1":
+  version: 1.9.0-next.1
+  resolution: "@backstage/plugin-search-react@npm:1.9.0-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
     "@backstage/plugin-search-common": "npm:1.2.18-next.0"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
@@ -6457,7 +6528,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/cbc435869d1691b28ed96585672be58dcb7b5c51c5e75663b22217be89c0d708dae40391d4175af2719003e9242e0c3bf7b6f11864dc26e7b755f660c378e957
+  checksum: 10/54b11526dfb9dcc49f3dafc73ef6245253edc9955d5994cbaa508a7aa8b7379f50d3dc33412edf45847c6bbabeaaaeae21cd7dd78a90a0799175a4c715bed1a1
   languageName: node
   linkType: hard
 
@@ -6491,18 +6562,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.39.0-next.1&npm=1.4.26-next.1, @backstage/plugin-search@npm:^1.4.26-next.1":
-  version: 1.4.26-next.1
-  resolution: "@backstage/plugin-search@npm:1.4.26-next.1"
+"@backstage/plugin-search@backstage:^::backstage=1.39.0-next.2&npm=1.4.26-next.2, @backstage/plugin-search@npm:^1.4.26-next.2":
+  version: 1.4.26-next.2
+  resolution: "@backstage/plugin-search@npm:1.4.26-next.2"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
     "@backstage/plugin-search-common": "npm:1.2.18-next.0"
-    "@backstage/plugin-search-react": "npm:1.9.0-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -6517,11 +6588,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/34c5a24bbbd0499297582cb568c7671243199fcde4db127807379146cbd1137175b2cc311f8b4c2264486bb76ae7ea4e859aeaa908a1bf4d4c04d72a16e6d480
+  checksum: 10/0b124bc97db6cf5de836dcf632b8183c348ec12df52c6dad794599180d100a9b63e5690b9440efa27ddcab91f3cff9df0984c964c33c524f0ab49604e54df997
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.39.0-next.1&npm=0.3.4-next.1, @backstage/plugin-signals-backend@npm:^0.3.4-next.1":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.39.0-next.2&npm=0.3.4-next.1, @backstage/plugin-signals-backend@npm:^0.3.4-next.1":
   version: 0.3.4-next.1
   resolution: "@backstage/plugin-signals-backend@npm:0.3.4-next.1"
   dependencies:
@@ -6558,12 +6629,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-react@npm:0.0.12":
-  version: 0.0.12
-  resolution: "@backstage/plugin-signals-react@npm:0.0.12"
+"@backstage/plugin-signals-react@npm:0.0.13-next.0":
+  version: 0.0.13-next.0
+  resolution: "@backstage/plugin-signals-react@npm:0.0.13-next.0"
   dependencies:
-    "@backstage/core-plugin-api": "npm:^1.10.6"
-    "@backstage/types": "npm:^1.2.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.4"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -6573,18 +6644,18 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ec2793ad36ed11f06a62ac86c84e347a446ae550c47888a79e266b35445a2f89b40b9dc1392d382d1ce772bd2ee7d7e00b6040580bccaea1a63804437c0ea28e
+  checksum: 10/826a420a111291c146ce94ee2141d822bed9c274753a3a31a148e44932fcf03bd0e37d57456cb190cf1e6bde045afe1c6ce92c362e01105315044f32bde39dc7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.39.0-next.1&npm=0.0.19-next.0, @backstage/plugin-signals@npm:^0.0.19-next.0":
-  version: 0.0.19-next.0
-  resolution: "@backstage/plugin-signals@npm:0.0.19-next.0"
+"@backstage/plugin-signals@backstage:^::backstage=1.39.0-next.2&npm=0.0.19-next.1, @backstage/plugin-signals@npm:^0.0.19-next.1":
+  version: 0.0.19-next.1
+  resolution: "@backstage/plugin-signals@npm:0.0.19-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-signals-react": "npm:0.0.12"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-signals-react": "npm:0.0.13-next.0"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.4"
@@ -6600,27 +6671,27 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5bc2c1104004a8eed8a18a12ca0211d1df40e7ff9cadf57710b5f71914eb1ac474a78d575fc3fa46d2e1415d9d8c7ffe63353cfb5db82c65a7ed043f979de39e
+  checksum: 10/cbbe70b2ba1714cadddd3718664525470209bfe0b97570a6922be71a301ce1259a2f863f0ceea59fda1d57c2ee7c3ca2ff657bdab2024c3be9ced3d80b9c871d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.39.0-next.1&npm=2.0.2-next.1, @backstage/plugin-techdocs-backend@npm:^2.0.2-next.1":
-  version: 2.0.2-next.1
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.2-next.1"
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.39.0-next.2&npm=2.0.2-next.2, @backstage/plugin-techdocs-backend@npm:^2.0.2-next.2":
+  version: 2.0.2-next.2
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.2-next.2"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.10.0-next.1"
+    "@backstage/backend-defaults": "npm:0.10.0-next.2"
     "@backstage/backend-plugin-api": "npm:1.3.1-next.1"
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.4-next.0"
     "@backstage/plugin-catalog-node": "npm:1.17.0-next.1"
     "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
-    "@backstage/plugin-search-backend-module-techdocs": "npm:0.4.2-next.1"
+    "@backstage/plugin-search-backend-module-techdocs": "npm:0.4.2-next.2"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-node": "npm:1.13.3-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.13.3-next.2"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
@@ -6628,7 +6699,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/3198aee55f0ddf9c4f5f885de66303054c65a60738241d5133a1594e523b5cac7448da2e3b39ddf97659432161b3fc2fd1ced3a0c926604df32c8658f642897e
+  checksum: 10/4fa1a43a7cec5685f6e9a182051629855528760e7dff39305b06e93ae7c5429a6c3a8ec28aa94734bf1f036b004041b66740788fca0eaaf7c968c8c4dc9f145d
   languageName: node
   linkType: hard
 
@@ -6639,16 +6710,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.39.0-next.1&npm=1.1.24-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.24-next.1":
-  version: 1.1.24-next.1
-  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.24-next.1"
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.39.0-next.2&npm=1.1.24-next.2, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.24-next.2":
+  version: 1.1.24-next.2
+  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.24-next.2"
   dependencies:
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/integration-react": "npm:1.2.7-next.1"
-    "@backstage/plugin-techdocs-react": "npm:1.2.17-next.0"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/integration-react": "npm:1.2.7-next.2"
+    "@backstage/plugin-techdocs-react": "npm:1.2.17-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@react-hookz/web": "npm:^24.0.0"
@@ -6662,13 +6733,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/98fd9f3b287baa55c652d116fbb4a0e617382672e0e4a11e20b9ea875f8e3a53be073ac5d943b2aa799c50a4f086be6e5a8a534dfcd85e01a93f47585dda7c07
+  checksum: 10/d5ebc3ec7e7546c47f8b16b5a890b0ee8985fa4138df070cb5f183db61a1bd4b14aca04bd1c4d71f88d082b8923b526d29a2e3a439ed6a826ed7d2a871c093f8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.39.0-next.1&npm=1.13.3-next.1, @backstage/plugin-techdocs-node@npm:1.13.3-next.1, @backstage/plugin-techdocs-node@npm:^1.13.3-next.1":
-  version: 1.13.3-next.1
-  resolution: "@backstage/plugin-techdocs-node@npm:1.13.3-next.1"
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.39.0-next.2&npm=1.13.3-next.2, @backstage/plugin-techdocs-node@npm:1.13.3-next.2, @backstage/plugin-techdocs-node@npm:^1.13.3-next.2":
+  version: 1.13.3-next.2
+  resolution: "@backstage/plugin-techdocs-node@npm:1.13.3-next.2"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -6680,8 +6751,8 @@ __metadata:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/integration-aws-node": "npm:0.1.15"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/integration-aws-node": "npm:0.1.16-next.0"
     "@backstage/plugin-search-common": "npm:1.2.18-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
     "@google-cloud/storage": "npm:^7.0.0"
@@ -6699,19 +6770,19 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/d123be0f2fc3d2d83d472fc46d122f4465625947460705b8e17edc5c2e998b74cbad8ac02ec24dfed5f9cfee5aa76ed319d97e2d7b5d58f0489b35ee2d4cb197
+  checksum: 10/4463f2bda17154feb3a1cb146104e8905affb7ffa16aeb95691ddbcc6807b0f343d5721a945e45e1fd2c665692a347220aa23279601013ba826ee5c730182129
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.39.0-next.1&npm=1.2.17-next.0, @backstage/plugin-techdocs-react@npm:1.2.17-next.0, @backstage/plugin-techdocs-react@npm:^1.2.17-next.0":
-  version: 1.2.17-next.0
-  resolution: "@backstage/plugin-techdocs-react@npm:1.2.17-next.0"
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.39.0-next.2&npm=1.2.17-next.1, @backstage/plugin-techdocs-react@npm:1.2.17-next.1, @backstage/plugin-techdocs-react@npm:^1.2.17-next.1":
+  version: 1.2.17-next.1
+  resolution: "@backstage/plugin-techdocs-react@npm:1.2.17-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/styles": "npm:^4.11.0"
@@ -6727,7 +6798,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/741267d9fe46cee5d6723299501bef3e71c61cedf925b60fc56894ec394d8170c5cc15169bcbdaee7943a5ef841575bf94a0410410e1619da8260d78b03a1527
+  checksum: 10/4e3612814a67531b3b859f2ead568a4e4d5c8c33c113c846f54009d4b38f0601eb4bda737350895edca2222a4239d20b61411a85c493001813777cd2ea384517
   languageName: node
   linkType: hard
 
@@ -6759,26 +6830,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.39.0-next.1&npm=1.12.6-next.1, @backstage/plugin-techdocs@npm:^1.12.6-next.1":
-  version: 1.12.6-next.1
-  resolution: "@backstage/plugin-techdocs@npm:1.12.6-next.1"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.39.0-next.2&npm=1.12.6-next.2, @backstage/plugin-techdocs@npm:^1.12.6-next.2":
+  version: 1.12.6-next.2
+  resolution: "@backstage/plugin-techdocs@npm:1.12.6-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.0-next.0"
     "@backstage/catalog-model": "npm:1.7.3"
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/integration": "npm:1.16.4-next.1"
-    "@backstage/integration-react": "npm:1.2.7-next.1"
-    "@backstage/plugin-auth-react": "npm:0.1.15-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/integration": "npm:1.17.0-next.2"
+    "@backstage/integration-react": "npm:1.2.7-next.2"
+    "@backstage/plugin-auth-react": "npm:0.1.15-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
     "@backstage/plugin-search-common": "npm:1.2.18-next.0"
-    "@backstage/plugin-search-react": "npm:1.9.0-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.0-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.0"
-    "@backstage/plugin-techdocs-react": "npm:1.2.17-next.0"
+    "@backstage/plugin-techdocs-react": "npm:1.2.17-next.1"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6799,7 +6870,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b88a5cf6a993e1c8adadfd931ce3e8ccbe3c02ba9b8f1d043068789dbbfd77e75e339442ee2690bd5add608c392ddc7eaafa036ebb2e05aaecf301e014a5c1ef
+  checksum: 10/96501e1bde092802973ca58dd25ab4bc7256bd4937d8e68e8309e1a75f0ae0e18b08b32b14dc8f2773eb9f186bd14ba1d7fbe91bad892370edf9f03b191be8a8
   languageName: node
   linkType: hard
 
@@ -6810,19 +6881,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.39.0-next.1&npm=0.8.22-next.1, @backstage/plugin-user-settings@npm:^0.8.22-next.1":
-  version: 0.8.22-next.1
-  resolution: "@backstage/plugin-user-settings@npm:0.8.22-next.1"
+"@backstage/plugin-user-settings@backstage:^::backstage=1.39.0-next.2&npm=0.8.22-next.2, @backstage/plugin-user-settings@npm:^0.8.22-next.2":
+  version: 0.8.22-next.2
+  resolution: "@backstage/plugin-user-settings@npm:0.8.22-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.3"
-    "@backstage/core-app-api": "npm:1.16.1"
-    "@backstage/core-compat-api": "npm:0.4.2-next.1"
-    "@backstage/core-components": "npm:0.17.2-next.0"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-app-api": "npm:1.16.2-next.0"
+    "@backstage/core-compat-api": "npm:0.4.2-next.2"
+    "@backstage/core-components": "npm:0.17.2-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.10.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.18.0-next.1"
-    "@backstage/plugin-signals-react": "npm:0.0.12"
+    "@backstage/frontend-plugin-api": "npm:0.10.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.18.0-next.2"
+    "@backstage/plugin-signals-react": "npm:0.0.13-next.0"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
@@ -6839,7 +6910,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a64cbca3abc376d8d5d43f918f052df2a3887da82f3613f4e05c5c7b8d9bd66de1d85b1a0b1c0dd858534f2035c69e170d0474f885acbd0d7e8eaa70d022ffb0
+  checksum: 10/d62356ca882b624fbec601cd83a6c835a214981b90ad514201b8139f1bf2016c7994eaa6ca48a5a9398f2966817197f3540acee03141b6754be40013c909739c
   languageName: node
   linkType: hard
 
@@ -6850,15 +6921,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/test-utils@npm:1.7.8-next.0":
-  version: 1.7.8-next.0
-  resolution: "@backstage/test-utils@npm:1.7.8-next.0"
+"@backstage/test-utils@npm:1.7.8-next.1":
+  version: 1.7.8-next.1
+  resolution: "@backstage/test-utils@npm:1.7.8-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.2"
-    "@backstage/core-app-api": "npm:1.16.1"
-    "@backstage/core-plugin-api": "npm:1.10.6"
+    "@backstage/core-app-api": "npm:1.16.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.7-next.0"
     "@backstage/plugin-permission-common": "npm:0.9.0-next.0"
-    "@backstage/plugin-permission-react": "npm:0.4.34-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.34-next.1"
     "@backstage/theme": "npm:0.6.6-next.0"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
@@ -6875,7 +6946,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/46085ddb19c5ff926da92648dc815d3875bbe8a527fe480112e40825dd18707a0f451928d0a197ea2433a40c567acfdef8d1301390c6d69947cdbdc2b92e069f
+  checksum: 10/39dccf06d70f59916add1f1a67408b96e25fa4642e3905c4cf28090b91ab44943a98b47b7e9bbd969e0139956c8de62b536ed16832067a37d378edb2c0d3d173
   languageName: node
   linkType: hard
 
@@ -6908,7 +6979,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.39.0-next.1&npm=0.6.6-next.0, @backstage/theme@npm:0.6.6-next.0, @backstage/theme@npm:^0.6.6-next.0":
+"@backstage/theme@backstage:^::backstage=1.39.0-next.2&npm=0.6.6-next.0, @backstage/theme@npm:0.6.6-next.0, @backstage/theme@npm:^0.6.6-next.0":
   version: 0.6.6-next.0
   resolution: "@backstage/theme@npm:0.6.6-next.0"
   dependencies:
@@ -6993,16 +7064,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@base-ui-components/react@npm:^1.0.0-alpha.7":
-  version: 1.0.0-alpha.8
-  resolution: "@base-ui-components/react@npm:1.0.0-alpha.8"
+"@base-ui-components/react@npm:1.0.0-alpha.7":
+  version: 1.0.0-alpha.7
+  resolution: "@base-ui-components/react@npm:1.0.0-alpha.7"
   dependencies:
-    "@babel/runtime": "npm:^7.27.0"
-    "@floating-ui/react": "npm:^0.27.7"
+    "@babel/runtime": "npm:^7.26.10"
+    "@floating-ui/react": "npm:^0.27.5"
     "@floating-ui/utils": "npm:^0.2.9"
-    "@react-aria/overlays": "npm:^3.27.0"
+    "@react-aria/overlays": "npm:^3.26.1"
     prop-types: "npm:^15.8.1"
-    use-sync-external-store: "npm:^1.5.0"
+    use-sync-external-store: "npm:^1.4.0"
   peerDependencies:
     "@types/react": ^17 || ^18 || ^19
     react: ^17 || ^18 || ^19
@@ -7010,7 +7081,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/02bee635d0dd6ab801a52b7226cbc22ff81af1272e15eb595423f77c6f8f3851eae9672a5192a37dab9104619cfc95858af5e9d9d26b1599872f1ff81ab9b9c0
+  checksum: 10/2a1393f5e2bd0af7f32e10259fe86a1482411d57011aa8cf4f9780f4f06eee61c2dc2216ee0526dd3648d609b951cb3b1e5fcb5aba643c82ac7fab6d8af054e7
   languageName: node
   linkType: hard
 
@@ -7878,7 +7949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/react@npm:^0.27.7":
+"@floating-ui/react@npm:^0.27.5":
   version: 0.27.8
   resolution: "@floating-ui/react@npm:0.27.8"
   dependencies:
@@ -11555,7 +11626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-aria/overlays@npm:^3.27.0":
+"@react-aria/overlays@npm:^3.26.1":
   version: 3.27.0
   resolution: "@react-aria/overlays@npm:3.27.0"
   dependencies:
@@ -34667,7 +34738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.0.0, use-sync-external-store@npm:^1.2.0, use-sync-external-store@npm:^1.5.0":
+"use-sync-external-store@npm:^1.0.0, use-sync-external-store@npm:^1.2.0, use-sync-external-store@npm:^1.4.0":
   version: 1.5.0
   resolution: "use-sync-external-store@npm:1.5.0"
   peerDependencies:


### PR DESCRIPTION
Backstage release v1.39.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.39.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.39.0-next.2-changelog.md)
- Upgrade Helper: [From 1.39.0-next.1 to 1.39.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.39.0-next.1&to=1.39.0-next.2)
 
Created by [Version Bump 14883376164](https://github.com/backstage/demo/actions/runs/14883376164)
 