### PR TITLE
v1.41.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 8af7b3f2d7d19cacc7a3712f871efcb6208ba283a1f532260b0cba80c2cb66ed772b207b5ba41b8c5d64dd8d5e0c0e15bbb445bd14afac491712965211ba027c
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.41.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.41.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.41.0-next.1"
+  "version": "1.41.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3501,15 +3501,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.41.0-next.1&npm=1.6.4-next.1, @backstage/app-defaults@npm:^1.6.4-next.1":
-  version: 1.6.4-next.1
-  resolution: "@backstage/app-defaults@npm:1.6.4-next.1"
+"@backstage/app-defaults@backstage:^::backstage=1.41.0-next.2&npm=1.6.4-next.2, @backstage/app-defaults@npm:^1.6.4-next.2":
+  version: 1.6.4-next.2
+  resolution: "@backstage/app-defaults@npm:1.6.4-next.2"
   dependencies:
-    "@backstage/core-app-api": "npm:1.17.2-next.0"
-    "@backstage/core-components": "npm:0.17.4-next.1"
+    "@backstage/core-app-api": "npm:1.18.0-next.1"
+    "@backstage/core-components": "npm:0.17.4-next.2"
     "@backstage/core-plugin-api": "npm:1.10.9-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.36-next.0"
-    "@backstage/theme": "npm:0.6.7-next.0"
+    "@backstage/theme": "npm:0.6.7-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -3520,7 +3520,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4238ed6416bd57a2499d175e904575e0cfd0dfc71c57fcec6768e6dc4d40bd258a8a31cfa8b0eaca933a284ae99c9c78e0e2d0a14c54c8e4fef5d42008d23de6
+  checksum: 10/2e6ff4d436545913bb9d4b2518cb97a6d0e594c84cffa499311a21832b4f64184eaecb38047f7456cd0bb84819f0f6671423767658a324d353bc0e267ef02b15
   languageName: node
   linkType: hard
 
@@ -3699,7 +3699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.41.0-next.1&npm=0.11.1-next.1, @backstage/backend-defaults@npm:0.11.1-next.1, @backstage/backend-defaults@npm:^0.11.1-next.1":
+"@backstage/backend-defaults@backstage:^::backstage=1.41.0-next.2&npm=0.11.1-next.1, @backstage/backend-defaults@npm:0.11.1-next.1, @backstage/backend-defaults@npm:^0.11.1-next.1":
   version: 0.11.1-next.1
   resolution: "@backstage/backend-defaults@npm:0.11.1-next.1"
   dependencies:
@@ -3920,7 +3920,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.41.0-next.1&npm=1.4.1-next.0, @backstage/backend-plugin-api@npm:1.4.1-next.0, @backstage/backend-plugin-api@npm:^1.4.1-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.41.0-next.2&npm=1.4.1-next.0, @backstage/backend-plugin-api@npm:1.4.1-next.0, @backstage/backend-plugin-api@npm:^1.4.1-next.0":
   version: 1.4.1-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.4.1-next.0"
   dependencies:
@@ -3983,14 +3983,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/canon@backstage:^::backstage=1.41.0-next.1&npm=0.6.0-next.0, @backstage/canon@npm:^0.6.0-next.0":
-  version: 0.6.0-next.0
-  resolution: "@backstage/canon@npm:0.6.0-next.0"
+"@backstage/canon@backstage:^::backstage=1.41.0-next.2&npm=0.6.0-next.1, @backstage/canon@npm:^0.6.0-next.1":
+  version: 0.6.0-next.1
+  resolution: "@backstage/canon@npm:0.6.0-next.1"
   dependencies:
     "@base-ui-components/react": "npm:1.0.0-alpha.7"
     "@remixicon/react": "npm:^4.6.0"
     "@tanstack/react-table": "npm:^8.21.3"
     clsx: "npm:^2.1.1"
+    motion: "npm:^12.20.1"
     react-aria-components: "npm:^1.10.1"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -4000,7 +4001,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0198f11aabe2638f4c24b900c9299c3188b63cff31f7269f578f32f8a647edc29df6d99b69a327916136b1a6d330ebbd116bbdac0b0ab7b19f9371c49de9a942
+  checksum: 10/f17a5387bd52f3fbed8fd7082f7334a4e6617fd1d5452e277893cdd7debb652e25ee929736c941548374a98262896cd37f72cc20111c349b4907a6378d48afc1
   languageName: node
   linkType: hard
 
@@ -4028,7 +4029,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.41.0-next.1&npm=1.7.5-next.0, @backstage/catalog-model@npm:1.7.5-next.0, @backstage/catalog-model@npm:^1.7.5-next.0":
+"@backstage/catalog-model@backstage:^::backstage=1.41.0-next.2&npm=1.7.5-next.0, @backstage/catalog-model@npm:1.7.5-next.0, @backstage/catalog-model@npm:^1.7.5-next.0":
   version: 1.7.5-next.0
   resolution: "@backstage/catalog-model@npm:1.7.5-next.0"
   dependencies:
@@ -4075,9 +4076,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.41.0-next.1&npm=0.33.1-next.1, @backstage/cli@npm:^0.33.1-next.1":
-  version: 0.33.1-next.1
-  resolution: "@backstage/cli@npm:0.33.1-next.1"
+"@backstage/cli@backstage:^::backstage=1.41.0-next.2&npm=0.33.1-next.2, @backstage/cli@npm:^0.33.1-next.2":
+  version: 0.33.1-next.2
+  resolution: "@backstage/cli@npm:0.33.1-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.5-next.0"
     "@backstage/cli-common": "npm:0.1.15"
@@ -4206,7 +4207,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/5d6ee8d5c5b2e0b6db26c001591a98537b4fc130959643acff623f25176dfc4e68dc2b1eaf11516fad9ff7b22bf9177c882477a207008a643add9d000224dd59
+  checksum: 10/575d54036ed6d61071b7c46c1ee0a3859db1a149efd6212acd7c2aeae85b6d4c04ace453c4d724a40b874ac5a9dfff4b13fd4f4aded175eed15eb1a81ba028f8
   languageName: node
   linkType: hard
 
@@ -4256,7 +4257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.41.0-next.1&npm=1.3.3-next.0, @backstage/config@npm:1.3.3-next.0, @backstage/config@npm:^1.3.3-next.0":
+"@backstage/config@backstage:^::backstage=1.41.0-next.2&npm=1.3.3-next.0, @backstage/config@npm:1.3.3-next.0, @backstage/config@npm:^1.3.3-next.0":
   version: 1.3.3-next.0
   resolution: "@backstage/config@npm:1.3.3-next.0"
   dependencies:
