### PR TITLE
Removed `allowedHosts` from the Demo Template

### DIFF
--- a/demo-template/template/template.yaml
+++ b/demo-template/template/template.yaml
@@ -128,7 +128,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com']
         repoUrl: ${{ parameters.repoUrl }}
         token: ${{ secrets.USER_OAUTH_TOKEN or false }}
         repoVisibility: public


### PR DESCRIPTION
Removed `allowedHosts` from the Demo Template

Fixes #1005 