### PR TITLE
fix: remove node version from task name

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 1
 
       # Beginning of yarn setup
-      - name: use node.js 20.x
+      - name: use node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.x


### PR DESCRIPTION
Removes incorrect NodeJS version from the task name.

Another fix would be to update the version in the name to match the actual version used, but it is likely that this will not be maintained.