@@ -4278,7 +4279,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.41.0-next.1&npm=1.17.2-next.0, @backstage/core-app-api@npm:1.17.2-next.0, @backstage/core-app-api@npm:^1.17.2-next.0":
+"@backstage/core-app-api@backstage:^::backstage=1.41.0-next.2&npm=1.18.0-next.1, @backstage/core-app-api@npm:1.18.0-next.1, @backstage/core-app-api@npm:^1.18.0-next.1":
+  version: 1.18.0-next.1
+  resolution: "@backstage/core-app-api@npm:1.18.0-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.9-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@types/prop-types": "npm:^15.7.3"
+    history: "npm:^5.0.0"
+    i18next: "npm:^22.4.15"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/efa762bd535ed9fdff82e51d44dfd4a45028f883d41c498281c63c67d402ab987e85285aa595439225085dead6519f8a739a6c4a12d31520ea3f2edcd77a4790
+  languageName: node
+  linkType: hard
+
+"@backstage/core-app-api@npm:1.17.2-next.0":
   version: 1.17.2-next.0
   resolution: "@backstage/core-app-api@npm:1.17.2-next.0"
   dependencies:
@@ -4334,7 +4363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.41.0-next.1&npm=0.4.4-next.1, @backstage/core-compat-api@npm:0.4.4-next.1, @backstage/core-compat-api@npm:^0.4.4-next.1":
+"@backstage/core-compat-api@backstage:^::backstage=1.41.0-next.2&npm=0.4.4-next.1, @backstage/core-compat-api@npm:0.4.4-next.1, @backstage/core-compat-api@npm:^0.4.4-next.1":
   version: 0.4.4-next.1
   resolution: "@backstage/core-compat-api@npm:0.4.4-next.1"
   dependencies:
@@ -4392,7 +4421,61 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.41.0-next.1&npm=0.17.4-next.1, @backstage/core-components@npm:0.17.4-next.1, @backstage/core-components@npm:^0.17.4-next.1":
+"@backstage/core-components@backstage:^::backstage=1.41.0-next.2&npm=0.17.4-next.2, @backstage/core-components@npm:0.17.4-next.2, @backstage/core-components@npm:^0.17.4-next.2":
+  version: 0.17.4-next.2
+  resolution: "@backstage/core-components@npm:0.17.4-next.2"
+  dependencies:
+    "@backstage/config": "npm:1.3.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.10.9-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/theme": "npm:0.6.7-next.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.1.3"
+    linkifyjs: "npm:4.1.3"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/c9bd1e62e81aeb7af992fc8fac42a8066b44e3f06218a98e6f1115528a4ac26c783c26c24e624b723c4dd933c6c6d311bdc3bd89a04741d6a434cdacbf86b02b
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.17.4-next.1":
   version: 0.17.4-next.1
   resolution: "@backstage/core-components@npm:0.17.4-next.1"
   dependencies:
@@ -4549,7 +4632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.41.0-next.1&npm=1.10.9-next.0, @backstage/core-plugin-api@npm:1.10.9-next.0, @backstage/core-plugin-api@npm:^1.10.9-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.41.0-next.2&npm=1.10.9-next.0, @backstage/core-plugin-api@npm:1.10.9-next.0, @backstage/core-plugin-api@npm:^1.10.9-next.0":
   version: 1.10.9-next.0
   resolution: "@backstage/core-plugin-api@npm:1.10.9-next.0"
   dependencies:
@@ -4591,7 +4674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.41.0-next.1&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.41.0-next.2&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -4678,7 +4761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.41.0-next.1&npm=0.2.4-next.1, @backstage/frontend-defaults@npm:0.2.4-next.1, @backstage/frontend-defaults@npm:^0.2.4-next.1":
+"@backstage/frontend-defaults@backstage:^::backstage=1.41.0-next.2&npm=0.2.4-next.1, @backstage/frontend-defaults@npm:0.2.4-next.1, @backstage/frontend-defaults@npm:^0.2.4-next.1":
   version: 0.2.4-next.1
   resolution: "@backstage/frontend-defaults@npm:0.2.4-next.1"
   dependencies:
@@ -4722,7 +4805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.41.0-next.1&npm=0.10.4-next.1, @backstage/frontend-plugin-api@npm:0.10.4-next.1, @backstage/frontend-plugin-api@npm:^0.10.4-next.1":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.41.0-next.2&npm=0.10.4-next.1, @backstage/frontend-plugin-api@npm:0.10.4-next.1, @backstage/frontend-plugin-api@npm:^0.10.4-next.1":
   version: 0.10.4-next.1
   resolution: "@backstage/frontend-plugin-api@npm:0.10.4-next.1"
   dependencies:
@@ -4870,7 +4953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.41.0-next.1&npm=1.2.9-next.1, @backstage/integration-react@npm:1.2.9-next.1, @backstage/integration-react@npm:^1.2.9-next.1":
+"@backstage/integration-react@backstage:^::backstage=1.41.0-next.2&npm=1.2.9-next.1, @backstage/integration-react@npm:1.2.9-next.1, @backstage/integration-react@npm:^1.2.9-next.1":
   version: 1.2.9-next.1
   resolution: "@backstage/integration-react@npm:1.2.9-next.1"
   dependencies:
@@ -4966,7 +5049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.41.0-next.1&npm=0.12.9-next.1, @backstage/plugin-api-docs@npm:^0.12.9-next.1":
+"@backstage/plugin-api-docs@backstage:^::backstage=1.41.0-next.2&npm=0.12.9-next.1, @backstage/plugin-api-docs@npm:^0.12.9-next.1":
   version: 0.12.9-next.1
   resolution: "@backstage/plugin-api-docs@npm:0.12.9-next.1"
   dependencies:
@@ -5002,7 +5085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.41.0-next.1&npm=0.5.4-next.0, @backstage/plugin-app-backend@npm:^0.5.4-next.0":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.41.0-next.2&npm=0.5.4-next.0, @backstage/plugin-app-backend@npm:^0.5.4-next.0":
   version: 0.5.4-next.0
   resolution: "@backstage/plugin-app-backend@npm:0.5.4-next.0"
   dependencies:
@@ -5093,7 +5176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.41.0-next.1&npm=0.3.5-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.5-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.41.0-next.2&npm=0.3.5-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.5-next.0":
   version: 0.3.5-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.5-next.0"
   dependencies:
@@ -5105,7 +5188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.41.0-next.1&npm=0.2.10-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.10-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.41.0-next.2&npm=0.2.10-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.10-next.0":
   version: 0.2.10-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.10-next.0"
   dependencies:
@@ -5118,9 +5201,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.41.0-next.1&npm=0.25.2-next.0, @backstage/plugin-auth-backend@npm:^0.25.2-next.0":
-  version: 0.25.2-next.0
-  resolution: "@backstage/plugin-auth-backend@npm:0.25.2-next.0"
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.41.0-next.2&npm=0.25.2-next.1, @backstage/plugin-auth-backend@npm:^0.25.2-next.1":
+  version: 0.25.2-next.1
+  resolution: "@backstage/plugin-auth-backend@npm:0.25.2-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/catalog-model": "npm:1.7.5-next.0"
@@ -5142,7 +5225,7 @@ __metadata:
     minimatch: "npm:^9.0.0"
     passport: "npm:^0.7.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/44ffada16d33136e37d5a19f266f14ebde6b7493802726929d9ac0182d4f83b3d42eaa335cc36a76366fbe612a506f7ea15720526b7f130c88e6e510c137952c
+  checksum: 10/90044e5e42996395507c1739a8408d7bf9d1ddf71e67213e08f1c95820dd10805357615ff30b5c39643d26c6f2f957b248a181cd93ee63de6f86701a5e80e141
   languageName: node
   linkType: hard
 
@@ -5273,7 +5356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.41.0-next.1&npm=0.10.1-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.10.1-next.1":
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.41.0-next.2&npm=0.10.1-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.10.1-next.1":
   version: 0.10.1-next.1
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.10.1-next.1"
   dependencies:
@@ -5298,7 +5381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.41.0-next.1&npm=0.1.12-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.12-next.1":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.41.0-next.2&npm=0.1.12-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.12-next.1":
   version: 0.1.12-next.1
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.12-next.1"
   dependencies:
@@ -5309,20 +5392,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.41.0-next.1&npm=0.2.10-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.10-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.10-next.0":
-  version: 0.2.10-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.10-next.0"
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.41.0-next.2&npm=0.2.10-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.10-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.10-next.1":
+  version: 0.2.10-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.10-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/catalog-model": "npm:1.7.5-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.5-next.0"
     "@backstage/plugin-catalog-node": "npm:1.17.2-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.12-next.0"
-  checksum: 10/154e1231eabebaca220be82a930fb666f4b1d5c59c420d8b3f2c77dd938ab4cfc496ebb6369606b31b29357c79fbcbf911df329c9707668bba8ca4360ea80dcf
+    "@backstage/plugin-scaffolder-common": "npm:1.6.0-next.1"
+  checksum: 10/6ad395cf000bfb4a63163e70cd75c31a085a1c1fd91b48be983a7c5844be35ea5d37bef0b6383eebfedf3ad0ee0c38299f2caab6b244641758c04fc945058949
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.41.0-next.1&npm=3.0.0-next.1, @backstage/plugin-catalog-backend@npm:3.0.0-next.1, @backstage/plugin-catalog-backend@npm:^3.0.0-next.1":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.41.0-next.2&npm=3.0.0-next.1, @backstage/plugin-catalog-backend@npm:3.0.0-next.1, @backstage/plugin-catalog-backend@npm:^3.0.0-next.1":
   version: 3.0.0-next.1
   resolution: "@backstage/plugin-catalog-backend@npm:3.0.0-next.1"
   dependencies:
@@ -5361,7 +5444,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.41.0-next.1&npm=1.1.5-next.0, @backstage/plugin-catalog-common@npm:1.1.5-next.0, @backstage/plugin-catalog-common@npm:^1.1.5-next.0":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.41.0-next.2&npm=1.1.5-next.0, @backstage/plugin-catalog-common@npm:1.1.5-next.0, @backstage/plugin-catalog-common@npm:^1.1.5-next.0":
   version: 1.1.5-next.0
   resolution: "@backstage/plugin-catalog-common@npm:1.1.5-next.0"
   dependencies:
@@ -5383,7 +5466,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.41.0-next.1&npm=0.4.21-next.1, @backstage/plugin-catalog-graph@npm:^0.4.21-next.1":
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.41.0-next.2&npm=0.4.21-next.1, @backstage/plugin-catalog-graph@npm:^0.4.21-next.1":
   version: 0.4.21-next.1
   resolution: "@backstage/plugin-catalog-graph@npm:0.4.21-next.1"
   dependencies:
@@ -5415,7 +5498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.41.0-next.1&npm=1.17.2-next.0, @backstage/plugin-catalog-node@npm:1.17.2-next.0, @backstage/plugin-catalog-node@npm:^1.17.2-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.41.0-next.2&npm=1.17.2-next.0, @backstage/plugin-catalog-node@npm:1.17.2-next.0, @backstage/plugin-catalog-node@npm:^1.17.2-next.0":
   version: 1.17.2-next.0
   resolution: "@backstage/plugin-catalog-node@npm:1.17.2-next.0"
   dependencies:
@@ -5451,7 +5534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.41.0-next.1&npm=1.19.1-next.1, @backstage/plugin-catalog-react@npm:1.19.1-next.1, @backstage/plugin-catalog-react@npm:^1.19.1-next.1":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.41.0-next.2&npm=1.19.1-next.1, @backstage/plugin-catalog-react@npm:1.19.1-next.1, @backstage/plugin-catalog-react@npm:^1.19.1-next.1":
   version: 1.19.1-next.1
   resolution: "@backstage/plugin-catalog-react@npm:1.19.1-next.1"
   dependencies:
@@ -5533,7 +5616,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.41.0-next.1&npm=1.31.1-next.1, @backstage/plugin-catalog@npm:1.31.1-next.1, @backstage/plugin-catalog@npm:^1.31.1-next.1":
+"@backstage/plugin-catalog@backstage:^::backstage=1.41.0-next.2&npm=1.31.1-next.2, @backstage/plugin-catalog@npm:^1.31.1-next.2":
+  version: 1.31.1-next.2
+  resolution: "@backstage/plugin-catalog@npm:1.31.1-next.2"
+  dependencies:
+    "@backstage/catalog-client": "npm:1.10.2-next.0"
+    "@backstage/catalog-model": "npm:1.7.5-next.0"
+    "@backstage/core-compat-api": "npm:0.4.4-next.1"
+    "@backstage/core-components": "npm:0.17.4-next.2"
+    "@backstage/core-plugin-api": "npm:1.10.9-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-plugin-api": "npm:0.10.4-next.1"
+    "@backstage/integration-react": "npm:1.2.9-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.19.1-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.36-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.6.0-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.19-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.2-next.1"
+    "@backstage/plugin-techdocs-common": "npm:0.1.1"
+    "@backstage/plugin-techdocs-react": "npm:1.3.1-next.1"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@mui/utils": "npm:^5.14.15"
+    classnames: "npm:^2.3.1"
+    dataloader: "npm:^2.0.0"
+    history: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    react-helmet: "npm:6.1.0"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/e19be8b71667ae6ec1242bd051de1c3e869256f6e4d002e6a500378e88d85779d97aa0285e865118454db63c9262d637f028be17f296ce6588c98d6879eaa92d
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog@npm:1.31.1-next.1":
   version: 1.31.1-next.1
   resolution: "@backstage/plugin-catalog@npm:1.31.1-next.1"
   dependencies:
@@ -5579,7 +5708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.41.0-next.1&npm=0.4.2-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.2-next.1":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.41.0-next.2&npm=0.4.2-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.2-next.1":
   version: 0.4.2-next.1
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.2-next.1"
   dependencies:
@@ -5596,7 +5725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.41.0-next.1&npm=0.5.4-next.0, @backstage/plugin-events-backend@npm:^0.5.4-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.41.0-next.2&npm=0.5.4-next.0, @backstage/plugin-events-backend@npm:^0.5.4-next.0":
   version: 0.5.4-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.5.4-next.0"
   dependencies:
@@ -5671,21 +5800,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.41.0-next.1&npm=0.8.10-next.1, @backstage/plugin-home@npm:^0.8.10-next.1":
-  version: 0.8.10-next.1
-  resolution: "@backstage/plugin-home@npm:0.8.10-next.1"
+"@backstage/plugin-home@backstage:^::backstage=1.41.0-next.2&npm=0.8.10-next.2, @backstage/plugin-home@npm:^0.8.10-next.2":
+  version: 0.8.10-next.2
+  resolution: "@backstage/plugin-home@npm:0.8.10-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.2-next.0"
     "@backstage/catalog-model": "npm:1.7.5-next.0"
     "@backstage/config": "npm:1.3.3-next.0"
-    "@backstage/core-app-api": "npm:1.17.2-next.0"
+    "@backstage/core-app-api": "npm:1.18.0-next.1"
     "@backstage/core-compat-api": "npm:0.4.4-next.1"
-    "@backstage/core-components": "npm:0.17.4-next.1"
+    "@backstage/core-components": "npm:0.17.4-next.2"
     "@backstage/core-plugin-api": "npm:1.10.9-next.0"
     "@backstage/frontend-plugin-api": "npm:0.10.4-next.1"
     "@backstage/plugin-catalog-react": "npm:1.19.1-next.1"
     "@backstage/plugin-home-react": "npm:0.1.28-next.1"
-    "@backstage/theme": "npm:0.6.7-next.0"
+    "@backstage/theme": "npm:0.6.7-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5707,11 +5836,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a465fada85a2ae915cf06f622a50b362934559edaf69a92ac1f09061951e0331357aaf79227d3bbcaf991b2dd9f8d5e86a2f7d2bb728ff0494bef61b3a5e0284
+  checksum: 10/d9d42bb9c51dba20a1e1be2b42ababbfb07e3ad0bda6bd22d6be6a064cd4809a9b8e99ae39214902c64629d8017cc945ba9b7f8a39ef6df04afebb787d912af2
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.41.0-next.1&npm=0.19.8-next.0, @backstage/plugin-kubernetes-backend@npm:^0.19.8-next.0":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.41.0-next.2&npm=0.19.8-next.0, @backstage/plugin-kubernetes-backend@npm:^0.19.8-next.0":
   version: 0.19.8-next.0
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.8-next.0"
   dependencies:
@@ -5824,7 +5953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.41.0-next.1&npm=0.12.9-next.1, @backstage/plugin-kubernetes@npm:^0.12.9-next.1":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.41.0-next.2&npm=0.12.9-next.1, @backstage/plugin-kubernetes@npm:^0.12.9-next.1":
   version: 0.12.9-next.1
   resolution: "@backstage/plugin-kubernetes@npm:0.12.9-next.1"
   dependencies:
@@ -5861,7 +5990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.41.0-next.1&npm=0.5.8-next.1, @backstage/plugin-notifications-backend@npm:^0.5.8-next.1":
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.41.0-next.2&npm=0.5.8-next.1, @backstage/plugin-notifications-backend@npm:^0.5.8-next.1":
   version: 0.5.8-next.1
   resolution: "@backstage/plugin-notifications-backend@npm:0.5.8-next.1"
   dependencies:
@@ -5897,7 +6026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.41.0-next.1&npm=0.2.17-next.0, @backstage/plugin-notifications-node@npm:0.2.17-next.0, @backstage/plugin-notifications-node@npm:^0.2.17-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.41.0-next.2&npm=0.2.17-next.0, @backstage/plugin-notifications-node@npm:0.2.17-next.0, @backstage/plugin-notifications-node@npm:^0.2.17-next.0":
   version: 0.2.17-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.17-next.0"
   dependencies:
@@ -5912,7 +6041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.41.0-next.1&npm=0.5.7-next.1, @backstage/plugin-notifications@npm:^0.5.7-next.1":
+"@backstage/plugin-notifications@backstage:^::backstage=1.41.0-next.2&npm=0.5.7-next.1, @backstage/plugin-notifications@npm:^0.5.7-next.1":
   version: 0.5.7-next.1
   resolution: "@backstage/plugin-notifications@npm:0.5.7-next.1"
   dependencies:
@@ -5945,7 +6074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.41.0-next.1&npm=0.6.41-next.1, @backstage/plugin-org@npm:^0.6.41-next.1":
+"@backstage/plugin-org@backstage:^::backstage=1.41.0-next.2&npm=0.6.41-next.1, @backstage/plugin-org@npm:^0.6.41-next.1":
   version: 0.6.41-next.1
   resolution: "@backstage/plugin-org@npm:0.6.41-next.1"
   dependencies:
@@ -6097,7 +6226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.41.0-next.1&npm=0.6.4-next.0, @backstage/plugin-proxy-backend@npm:^0.6.4-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.41.0-next.2&npm=0.6.4-next.0, @backstage/plugin-proxy-backend@npm:^0.6.4-next.0":
   version: 0.6.4-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.4-next.0"
   dependencies:
@@ -6120,103 +6249,103 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.11-next.1":
-  version: 0.2.11-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.11-next.1"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.11-next.2":
+  version: 0.2.11-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.11-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/config": "npm:1.3.3-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.17.1-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     azure-devops-node-api: "npm:^14.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/568dbf8c84e1d87de73500b1026d377ed41de9c54c74daf3480e3c5f9d71de53195a303a5450e11d6c6a50e1e7903a1a2ab08e1953d09901b1d1e90b389b6e5d
+  checksum: 10/f53427cec26fcdc8d0c595a422b97de70aded5c098e532d3abbc8cd6c43f4c928f4295bf1409c31c9abe5767ae40187e27c9183344361ad681c1b2bba47cd5c9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.11-next.1":
-  version: 0.2.11-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.11-next.1"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.11-next.2":
+  version: 0.2.11-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.11-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/config": "npm:1.3.3-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.17.1-next.1"
     "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.1-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     bitbucket: "npm:^2.12.0"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/041736d8de45783422440f7f8afd85f62ad64c1ac7b5980478ea901709fd6fcc3e0a574024bd5dfdcff18d1801bb476f5a13153de9d17dc58e7f5995518eb62c
+  checksum: 10/84c388ac15ab9a3e3b090084bd30466da9d708c0485ee0af5de5170c166d74e4f611a48c5642d28daab56bb44a6603b7e8b41dea681905f8a721064e15b07481
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.11-next.1":
-  version: 0.2.11-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.11-next.1"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.11-next.2":
+  version: 0.2.11-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.11-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/config": "npm:1.3.3-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.17.1-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/020923897c1f35937fc2b5f5c8b662097447f214f10b2adc70afa88ee20c085aaf3cb84ae9d0f6923d8dc5b6ad06cd495e3c54e544f6f32c634eba0fcdb94c40
+  checksum: 10/469673d9047f53cebe1a70e5a6606e1438582986131416d8e3ff4e69e669ccd91ca357058ff0bfe408aa625e74daae016ae1cbb87cc9428e9def503c4f1775da
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.12-next.1":
-  version: 0.3.12-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.12-next.1"
+"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.12-next.2":
+  version: 0.3.12-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.12-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/config": "npm:1.3.3-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.17.1-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.11-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.11-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.11-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.11-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/94e7bbfc70a87ba5272d689bfda7dc8ca9df484ab49783d645551f5c2c29804f83d0b04b1ffbe3375b7364188e1762e626f094aa60d6eeef01b1a3ac9ba75b76
+  checksum: 10/08b2b7363dc86cf1e383f26d68e6ff512be7cb53d5ab99861f716692bdfa86d0bbe1f58562b906081381504346521bf1f45eac2a38fdffd80a75dc87bb2a3381
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.11-next.1":
-  version: 0.2.11-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.11-next.1"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.11-next.2":
+  version: 0.2.11-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.11-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/config": "npm:1.3.3-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.17.1-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     yaml: "npm:^2.0.0"
-  checksum: 10/a2cbbe83ee707f1146b5862beeca92a602c8b8f39386ffa103117ac62505bcc6c27bb55a8ed820b48056ba136700f34df903fe9b5ad423d5017e6605e7aea966
+  checksum: 10/a58c7eca74da4934fdd8e09c548494b3654f6fcba7ba77be9e604367c80dc015bf2a1e9b13589e5adbb5b229e55c3daedefa92f0fe9bd5ed602f5e3ad38aeb75
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.11-next.1":
-  version: 0.2.11-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.11-next.1"
+"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.11-next.2":
+  version: 0.2.11-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.11-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/config": "npm:1.3.3-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.17.1-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     yaml: "npm:^2.0.0"
-  checksum: 10/de52c1d2b56ef2e1f9c6b5f4f52672c14fce6e4972e30264cdde213f78a83b230f8f1d4acc230538bfb9a0bbe488c14784d51aacafef0f57626ce29f4b374215
+  checksum: 10/4e42e6ac9181f5a5eaec0df2463ed9eecfc89d19efd8e6192623a37846e91906641b8d51220c5ec64248db5b7a9695e629c4e36b8bb2bdd2f8afb4a7d2213de4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.41.0-next.1&npm=0.8.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:0.8.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.8.1-next.1":
-  version: 0.8.1-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.8.1-next.1"
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.41.0-next.2&npm=0.8.1-next.2, @backstage/plugin-scaffolder-backend-module-github@npm:0.8.1-next.2, @backstage/plugin-scaffolder-backend-module-github@npm:^0.8.1-next.2":
+  version: 0.8.1-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.8.1-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/catalog-model": "npm:1.7.5-next.0"
@@ -6224,7 +6353,7 @@ __metadata:
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.17.1-next.1"
     "@backstage/plugin-catalog-node": "npm:1.17.2-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@octokit/webhooks": "npm:^10.9.2"
     libsodium-wrappers: "npm:^0.7.11"
@@ -6232,44 +6361,44 @@ __metadata:
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/66e3c23f1c83b12f0aff1908bac40e0e908d8e3b851179d15f33e007540b63e6eacd9eac45bf838c22ce871c1d84980c5d4403b12457ac4d0b8d31691379dff4
+  checksum: 10/25e834c9bb53bc736adb0a18c3b495c44cd77c2408f918d4719909062ffc1268031eaad23acca13b4161ea0e43049ca40e9a6a344bd6f525c9183685a6150e06
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.3-next.1":
-  version: 0.9.3-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.3-next.1"
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.3-next.2":
+  version: 0.9.3-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.3-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/config": "npm:1.3.3-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.17.1-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     winston: "npm:^3.2.1"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/244948ad02d87e51f5616304d62d667be8f6b14a57635c0ff1c6a187d49d61f1fa07fb74ca1d16510bd7134560719030ec556a41e8b63b16b9c7bf1503918759
+  checksum: 10/4ce8f60681ec7941c47fc6b3fa79fbc377c350d13a76cd0519b6267cdbf19ff7a23567c8c0fc88e919073ea8f6d381645c229441db25ffb441523f6ffd33a3a6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.41.0-next.1&npm=0.1.12-next.1, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.12-next.1":
-  version: 0.1.12-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.12-next.1"
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.41.0-next.2&npm=0.1.12-next.2, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.12-next.2":
+  version: 0.1.12-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.12-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/plugin-notifications-common": "npm:0.0.10-next.0"
     "@backstage/plugin-notifications-node": "npm:0.2.17-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     yaml: "npm:^2.0.0"
-  checksum: 10/aac71b047f3599e197e04ce619a79f69e6d57efbf3364966aa028b7d6ab58ea2c7af4ac28b7684630dc28257e3cbe990032bc453729db4e202c076674d341c84
+  checksum: 10/7fbb57d0c96f23ed559c34c14d3d9f568f3d1a42940d3085ae111ef6ecc0e0a2a2c6921119753e63dce11205c19c084a632f56e37971078df9732b27820dc7b2
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.41.0-next.1&npm=2.0.1-next.1, @backstage/plugin-scaffolder-backend@npm:^2.0.1-next.1":
-  version: 2.0.1-next.1
-  resolution: "@backstage/plugin-scaffolder-backend@npm:2.0.1-next.1"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.41.0-next.2&npm=2.1.0-next.2, @backstage/plugin-scaffolder-backend@npm:^2.1.0-next.2":
+  version: 2.1.0-next.2
+  resolution: "@backstage/plugin-scaffolder-backend@npm:2.1.0-next.2"
   dependencies:
     "@backstage/backend-defaults": "npm:0.11.1-next.1"
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
@@ -6279,21 +6408,21 @@ __metadata:
     "@backstage/integration": "npm:1.17.1-next.1"
     "@backstage/plugin-auth-node": "npm:0.6.5-next.0"
     "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.1-next.0"
-    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.10-next.0"
+    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.10-next.1"
     "@backstage/plugin-catalog-node": "npm:1.17.2-next.0"
     "@backstage/plugin-events-node": "npm:0.4.13-next.0"
     "@backstage/plugin-permission-common": "npm:0.9.1-next.0"
     "@backstage/plugin-permission-node": "npm:0.10.2-next.0"
-    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.11-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.12-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.11-next.1"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.11-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.11-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.11-next.1"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.8.1-next.1"
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.9.3-next.1"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.12-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.9.1-next.1"
+    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.11-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.12-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.11-next.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.11-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.11-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.11-next.2"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.8.1-next.2"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.9.3-next.2"
+    "@backstage/plugin-scaffolder-common": "npm:1.6.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.10.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/luxon": "npm:^3.0.0"
@@ -6322,7 +6451,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/dd3c1693f3fab82c40e82e9cb9e074bf972e83e64f69a739e7c173ee99fb7466383173293891b85a9dc5fe994f79016a3e8c56c7b79847ab0df8cabd9fbbed44
+  checksum: 10/2ceac0c7117d18a32e1325fa92d3651c459f31c59de3b948e702a937d3071936948cd014d74f90c871a443ffd4687966c849e266b095bc3814d70e302978ab95
   languageName: node
   linkType: hard
 
@@ -6337,15 +6466,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:0.9.1-next.1":
-  version: 0.9.1-next.1
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.9.1-next.1"
+"@backstage/plugin-scaffolder-common@npm:1.6.0-next.1":
+  version: 1.6.0-next.1
+  resolution: "@backstage/plugin-scaffolder-common@npm:1.6.0-next.1"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.7.5-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.1-next.0"
+    "@backstage/types": "npm:1.2.1"
+  checksum: 10/6276ed46fb826bd8e29736310b4c4d7b0768c41c0e528af8ba7d14b8338eed8691e36661dff4550fa83930e7757358402534be2f14215aa236e19025d213b3a6
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-node@npm:0.10.0-next.2":
+  version: 0.10.0-next.2
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.10.0-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
     "@backstage/catalog-model": "npm:1.7.5-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.17.1-next.1"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.12-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.1-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.6.0-next.1"
     "@backstage/types": "npm:1.2.1"
     "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
     concat-stream: "npm:^2.0.0"
@@ -6360,23 +6501,23 @@ __metadata:
     winston-transport: "npm:^4.7.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/e79a6d55c4b038433c58d842cdca6d3d93f71ef2a73d3868e329bf47dcba625d6561d01ee7f65192925679542e486e2e01662f5be0da2d6ac8cf977e5d257625
+  checksum: 10/238a9093d62ddd7a93e3c7de89bd38f596d10ca57f5bb620f23568378d264416517f76395c8e84101bb9f2cb79cb3cae37a38bcc3ef4b363eec8b771b93b84a6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.17.1-next.1":
-  version: 1.17.1-next.1
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.17.1-next.1"
+"@backstage/plugin-scaffolder-react@npm:1.18.0-next.2":
+  version: 1.18.0-next.2
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.18.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.2-next.0"
     "@backstage/catalog-model": "npm:1.7.5-next.0"
-    "@backstage/core-components": "npm:0.17.4-next.1"
+    "@backstage/core-components": "npm:0.17.4-next.2"
     "@backstage/core-plugin-api": "npm:1.10.9-next.0"
     "@backstage/frontend-plugin-api": "npm:0.10.4-next.1"
     "@backstage/plugin-catalog-react": "npm:1.19.1-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.36-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.12-next.0"
-    "@backstage/theme": "npm:0.6.7-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.6.0-next.1"
+    "@backstage/theme": "npm:0.6.7-next.1"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -6412,18 +6553,18 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e478830e3c3274a924a7ef32154c25c1217f48ed7ab9a28aa909bd633cab61052edc9cbd2088e465a9c3ed0f78e31dba0b2bbc244cac593a9d21956d7f76cb04
+  checksum: 10/112d2a0fb7a6e0b651982cba5b22040ab729766e287f88bfa03a7fdfe820b2e825945481bd3e265bdafae911409d5aa73d30d68ad98bbe8013562c89437ff2d0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.41.0-next.1&npm=1.32.1-next.1, @backstage/plugin-scaffolder@npm:^1.32.1-next.1":
-  version: 1.32.1-next.1
-  resolution: "@backstage/plugin-scaffolder@npm:1.32.1-next.1"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.41.0-next.2&npm=1.33.0-next.2, @backstage/plugin-scaffolder@npm:^1.33.0-next.2":
+  version: 1.33.0-next.2
+  resolution: "@backstage/plugin-scaffolder@npm:1.33.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.10.2-next.0"
     "@backstage/catalog-model": "npm:1.7.5-next.0"
     "@backstage/core-compat-api": "npm:0.4.4-next.1"
-    "@backstage/core-components": "npm:0.17.4-next.1"
+    "@backstage/core-components": "npm:0.17.4-next.2"
     "@backstage/core-plugin-api": "npm:1.10.9-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.10.4-next.1"
@@ -6432,8 +6573,8 @@ __metadata:
     "@backstage/plugin-catalog-common": "npm:1.1.5-next.0"
     "@backstage/plugin-catalog-react": "npm:1.19.1-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.36-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.5.12-next.0"
-    "@backstage/plugin-scaffolder-react": "npm:1.17.1-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:1.6.0-next.1"
+    "@backstage/plugin-scaffolder-react": "npm:1.18.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
@@ -6473,11 +6614,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/804e5e99b07c353cdefe2b6154faa14a133aa57b1fe58dcba654f10e6ddef62753e80a67424fb20f75d887587b4b1ab8543a72d03fd26aa8f33e4e4b41289d6f
+  checksum: 10/845a552337d47bae44634b6b4c0ea06ba51b93d82cf86400cb2c98f166d22f17815469ba8f4c831bade600d10c460f8b0f75e5a15cd267d89c7d34d8aff67179
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.41.0-next.1&npm=0.3.6-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.6-next.0":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.41.0-next.2&npm=0.3.6-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.6-next.0":
   version: 0.3.6-next.0
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.6-next.0"
   dependencies:
@@ -6495,7 +6636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-explore@backstage:^::backstage=1.41.0-next.1&npm=0.3.4-next.0, @backstage/plugin-search-backend-module-explore@npm:^0.3.4-next.0":
+"@backstage/plugin-search-backend-module-explore@backstage:^::backstage=1.41.0-next.2&npm=0.3.4-next.0, @backstage/plugin-search-backend-module-explore@npm:^0.3.4-next.0":
   version: 0.3.4-next.0
   resolution: "@backstage/plugin-search-backend-module-explore@npm:0.3.4-next.0"
   dependencies:
@@ -6546,7 +6687,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.41.0-next.1&npm=2.0.4-next.1, @backstage/plugin-search-backend@npm:^2.0.4-next.1":
+"@backstage/plugin-search-backend@backstage:^::backstage=1.41.0-next.2&npm=2.0.4-next.1, @backstage/plugin-search-backend@npm:^2.0.4-next.1":
   version: 2.0.4-next.1
   resolution: "@backstage/plugin-search-backend@npm:2.0.4-next.1"
   dependencies:
@@ -6590,7 +6731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.41.0-next.1&npm=1.9.2-next.1, @backstage/plugin-search-react@npm:1.9.2-next.1, @backstage/plugin-search-react@npm:^1.9.2-next.1":
+"@backstage/plugin-search-react@backstage:^::backstage=1.41.0-next.2&npm=1.9.2-next.1, @backstage/plugin-search-react@npm:1.9.2-next.1, @backstage/plugin-search-react@npm:^1.9.2-next.1":
   version: 1.9.2-next.1
   resolution: "@backstage/plugin-search-react@npm:1.9.2-next.1"
   dependencies:
@@ -6650,7 +6791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.41.0-next.1&npm=1.4.28-next.1, @backstage/plugin-search@npm:^1.4.28-next.1":
+"@backstage/plugin-search@backstage:^::backstage=1.41.0-next.2&npm=1.4.28-next.1, @backstage/plugin-search@npm:^1.4.28-next.1":
   version: 1.4.28-next.1
   resolution: "@backstage/plugin-search@npm:1.4.28-next.1"
   dependencies:
@@ -6680,7 +6821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.41.0-next.1&npm=0.3.6-next.0, @backstage/plugin-signals-backend@npm:^0.3.6-next.0":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.41.0-next.2&npm=0.3.6-next.0, @backstage/plugin-signals-backend@npm:^0.3.6-next.0":
   version: 0.3.6-next.0
   resolution: "@backstage/plugin-signals-backend@npm:0.3.6-next.0"
   dependencies:
@@ -6736,15 +6877,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.41.0-next.1&npm=0.0.21-next.1, @backstage/plugin-signals@npm:^0.0.21-next.1":
-  version: 0.0.21-next.1
-  resolution: "@backstage/plugin-signals@npm:0.0.21-next.1"
+"@backstage/plugin-signals@backstage:^::backstage=1.41.0-next.2&npm=0.0.21-next.2, @backstage/plugin-signals@npm:^0.0.21-next.2":
+  version: 0.0.21-next.2
+  resolution: "@backstage/plugin-signals@npm:0.0.21-next.2"
   dependencies:
-    "@backstage/core-components": "npm:0.17.4-next.1"
+    "@backstage/core-compat-api": "npm:0.4.4-next.1"
+    "@backstage/core-components": "npm:0.17.4-next.2"
     "@backstage/core-plugin-api": "npm:1.10.9-next.0"
     "@backstage/frontend-plugin-api": "npm:0.10.4-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.15-next.0"
-    "@backstage/theme": "npm:0.6.7-next.0"
+    "@backstage/theme": "npm:0.6.7-next.1"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6759,11 +6901,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a7ed5b63ac6b58ebfc1a7017632a7d4297a895d36ffd4950aa7e018a4d2155ba4f2c7dfe29ac0f8da540e7a7cabf765af861ed428608bc3e140141b59ba55ff9
+  checksum: 10/51023d132e960a6a85f17f56a2f4ea38090a8743763a56d9e5bd13a70e6ddc93ea4badb1a5da4a85b7e9cf97fca3d0ddeaa601bec7458feeb83fed91b36386eb
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.41.0-next.1&npm=2.0.4-next.1, @backstage/plugin-techdocs-backend@npm:^2.0.4-next.1":
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.41.0-next.2&npm=2.0.4-next.1, @backstage/plugin-techdocs-backend@npm:^2.0.4-next.1":
   version: 2.0.4-next.1
   resolution: "@backstage/plugin-techdocs-backend@npm:2.0.4-next.1"
   dependencies:
@@ -6798,7 +6940,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.41.0-next.1&npm=1.1.26-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.26-next.1":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.41.0-next.2&npm=1.1.26-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.26-next.1":
   version: 1.1.26-next.1
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.26-next.1"
   dependencies:
@@ -6825,7 +6967,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.41.0-next.1&npm=1.13.5-next.1, @backstage/plugin-techdocs-node@npm:1.13.5-next.1, @backstage/plugin-techdocs-node@npm:^1.13.5-next.1":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.41.0-next.2&npm=1.13.5-next.2, @backstage/plugin-techdocs-node@npm:^1.13.5-next.2":
+  version: 1.13.5-next.2
+  resolution: "@backstage/plugin-techdocs-node@npm:1.13.5-next.2"
+  dependencies:
+    "@aws-sdk/client-s3": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/lib-storage": "npm:^3.350.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/backend-plugin-api": "npm:1.4.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.5-next.0"
+    "@backstage/config": "npm:1.3.3-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/integration": "npm:1.17.1-next.1"
+    "@backstage/integration-aws-node": "npm:0.1.17-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.19-next.0"
+    "@backstage/plugin-techdocs-common": "npm:0.1.1"
+    "@google-cloud/storage": "npm:^7.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@trendyol-js/openstack-swift-sdk": "npm:^0.0.7"
+    "@types/express": "npm:^4.17.6"
+    dockerode: "npm:^4.0.0"
+    express: "npm:^4.17.1"
+    fs-extra: "npm:^11.2.0"
+    git-url-parse: "npm:^15.0.0"
+    hpagent: "npm:^1.2.0"
+    js-yaml: "npm:^4.0.0"
+    json5: "npm:^2.1.3"
+    mime-types: "npm:^2.1.27"
+    p-limit: "npm:^3.1.0"
+    recursive-readdir: "npm:^2.2.2"
+    winston: "npm:^3.2.1"
+  checksum: 10/4eb357d665fbf520f57e356a967a02a6d3d9f9c41e6ee2989c9f424d5546e6e47e000e005078f64af54024924a97995bfbd311cc99c4b98bcae775c1f576c86a
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs-node@npm:1.13.5-next.1":
   version: 1.13.5-next.1
   resolution: "@backstage/plugin-techdocs-node@npm:1.13.5-next.1"
   dependencies:
@@ -6862,7 +7041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.41.0-next.1&npm=1.3.1-next.1, @backstage/plugin-techdocs-react@npm:1.3.1-next.1, @backstage/plugin-techdocs-react@npm:^1.3.1-next.1":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.41.0-next.2&npm=1.3.1-next.1, @backstage/plugin-techdocs-react@npm:1.3.1-next.1, @backstage/plugin-techdocs-react@npm:^1.3.1-next.1":
   version: 1.3.1-next.1
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.1-next.1"
   dependencies:
@@ -6919,7 +7098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.41.0-next.1&npm=1.13.2-next.1, @backstage/plugin-techdocs@npm:^1.13.2-next.1":
+"@backstage/plugin-techdocs@backstage:^::backstage=1.41.0-next.2&npm=1.13.2-next.1, @backstage/plugin-techdocs@npm:^1.13.2-next.1":
   version: 1.13.2-next.1
   resolution: "@backstage/plugin-techdocs@npm:1.13.2-next.1"
   dependencies:
@@ -6970,21 +7149,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.41.0-next.1&npm=0.8.24-next.1, @backstage/plugin-user-settings@npm:^0.8.24-next.1":
-  version: 0.8.24-next.1
-  resolution: "@backstage/plugin-user-settings@npm:0.8.24-next.1"
+"@backstage/plugin-user-settings@backstage:^::backstage=1.41.0-next.2&npm=0.8.24-next.2, @backstage/plugin-user-settings@npm:^0.8.24-next.2":
+  version: 0.8.24-next.2
+  resolution: "@backstage/plugin-user-settings@npm:0.8.24-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.5-next.0"
-    "@backstage/core-app-api": "npm:1.17.2-next.0"
+    "@backstage/core-app-api": "npm:1.18.0-next.1"
     "@backstage/core-compat-api": "npm:0.4.4-next.1"
-    "@backstage/core-components": "npm:0.17.4-next.1"
+    "@backstage/core-components": "npm:0.17.4-next.2"
     "@backstage/core-plugin-api": "npm:1.10.9-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.10.4-next.1"
     "@backstage/plugin-catalog-react": "npm:1.19.1-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.15-next.0"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
-    "@backstage/theme": "npm:0.6.7-next.0"
+    "@backstage/theme": "npm:0.6.7-next.1"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6999,7 +7178,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3507a0b8bad2ec30332f53e60997419f5b18950a44451d4ece3788a9d6f28b6cefe836f0c5ced5394226becfa9dec60b0f5f5cd5cda2d4a98d9a2f1320825efa
+  checksum: 10/254c296ed6e3dab14adf3bc45394b67273c225ddd317f78c029d0a81f528476e876ac3d5e6078c9d2041d30e8adf1876e6cac2dc4d92b65b17305a2b34ea725d
   languageName: node
   linkType: hard
 
@@ -7068,7 +7247,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.41.0-next.1&npm=0.6.7-next.0, @backstage/theme@npm:0.6.7-next.0, @backstage/theme@npm:^0.6.7-next.0":
+"@backstage/theme@backstage:^::backstage=1.41.0-next.2&npm=0.6.7-next.1, @backstage/theme@npm:0.6.7-next.1, @backstage/theme@npm:^0.6.7-next.1":
+  version: 0.6.7-next.1
+  resolution: "@backstage/theme@npm:0.6.7-next.1"
+  dependencies:
+    "@emotion/react": "npm:^11.10.5"
+    "@emotion/styled": "npm:^11.10.5"
+    "@mui/material": "npm:^5.12.2"
+  peerDependencies:
+    "@material-ui/core": ^4.12.2
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/466fefcb1e0dacf895db32cdc9a40531e2c622207d8ba29250d63f471c614cfed686c9f4b22f40da8507cd2a854576ff9afb841fa3e6ed8a2e41c85b8b2a0592
+  languageName: node
+  linkType: hard
+
+"@backstage/theme@npm:0.6.7-next.0":
   version: 0.6.7-next.0
   resolution: "@backstage/theme@npm:0.6.7-next.0"
   dependencies:
@@ -24807,6 +25006,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"framer-motion@npm:^12.23.0":
+  version: 12.23.0
+  resolution: "framer-motion@npm:12.23.0"
+  dependencies:
+    motion-dom: "npm:^12.22.0"
+    motion-utils: "npm:^12.19.0"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@emotion/is-prop-valid": "*"
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10/61a5bee46a3d354419f63125c3cf745adde06d213caaa2f2a8ff88cc50aea8f9d09558993d86e9fce4251e0438d833de5023778ac33d85e0a8e60fd48354a0b2
+  languageName: node
+  linkType: hard
+
 "framer-motion@npm:^6.5.1":
   version: 6.5.1
   resolution: "framer-motion@npm:6.5.1"
@@ -30591,6 +30812,43 @@ __metadata:
     on-finished: "npm:~2.3.0"
     on-headers: "npm:~1.0.2"
   checksum: 10/4497ace00dac65318658595528c1924942c900aae88b7adc5e69e18dd78fb5d1fcccdc2048404ce7d88b5344dc088c492e3aa7cf8023f1e601c6b0f4ff806b93
+  languageName: node
+  linkType: hard
+
+"motion-dom@npm:^12.22.0":
+  version: 12.22.0
+  resolution: "motion-dom@npm:12.22.0"
+  dependencies:
+    motion-utils: "npm:^12.19.0"
+  checksum: 10/857de46f6b0fbf1b340f2198a5ccc9ad1d5cfb9dbaa86764ec521c17bb5c9f0f97681e883c05a76f04f8521d9adf6accc721dca154e8812fb888a855aa2a2f3e
+  languageName: node
+  linkType: hard
+
+"motion-utils@npm:^12.19.0":
+  version: 12.19.0
+  resolution: "motion-utils@npm:12.19.0"
+  checksum: 10/a6fe6b329bf4e2070bb95788218f36f0d7ea6cc3098e6ea2646ed68d5be88d25fa30e55284463ace78d19a5e19714875a7b70055bd86ae6e52a5fdee08438470
+  languageName: node
+  linkType: hard
+
+"motion@npm:^12.20.1":
+  version: 12.23.0
+  resolution: "motion@npm:12.23.0"
+  dependencies:
+    framer-motion: "npm:^12.23.0"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    "@emotion/is-prop-valid": "*"
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 10/ec96edd3e8330055dba80247bf15fd60dfb7f3e39cd60ceaae15f3553e1287fcad39b357925266e8b66bde41010241cffe6b23507a1308a8ff05272cc9397c4f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.41.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.41.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.41.0-next.2-changelog.md)
- Upgrade Helper: [From 1.41.0-next.1 to 1.41.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.41.0-next.1&to=1.41.0-next.2)
 
Created by [Version Bump 16166432049](https://github.com/backstage/demo/actions/runs/16166432049)
 