### PR TITLE
v1.42.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 8af7b3f2d7d19cacc7a3712f871efcb6208ba283a1f532260b0cba80c2cb66ed772b207b5ba41b8c5d64dd8d5e0c0e15bbb445bd14afac491712965211ba027c
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.42.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.42.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.42.0-next.1"
+  "version": "1.42.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3505,7 +3505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.42.0-next.1&npm=1.6.5-next.0, @backstage/app-defaults@npm:^1.6.5-next.0":
+"@backstage/app-defaults@backstage:^::backstage=1.42.0-next.2&npm=1.6.5-next.0, @backstage/app-defaults@npm:^1.6.5-next.0":
   version: 1.6.5-next.0
   resolution: "@backstage/app-defaults@npm:1.6.5-next.0"
   dependencies:
@@ -3703,7 +3703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.42.0-next.1&npm=0.11.2-next.0, @backstage/backend-defaults@npm:0.11.2-next.0, @backstage/backend-defaults@npm:^0.11.2-next.0":
+"@backstage/backend-defaults@backstage:^::backstage=1.42.0-next.2&npm=0.11.2-next.0, @backstage/backend-defaults@npm:0.11.2-next.0, @backstage/backend-defaults@npm:^0.11.2-next.0":
   version: 0.11.2-next.0
   resolution: "@backstage/backend-defaults@npm:0.11.2-next.0"
   dependencies:
@@ -3924,7 +3924,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.42.0-next.1&npm=1.4.2-next.0, @backstage/backend-plugin-api@npm:1.4.2-next.0, @backstage/backend-plugin-api@npm:^1.4.2-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.42.0-next.2&npm=1.4.2-next.0, @backstage/backend-plugin-api@npm:1.4.2-next.0, @backstage/backend-plugin-api@npm:^1.4.2-next.0":
   version: 1.4.2-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.4.2-next.0"
   dependencies:
@@ -4011,7 +4011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.42.0-next.1&npm=1.7.5, @backstage/catalog-model@npm:1.7.5, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.3, @backstage/catalog-model@npm:^1.7.4, @backstage/catalog-model@npm:^1.7.5":
+"@backstage/catalog-model@backstage:^::backstage=1.42.0-next.2&npm=1.7.5, @backstage/catalog-model@npm:1.7.5, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.3, @backstage/catalog-model@npm:^1.7.4, @backstage/catalog-model@npm:^1.7.5":
   version: 1.7.5
   resolution: "@backstage/catalog-model@npm:1.7.5"
   dependencies:
@@ -4046,9 +4046,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.42.0-next.1&npm=0.33.2-next.0, @backstage/cli@npm:^0.33.2-next.0":
-  version: 0.33.2-next.0
-  resolution: "@backstage/cli@npm:0.33.2-next.0"
+"@backstage/cli@backstage:^::backstage=1.42.0-next.2&npm=0.34.0-next.1, @backstage/cli@npm:^0.34.0-next.1":
+  version: 0.34.0-next.1
+  resolution: "@backstage/cli@npm:0.34.0-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.5"
     "@backstage/cli-common": "npm:0.1.15"
@@ -4177,7 +4177,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/d4a9a85ba91a066d6c6e792cf2112e09bad4d02cd1c0b2a5ea2a06b1e31a3a352cfc4832ba899a1ca499292e3c9737e7cc8c08b513c5b74c20faed76daa5f44a
+  checksum: 10/23604195452c6c4fbb5a3a14cc15239ebafcd6ab6614c474cc3904d6da2be0151d36de4604ec754272739695d2746b6d931e1d9c4e4d1615db9a1ecfa4cb3118
   languageName: node
   linkType: hard
 
@@ -4204,7 +4204,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.42.0-next.1&npm=1.3.3, @backstage/config@npm:1.3.3, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2, @backstage/config@npm:^1.3.3":
+"@backstage/config@backstage:^::backstage=1.42.0-next.2&npm=1.3.3, @backstage/config@npm:1.3.3, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2, @backstage/config@npm:^1.3.3":
   version: 1.3.3
   resolution: "@backstage/config@npm:1.3.3"
   dependencies:
@@ -4215,7 +4215,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.42.0-next.1&npm=1.18.0, @backstage/core-app-api@npm:1.18.0, @backstage/core-app-api@npm:^1.18.0":
+"@backstage/core-app-api@backstage:^::backstage=1.42.0-next.2&npm=1.18.0, @backstage/core-app-api@npm:1.18.0, @backstage/core-app-api@npm:^1.18.0":
   version: 1.18.0
   resolution: "@backstage/core-app-api@npm:1.18.0"
   dependencies:
@@ -4243,7 +4243,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.42.0-next.1&npm=0.4.5-next.1, @backstage/core-compat-api@npm:0.4.5-next.1, @backstage/core-compat-api@npm:^0.4.5-next.1":
+"@backstage/core-compat-api@backstage:^::backstage=1.42.0-next.2&npm=0.5.0-next.2, @backstage/core-compat-api@npm:0.5.0-next.2, @backstage/core-compat-api@npm:^0.5.0-next.2":
+  version: 0.5.0-next.2
+  resolution: "@backstage/core-compat-api@npm:0.5.0-next.2"
+  dependencies:
+    "@backstage/core-plugin-api": "npm:1.10.9"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/283f65a59809de4c44dab71a6323e004ffac25fa15189828da96a7d6618f146cdc73b1bf40986351e92a3d76eb1c711a32bedb5e3733d5c92f877210bbc61152
+  languageName: node
+  linkType: hard
+
+"@backstage/core-compat-api@npm:0.4.5-next.1":
   version: 0.4.5-next.1
   resolution: "@backstage/core-compat-api@npm:0.4.5-next.1"
   dependencies:
@@ -4285,7 +4306,61 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.42.0-next.1&npm=0.17.5-next.0, @backstage/core-components@npm:0.17.5-next.0, @backstage/core-components@npm:^0.17.5-next.0":
+"@backstage/core-components@backstage:^::backstage=1.42.0-next.2&npm=0.17.5-next.1, @backstage/core-components@npm:0.17.5-next.1, @backstage/core-components@npm:^0.17.5-next.1":
+  version: 0.17.5-next.1
+  resolution: "@backstage/core-components@npm:0.17.5-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.3"
+    "@backstage/core-plugin-api": "npm:1.10.9"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/theme": "npm:0.6.8-next.0"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.1.3"
+    linkifyjs: "npm:4.1.3"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/b5e9a186cdd05adbf967a1644e095c0e434823711150a6e4fe0831e7a5d2ef81954c968d984060b3a0ec68b00d46e0fc598eb3903e0af22203ff6e024572dc36
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.17.5-next.0":
   version: 0.17.5-next.0
   resolution: "@backstage/core-components@npm:0.17.5-next.0"
   dependencies:
@@ -4393,7 +4468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.42.0-next.1&npm=1.10.9, @backstage/core-plugin-api@npm:1.10.9, @backstage/core-plugin-api@npm:^1.10.8, @backstage/core-plugin-api@npm:^1.10.9":
+"@backstage/core-plugin-api@backstage:^::backstage=1.42.0-next.2&npm=1.10.9, @backstage/core-plugin-api@npm:1.10.9, @backstage/core-plugin-api@npm:^1.10.8, @backstage/core-plugin-api@npm:^1.10.9":
   version: 1.10.9
   resolution: "@backstage/core-plugin-api@npm:1.10.9"
   dependencies:
@@ -4414,7 +4489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.42.0-next.1&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.42.0-next.2&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -4475,6 +4550,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-app-api@npm:0.12.0-next.2":
+  version: 0.12.0-next.2
+  resolution: "@backstage/frontend-app-api@npm:0.12.0-next.2"
+  dependencies:
+    "@backstage/config": "npm:1.3.3"
+    "@backstage/core-app-api": "npm:1.18.0"
+    "@backstage/core-plugin-api": "npm:1.10.9"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-defaults": "npm:0.3.0-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/25b5924ab62faec6a1997d113491ae082a95a07fa640a0250c49361a714ea1313ca179103ce15043ff7f1dc48bfd8233c09faf414d4527388a8e49e94e77907d
+  languageName: node
+  linkType: hard
+
 "@backstage/frontend-app-api@npm:^0.11.4":
   version: 0.11.4
   resolution: "@backstage/frontend-app-api@npm:0.11.4"
@@ -4501,7 +4602,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.42.0-next.1&npm=0.2.5-next.1, @backstage/frontend-defaults@npm:0.2.5-next.1, @backstage/frontend-defaults@npm:^0.2.5-next.1":
+"@backstage/frontend-defaults@backstage:^::backstage=1.42.0-next.2&npm=0.3.0-next.2, @backstage/frontend-defaults@npm:0.3.0-next.2, @backstage/frontend-defaults@npm:^0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/frontend-defaults@npm:0.3.0-next.2"
+  dependencies:
+    "@backstage/config": "npm:1.3.3"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-app-api": "npm:0.12.0-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/plugin-app": "npm:0.2.0-next.1"
+    "@react-hookz/web": "npm:^24.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/de1679252d60a623fdfedc309223f379ef2ac2d1ae85d5da7f8410cea123af7a3c7cdac215e70f5dfa07489d346f9f6d35f8a1be520d5b2b71d5548f7cd89e12
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-defaults@npm:0.2.5-next.1":
   version: 0.2.5-next.1
   resolution: "@backstage/frontend-defaults@npm:0.2.5-next.1"
   dependencies:
@@ -4545,7 +4668,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.42.0-next.1&npm=0.11.0-next.0, @backstage/frontend-plugin-api@npm:0.11.0-next.0, @backstage/frontend-plugin-api@npm:^0.11.0-next.0":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.42.0-next.2&npm=0.11.0-next.1, @backstage/frontend-plugin-api@npm:0.11.0-next.1, @backstage/frontend-plugin-api@npm:^0.11.0-next.1":
+  version: 0.11.0-next.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.11.0-next.1"
+  dependencies:
+    "@backstage/core-components": "npm:0.17.5-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.9"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.4"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.21.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/bb1081fd5339ad08e9963e76b4dec7ae57f7c0db48bbc86c5e0fd3a50458c17e1b8a72201302b6b9b8ad0cb61285878d485d966cdaeda5a58131b02cbab203ce
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:0.11.0-next.0":
   version: 0.11.0-next.0
   resolution: "@backstage/frontend-plugin-api@npm:0.11.0-next.0"
   dependencies:
@@ -4618,6 +4765,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-test-utils@npm:0.3.5-next.2":
+  version: 0.3.5-next.2
+  resolution: "@backstage/frontend-test-utils@npm:0.3.5-next.2"
+  dependencies:
+    "@backstage/config": "npm:1.3.3"
+    "@backstage/frontend-app-api": "npm:0.12.0-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/plugin-app": "npm:0.2.0-next.1"
+    "@backstage/test-utils": "npm:1.7.11-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/7b1811c2c450c4122a1e9b3d18d57cc035faf4387451af349ff3968755bf1e8206104a3a45b428b21c440057a6aeee1977247efe7cc563bd48774e10b366f82e
+  languageName: node
+  linkType: hard
+
 "@backstage/frontend-test-utils@npm:^0.3.4":
   version: 0.3.4
   resolution: "@backstage/frontend-test-utils@npm:0.3.4"
@@ -4658,7 +4830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.42.0-next.1&npm=1.2.9, @backstage/integration-react@npm:1.2.9, @backstage/integration-react@npm:^1.2.9":
+"@backstage/integration-react@backstage:^::backstage=1.42.0-next.2&npm=1.2.9, @backstage/integration-react@npm:1.2.9, @backstage/integration-react@npm:^1.2.9":
   version: 1.2.9
   resolution: "@backstage/integration-react@npm:1.2.9"
   dependencies:
@@ -4697,19 +4869,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.42.0-next.1&npm=0.12.10-next.1, @backstage/plugin-api-docs@npm:^0.12.10-next.1":
-  version: 0.12.10-next.1
-  resolution: "@backstage/plugin-api-docs@npm:0.12.10-next.1"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.42.0-next.2&npm=0.12.10-next.2, @backstage/plugin-api-docs@npm:^0.12.10-next.2":
+  version: 0.12.10-next.2
+  resolution: "@backstage/plugin-api-docs@npm:0.12.10-next.2"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
-    "@backstage/plugin-catalog": "npm:1.31.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/plugin-catalog": "npm:1.31.2-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.5"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@backstage/plugin-permission-react": "npm:0.4.36"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -4729,11 +4901,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7dea7939ed6787a5b26c759773fa68fd8d1922a9ed9326f13ba1feac42bab24d56d3ac9c08332680fe1b9cfed96e2243ccee0a24b80e7d5f3a3fe2f5eff26d9b
+  checksum: 10/0572fb1f81f14bd63ff81831a595b752b5298e55294c4b17b8dec4774d9d91c8b8885257bf7da84fd53f36293a85093fae060afbfda54ab07225f7c09795b0ba
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.42.0-next.1&npm=0.5.5-next.0, @backstage/plugin-app-backend@npm:^0.5.5-next.0":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.42.0-next.2&npm=0.5.5-next.0, @backstage/plugin-app-backend@npm:^0.5.5-next.0":
   version: 0.5.5-next.0
   resolution: "@backstage/plugin-app-backend@npm:0.5.5-next.0"
   dependencies:
@@ -4797,6 +4969,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-app@npm:0.2.0-next.1":
+  version: 0.2.0-next.1
+  resolution: "@backstage/plugin-app@npm:0.2.0-next.1"
+  dependencies:
+    "@backstage/core-components": "npm:0.17.5-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.9"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/integration-react": "npm:1.2.9"
+    "@backstage/plugin-permission-react": "npm:0.4.36"
+    "@backstage/theme": "npm:0.6.8-next.0"
+    "@backstage/types": "npm:1.2.1"
+    "@material-ui/core": "npm:^4.9.13"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/e5e806552e8c6357aec67f46e219864a3b8242ee917a9683d991353486dd3277a06177c66788595e86c3c0b156a59ca48fc37d84e227eee9db342e894d1a88c5
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-app@npm:^0.1.11":
   version: 0.1.11
   resolution: "@backstage/plugin-app@npm:0.1.11"
@@ -4824,7 +5024,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.42.0-next.1&npm=0.3.6-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.6-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.42.0-next.2&npm=0.3.6-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.6-next.0":
   version: 0.3.6-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.6-next.0"
   dependencies:
@@ -4836,7 +5036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.42.0-next.1&npm=0.2.11-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.11-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.42.0-next.2&npm=0.2.11-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.11-next.0":
   version: 0.2.11-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.11-next.0"
   dependencies:
@@ -4849,7 +5049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.42.0-next.1&npm=0.25.3-next.0, @backstage/plugin-auth-backend@npm:^0.25.3-next.0":
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.42.0-next.2&npm=0.25.3-next.0, @backstage/plugin-auth-backend@npm:^0.25.3-next.0":
   version: 0.25.3-next.0
   resolution: "@backstage/plugin-auth-backend@npm:0.25.3-next.0"
   dependencies:
@@ -5004,7 +5204,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.42.0-next.1&npm=0.10.2-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.10.2-next.0":
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.42.0-next.2&npm=0.10.2-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.10.2-next.0":
   version: 0.10.2-next.0
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.10.2-next.0"
   dependencies:
@@ -5029,7 +5229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.42.0-next.1&npm=0.1.13-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.13-next.0":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.42.0-next.2&npm=0.1.13-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.13-next.0":
   version: 0.1.13-next.0
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.13-next.0"
   dependencies:
@@ -5040,7 +5240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.42.0-next.1&npm=0.2.11-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.11-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.11-next.0":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.42.0-next.2&npm=0.2.11-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.11-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.11-next.0":
   version: 0.2.11-next.0
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.11-next.0"
   dependencies:
@@ -5053,7 +5253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.42.0-next.1&npm=3.0.1-next.0, @backstage/plugin-catalog-backend@npm:3.0.1-next.0, @backstage/plugin-catalog-backend@npm:^3.0.1-next.0":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.42.0-next.2&npm=3.0.1-next.0, @backstage/plugin-catalog-backend@npm:3.0.1-next.0, @backstage/plugin-catalog-backend@npm:^3.0.1-next.0":
   version: 3.0.1-next.0
   resolution: "@backstage/plugin-catalog-backend@npm:3.0.1-next.0"
   dependencies:
@@ -5092,7 +5292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.42.0-next.1&npm=1.1.5, @backstage/plugin-catalog-common@npm:1.1.5, @backstage/plugin-catalog-common@npm:^1.1.5":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.42.0-next.2&npm=1.1.5, @backstage/plugin-catalog-common@npm:1.1.5, @backstage/plugin-catalog-common@npm:^1.1.5":
   version: 1.1.5
   resolution: "@backstage/plugin-catalog-common@npm:1.1.5"
   dependencies:
@@ -5103,17 +5303,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.42.0-next.1&npm=0.4.22-next.1, @backstage/plugin-catalog-graph@npm:^0.4.22-next.1":
-  version: 0.4.22-next.1
-  resolution: "@backstage/plugin-catalog-graph@npm:0.4.22-next.1"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.42.0-next.2&npm=0.4.22-next.2, @backstage/plugin-catalog-graph@npm:^0.4.22-next.2":
+  version: 0.4.22-next.2
+  resolution: "@backstage/plugin-catalog-graph@npm:0.4.22-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.11.0-next.0"
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@backstage/types": "npm:1.2.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5131,11 +5331,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/25ce50ab9473c016877b06d7fd073574b37b47721a6e16518f56f97cc3f3726a83c6bac2dd259704392214142ed9b11c6fbcdea7ffe340d787cadebc153c3f49
+  checksum: 10/c76af095d2c0b1c4d3679589349758fcbd11de2089cd636ef6dac054edbee68d3e57406ee83419505331697c75abcfcbf1a5768074a63e8b9c6591311ce4b23d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.42.0-next.1&npm=1.18.0-next.0, @backstage/plugin-catalog-node@npm:1.18.0-next.0, @backstage/plugin-catalog-node@npm:^1.18.0-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.42.0-next.2&npm=1.18.0-next.0, @backstage/plugin-catalog-node@npm:1.18.0-next.0, @backstage/plugin-catalog-node@npm:^1.18.0-next.0":
   version: 1.18.0-next.0
   resolution: "@backstage/plugin-catalog-node@npm:1.18.0-next.0"
   dependencies:
@@ -5171,7 +5371,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.42.0-next.1&npm=1.20.0-next.1, @backstage/plugin-catalog-react@npm:1.20.0-next.1, @backstage/plugin-catalog-react@npm:^1.20.0-next.1":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.42.0-next.2&npm=1.20.0-next.2, @backstage/plugin-catalog-react@npm:1.20.0-next.2, @backstage/plugin-catalog-react@npm:^1.20.0-next.2":
+  version: 1.20.0-next.2
+  resolution: "@backstage/plugin-catalog-react@npm:1.20.0-next.2"
+  dependencies:
+    "@backstage/catalog-client": "npm:1.11.0-next.0"
+    "@backstage/catalog-model": "npm:1.7.5"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
+    "@backstage/core-plugin-api": "npm:1.10.9"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/frontend-test-utils": "npm:0.3.5-next.2"
+    "@backstage/integration-react": "npm:1.2.9"
+    "@backstage/plugin-catalog-common": "npm:1.1.5"
+    "@backstage/plugin-permission-common": "npm:0.9.1"
+    "@backstage/plugin-permission-react": "npm:0.4.36"
+    "@backstage/types": "npm:1.2.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    classnames: "npm:^2.2.6"
+    lodash: "npm:^4.17.21"
+    material-ui-popup-state: "npm:^1.9.3"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.2.4"
+    yaml: "npm:^2.0.0"
+    zen-observable: "npm:^0.10.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/313cba66a3f3fa3ee1f6475c3d02b97882666196ce9d2929649d747cfebcb74ac720c6ddbc40da9179f8acc54d7e617a441c3ed3c67a1d02cd3803f67d2cccbe
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-react@npm:1.20.0-next.1":
   version: 1.20.0-next.1
   resolution: "@backstage/plugin-catalog-react@npm:1.20.0-next.1"
   dependencies:
@@ -5253,24 +5494,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.42.0-next.1&npm=1.31.2-next.1, @backstage/plugin-catalog@npm:1.31.2-next.1, @backstage/plugin-catalog@npm:^1.31.2-next.1":
-  version: 1.31.2-next.1
-  resolution: "@backstage/plugin-catalog@npm:1.31.2-next.1"
+"@backstage/plugin-catalog@backstage:^::backstage=1.42.0-next.2&npm=1.31.2-next.2, @backstage/plugin-catalog@npm:1.31.2-next.2, @backstage/plugin-catalog@npm:^1.31.2-next.2":
+  version: 1.31.2-next.2
+  resolution: "@backstage/plugin-catalog@npm:1.31.2-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.11.0-next.0"
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
     "@backstage/integration-react": "npm:1.2.9"
     "@backstage/plugin-catalog-common": "npm:1.1.5"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@backstage/plugin-permission-react": "npm:0.4.36"
     "@backstage/plugin-scaffolder-common": "npm:1.7.0-next.0"
     "@backstage/plugin-search-common": "npm:1.2.19"
-    "@backstage/plugin-search-react": "npm:1.9.3-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.3-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.2-next.0"
     "@backstage/types": "npm:1.2.1"
@@ -5295,11 +5536,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0b8e31fd8525e2f9d9c4949a776f2635ac39eb47c629883d942b053a3628e503072ccd8f8f96dee90c8825830232b884054da923effe186dc276e6b52ab43ab2
+  checksum: 10/8404bff6aff0e1f2b297c4473b17c912889d6beebbab825609cd75b604ba93e8f0d59c16520e137b95e2d0df5664589f43a8199f915914f7a73f3eefffec1d28
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.42.0-next.1&npm=0.4.3-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.3-next.0":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.42.0-next.2&npm=0.4.3-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.3-next.0":
   version: 0.4.3-next.0
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.3-next.0"
   dependencies:
@@ -5316,7 +5557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.42.0-next.1&npm=0.5.5-next.0, @backstage/plugin-events-backend@npm:^0.5.5-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.42.0-next.2&npm=0.5.5-next.0, @backstage/plugin-events-backend@npm:^0.5.5-next.0":
   version: 0.5.5-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.5.5-next.0"
   dependencies:
@@ -5391,19 +5632,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.42.0-next.1&npm=0.8.11-next.1, @backstage/plugin-home@npm:^0.8.11-next.1":
-  version: 0.8.11-next.1
-  resolution: "@backstage/plugin-home@npm:0.8.11-next.1"
+"@backstage/plugin-home@backstage:^::backstage=1.42.0-next.2&npm=0.8.11-next.2, @backstage/plugin-home@npm:^0.8.11-next.2":
+  version: 0.8.11-next.2
+  resolution: "@backstage/plugin-home@npm:0.8.11-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.11.0-next.0"
     "@backstage/catalog-model": "npm:1.7.5"
     "@backstage/config": "npm:1.3.3"
     "@backstage/core-app-api": "npm:1.18.0"
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@backstage/plugin-home-react": "npm:0.1.29-next.0"
     "@backstage/theme": "npm:0.6.8-next.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -5427,11 +5668,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e740c26049893f0204791f920a1c605eb21956aec144db873a7b882b6caaa77e4992712541b701c74f24d5c90096709a01172023a56a9efbf8be939ed9b6be4d
+  checksum: 10/70573f3f79e6dd78a37b5f72a02266537cf3136648c04003a92696a18bfb5e9b1722e62e1c880301a463416900fddc398f106b4e57f7ebb1f72e7ea5fdf165e0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.42.0-next.1&npm=0.19.9-next.0, @backstage/plugin-kubernetes-backend@npm:^0.19.9-next.0":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.42.0-next.2&npm=0.19.9-next.0, @backstage/plugin-kubernetes-backend@npm:^0.19.9-next.0":
   version: 0.19.9-next.0
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.9-next.0"
   dependencies:
@@ -5544,16 +5785,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.42.0-next.1&npm=0.12.10-next.1, @backstage/plugin-kubernetes@npm:^0.12.10-next.1":
-  version: 0.12.10-next.1
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.10-next.1"
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.42.0-next.2&npm=0.12.10-next.2, @backstage/plugin-kubernetes@npm:^0.12.10-next.2":
+  version: 0.12.10-next.2
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.10-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@backstage/plugin-kubernetes-common": "npm:0.9.6"
     "@backstage/plugin-kubernetes-react": "npm:0.5.10-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.36"
@@ -5577,11 +5818,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b86de0f064afa47af5ceda6acdf89bb830fc148506faf9c5d0b0430b1d9bf712017e6c15bddf71f56d4b6989d8ba3f2c77de3edc3455e4c599a4a244da4d44d4
+  checksum: 10/ca50626b51910e5747d79b41551eb8ee99b197c1b171c4e406e4bca1aed3a6b88f9a5db3a58a00280d920600e40c05e7bdb1ec08ba3bdf6c231e753f0fb6e016
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.42.0-next.1&npm=0.5.9-next.0, @backstage/plugin-notifications-backend@npm:^0.5.9-next.0":
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.42.0-next.2&npm=0.5.9-next.0, @backstage/plugin-notifications-backend@npm:^0.5.9-next.0":
   version: 0.5.9-next.0
   resolution: "@backstage/plugin-notifications-backend@npm:0.5.9-next.0"
   dependencies:
@@ -5617,7 +5858,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.42.0-next.1&npm=0.2.18-next.0, @backstage/plugin-notifications-node@npm:0.2.18-next.0, @backstage/plugin-notifications-node@npm:^0.2.18-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.42.0-next.2&npm=0.2.18-next.0, @backstage/plugin-notifications-node@npm:0.2.18-next.0, @backstage/plugin-notifications-node@npm:^0.2.18-next.0":
   version: 0.2.18-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.18-next.0"
   dependencies:
@@ -5632,15 +5873,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.42.0-next.1&npm=0.5.8-next.1, @backstage/plugin-notifications@npm:^0.5.8-next.1":
-  version: 0.5.8-next.1
-  resolution: "@backstage/plugin-notifications@npm:0.5.8-next.1"
+"@backstage/plugin-notifications@backstage:^::backstage=1.42.0-next.2&npm=0.5.8-next.2, @backstage/plugin-notifications@npm:^0.5.8-next.2":
+  version: 0.5.8-next.2
+  resolution: "@backstage/plugin-notifications@npm:0.5.8-next.2"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
     "@backstage/plugin-notifications-common": "npm:0.0.10"
     "@backstage/plugin-signals-react": "npm:0.0.15"
     "@backstage/theme": "npm:0.6.8-next.0"
@@ -5661,21 +5902,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ecf32b0eeaf10fd49681932396a75b814771b5434b1c6d92cc8514bab26dccaf1af9fd7c65b0b0a7ff2216f1cbd93f5fb9bb15aca5013deff8d6bae7b3151809
+  checksum: 10/2fa8720507ef53d9d07433823d74aa15d3252aab22545d153b72a12a9b04a56210c9c08302bb7b1b8538d0a0a1e0b8ea2bd87b3c94bc9b90173090d252f3dfe7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.42.0-next.1&npm=0.6.42-next.1, @backstage/plugin-org@npm:^0.6.42-next.1":
-  version: 0.6.42-next.1
-  resolution: "@backstage/plugin-org@npm:0.6.42-next.1"
+"@backstage/plugin-org@backstage:^::backstage=1.42.0-next.2&npm=0.6.42-next.2, @backstage/plugin-org@npm:^0.6.42-next.2":
+  version: 0.6.42-next.2
+  resolution: "@backstage/plugin-org@npm:0.6.42-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.5"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5692,7 +5933,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/db866a5bd793e5bd02c47111ddf9dd3000d2ead093a56077152f971e710a058fb758d6cb67cdb87f531d2a519e82b10efa600f9b1a7210dc553e9b1921fecff3
+  checksum: 10/53ac02b8c6ec7a52f1415b47109ec2d482e5f7fdaad016403f932aca12e78021df4f9c98003c61007fd5465f635a1383cb60cd54d012226610b62c7deedad47e
   languageName: node
   linkType: hard
 
@@ -5782,7 +6023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.42.0-next.1&npm=0.6.5-next.0, @backstage/plugin-proxy-backend@npm:^0.6.5-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.42.0-next.2&npm=0.6.5-next.0, @backstage/plugin-proxy-backend@npm:^0.6.5-next.0":
   version: 0.6.5-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.5-next.0"
   dependencies:
@@ -5899,7 +6140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.42.0-next.1&npm=0.8.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.8.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.8.2-next.0":
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.42.0-next.2&npm=0.8.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.8.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.8.2-next.0":
   version: 0.8.2-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.8.2-next.0"
   dependencies:
@@ -5939,7 +6180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.42.0-next.1&npm=0.1.13-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.13-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.42.0-next.2&npm=0.1.13-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.13-next.0":
   version: 0.1.13-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.13-next.0"
   dependencies:
@@ -5952,7 +6193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.42.0-next.1&npm=2.2.0-next.0, @backstage/plugin-scaffolder-backend@npm:^2.2.0-next.0":
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.42.0-next.2&npm=2.2.0-next.0, @backstage/plugin-scaffolder-backend@npm:^2.2.0-next.0":
   version: 2.2.0-next.0
   resolution: "@backstage/plugin-scaffolder-backend@npm:2.2.0-next.0"
   dependencies:
@@ -6110,21 +6351,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.42.0-next.1&npm=1.34.0-next.1, @backstage/plugin-scaffolder@npm:^1.34.0-next.1":
-  version: 1.34.0-next.1
-  resolution: "@backstage/plugin-scaffolder@npm:1.34.0-next.1"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.42.0-next.2&npm=1.34.0-next.2, @backstage/plugin-scaffolder@npm:^1.34.0-next.2":
+  version: 1.34.0-next.2
+  resolution: "@backstage/plugin-scaffolder@npm:1.34.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.11.0-next.0"
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
     "@backstage/integration": "npm:1.17.1"
     "@backstage/integration-react": "npm:1.2.9"
     "@backstage/plugin-catalog-common": "npm:1.1.5"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@backstage/plugin-permission-react": "npm:0.4.36"
     "@backstage/plugin-scaffolder-common": "npm:1.7.0-next.0"
     "@backstage/plugin-scaffolder-react": "npm:1.19.0-next.1"
@@ -6165,13 +6406,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e59e6ff1288dfb64963429080d71a59d88961344cd0de6cd9c6c05a7bd031f47f84297e9da211cf31ab0ee73f3776dd6f6834da00af1d715edaaf403c69ceb8a
+  checksum: 10/63b89af9c014f74a4004157b7a2d8497260ee9e5224801ecf5e8f2177754ff40932df1c0dad001742f07b467f8038d016deb74d75139f9787f4e37087b00321a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.42.0-next.1&npm=0.3.7-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.7-next.0":
-  version: 0.3.7-next.0
-  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.7-next.0"
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.42.0-next.2&npm=0.3.7-next.1, @backstage/plugin-search-backend-module-catalog@npm:^0.3.7-next.1":
+  version: 0.3.7-next.1
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.7-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.2-next.0"
     "@backstage/catalog-client": "npm:1.11.0-next.0"
@@ -6183,11 +6424,11 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:0.9.1"
     "@backstage/plugin-search-backend-node": "npm:1.3.14-next.0"
     "@backstage/plugin-search-common": "npm:1.2.19"
-  checksum: 10/0a8d8e06fb0606cd3e2d87e25b346cfc945a0612ec1b67cb8b600cd6e753adff972435cf44190d5ffde7ad6db6608a17964e7e52693e5fb5a3e3f1d124be88e6
+  checksum: 10/31eec5e2ec21e2e275f9e1e2fad12669ad67f27ada781b6155e530fb211356a32e9f9ddca0739b443f32b9630b4a5886c45549cffd987e15ec7b5ec409f0d458
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-explore@backstage:^::backstage=1.42.0-next.1&npm=0.3.5-next.0, @backstage/plugin-search-backend-module-explore@npm:^0.3.5-next.0":
+"@backstage/plugin-search-backend-module-explore@backstage:^::backstage=1.42.0-next.2&npm=0.3.5-next.0, @backstage/plugin-search-backend-module-explore@npm:^0.3.5-next.0":
   version: 0.3.5-next.0
   resolution: "@backstage/plugin-search-backend-module-explore@npm:0.3.5-next.0"
   dependencies:
@@ -6238,7 +6479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.42.0-next.1&npm=2.0.5-next.0, @backstage/plugin-search-backend@npm:^2.0.5-next.0":
+"@backstage/plugin-search-backend@backstage:^::backstage=1.42.0-next.2&npm=2.0.5-next.0, @backstage/plugin-search-backend@npm:^2.0.5-next.0":
   version: 2.0.5-next.0
   resolution: "@backstage/plugin-search-backend@npm:2.0.5-next.0"
   dependencies:
@@ -6272,13 +6513,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.42.0-next.1&npm=1.9.3-next.0, @backstage/plugin-search-react@npm:1.9.3-next.0, @backstage/plugin-search-react@npm:^1.9.3-next.0":
-  version: 1.9.3-next.0
-  resolution: "@backstage/plugin-search-react@npm:1.9.3-next.0"
+"@backstage/plugin-search-react@backstage:^::backstage=1.42.0-next.2&npm=1.9.3-next.1, @backstage/plugin-search-react@npm:1.9.3-next.1, @backstage/plugin-search-react@npm:^1.9.3-next.1":
+  version: 1.9.3-next.1
+  resolution: "@backstage/plugin-search-react@npm:1.9.3-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
     "@backstage/plugin-search-common": "npm:1.2.19"
     "@backstage/theme": "npm:0.6.8-next.0"
     "@backstage/types": "npm:1.2.1"
@@ -6298,7 +6539,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c607a5cf4b9a69b0f9fdd291af47c54b17131b9ad83ae516e72957af5f0dbb3dd79fdcf310d1b50a8ee0e39806216bd7250739b736154fe0046372f45ade982f
+  checksum: 10/a77bb6fdfb01df30e354dc4ef69d05ce0a8d353eb0b99a5512d3a4761fda305b224ab7c62999fc03ad4aa56f30617f7f89daa4a55301901341025197cd063d64
   languageName: node
   linkType: hard
 
@@ -6332,18 +6573,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.42.0-next.1&npm=1.4.29-next.1, @backstage/plugin-search@npm:^1.4.29-next.1":
-  version: 1.4.29-next.1
-  resolution: "@backstage/plugin-search@npm:1.4.29-next.1"
+"@backstage/plugin-search@backstage:^::backstage=1.42.0-next.2&npm=1.4.29-next.2, @backstage/plugin-search@npm:^1.4.29-next.2":
+  version: 1.4.29-next.2
+  resolution: "@backstage/plugin-search@npm:1.4.29-next.2"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@backstage/plugin-search-common": "npm:1.2.19"
-    "@backstage/plugin-search-react": "npm:1.9.3-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.3-next.1"
     "@backstage/types": "npm:1.2.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -6358,11 +6599,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/28017f10de23fb1df1174a03c145ddffa93a018e15d9dd7ac615eca80f8c4c38ea08183f04c7121caed4eb24d7dd3477a82aab2fc57f3be9c9f7113f307081b3
+  checksum: 10/8553e266222e17b2e9f999c4d3aa3e38048313e75a4f97835557e7684620bb68783477c8bd4e552d3bb29524fffa16ff53efba4540a5be901c49c1239764240f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.42.0-next.1&npm=0.3.7-next.0, @backstage/plugin-signals-backend@npm:^0.3.7-next.0":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.42.0-next.2&npm=0.3.7-next.0, @backstage/plugin-signals-backend@npm:^0.3.7-next.0":
   version: 0.3.7-next.0
   resolution: "@backstage/plugin-signals-backend@npm:0.3.7-next.0"
   dependencies:
@@ -6418,14 +6659,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.42.0-next.1&npm=0.0.22-next.1, @backstage/plugin-signals@npm:^0.0.22-next.1":
-  version: 0.0.22-next.1
-  resolution: "@backstage/plugin-signals@npm:0.0.22-next.1"
+"@backstage/plugin-signals@backstage:^::backstage=1.42.0-next.2&npm=0.0.22-next.2, @backstage/plugin-signals@npm:^0.0.22-next.2":
+  version: 0.0.22-next.2
+  resolution: "@backstage/plugin-signals@npm:0.0.22-next.2"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.15"
     "@backstage/theme": "npm:0.6.8-next.0"
     "@backstage/types": "npm:1.2.1"
@@ -6442,13 +6683,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4400ae45bf92b0352fae99fc6f505f2059b352456d40ccfa6e18ea18f3fea72e0b274cadf98339ef6c164e9ecd4f552d28ac439ab1622027988ae00c443cdf24
+  checksum: 10/1ca0a83417075b4ece644b477d22d8cd60e10fcf0bb61a003f8c997f14a1f36e59ffc8a2344b33e706ca88c83fbe8849b28a0b1b479f21d566bdc2cc239da30e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.42.0-next.1&npm=2.0.5-next.0, @backstage/plugin-techdocs-backend@npm:^2.0.5-next.0":
-  version: 2.0.5-next.0
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.5-next.0"
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.42.0-next.2&npm=2.0.5-next.1, @backstage/plugin-techdocs-backend@npm:^2.0.5-next.1":
+  version: 2.0.5-next.1
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.0.5-next.1"
   dependencies:
     "@backstage/backend-defaults": "npm:0.11.2-next.0"
     "@backstage/backend-plugin-api": "npm:1.4.2-next.0"
@@ -6470,7 +6711,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/0bb89bf4afa14d4d7baae0cee45da813fbddffe583b3d3edf14f614006715e2316ed75442e2b04e3c7151ef591ed1d6f1390b2fb2714debbc2ac95d8bfc71c5d
+  checksum: 10/917e1d7f81d93349dc975664ec5a759d58abf6186d05ebea5739310e84e7ef7304e63b59673ac112ab97f2361fe646c8ee8aead3a10de098e2a5529f2523eaf6
   languageName: node
   linkType: hard
 
@@ -6481,7 +6722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.42.0-next.1&npm=1.1.27-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.27-next.0":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.42.0-next.2&npm=1.1.27-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.27-next.0":
   version: 1.1.27-next.0
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.27-next.0"
   dependencies:
@@ -6508,7 +6749,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.42.0-next.1&npm=1.13.6-next.0, @backstage/plugin-techdocs-node@npm:1.13.6-next.0, @backstage/plugin-techdocs-node@npm:^1.13.6-next.0":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.42.0-next.2&npm=1.13.6-next.0, @backstage/plugin-techdocs-node@npm:1.13.6-next.0, @backstage/plugin-techdocs-node@npm:^1.13.6-next.0":
   version: 1.13.6-next.0
   resolution: "@backstage/plugin-techdocs-node@npm:1.13.6-next.0"
   dependencies:
@@ -6545,7 +6786,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.42.0-next.1&npm=1.3.2-next.0, @backstage/plugin-techdocs-react@npm:1.3.2-next.0, @backstage/plugin-techdocs-react@npm:^1.3.2-next.0":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.42.0-next.2&npm=1.3.2-next.0, @backstage/plugin-techdocs-react@npm:1.3.2-next.0, @backstage/plugin-techdocs-react@npm:^1.3.2-next.0":
   version: 1.3.2-next.0
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.2-next.0"
   dependencies:
@@ -6603,24 +6844,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.42.0-next.1&npm=1.14.0-next.1, @backstage/plugin-techdocs@npm:^1.14.0-next.1":
-  version: 1.14.0-next.1
-  resolution: "@backstage/plugin-techdocs@npm:1.14.0-next.1"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.42.0-next.2&npm=1.14.0-next.2, @backstage/plugin-techdocs@npm:^1.14.0-next.2":
+  version: 1.14.0-next.2
+  resolution: "@backstage/plugin-techdocs@npm:1.14.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.11.0-next.0"
     "@backstage/catalog-model": "npm:1.7.5"
     "@backstage/config": "npm:1.3.3"
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
     "@backstage/integration": "npm:1.17.1"
     "@backstage/integration-react": "npm:1.2.9"
     "@backstage/plugin-auth-react": "npm:0.1.18-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@backstage/plugin-search-common": "npm:1.2.19"
-    "@backstage/plugin-search-react": "npm:1.9.3-next.0"
+    "@backstage/plugin-search-react": "npm:1.9.3-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.2-next.0"
     "@backstage/theme": "npm:0.6.8-next.0"
@@ -6643,7 +6884,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c79ade836bdde10f938318007fcd712b5bd689cec82ba0d7e9df9535c617372b917ef1c5f640150503f13b36c8f06891f86aabb8ab3440eb92066a104d664f0f
+  checksum: 10/1f1a24cec94373f4ef7def973ea2e7f1f63013191f22d2277115c64d8ea3dd75ef1c6d94aa5a1f35e894b9cbe5575b9bf4890b67804ae851145b915911b9238f
   languageName: node
   linkType: hard
 
@@ -6654,18 +6895,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.42.0-next.1&npm=0.8.25-next.1, @backstage/plugin-user-settings@npm:^0.8.25-next.1":
-  version: 0.8.25-next.1
-  resolution: "@backstage/plugin-user-settings@npm:0.8.25-next.1"
+"@backstage/plugin-user-settings@backstage:^::backstage=1.42.0-next.2&npm=0.8.25-next.2, @backstage/plugin-user-settings@npm:^0.8.25-next.2":
+  version: 0.8.25-next.2
+  resolution: "@backstage/plugin-user-settings@npm:0.8.25-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.5"
     "@backstage/core-app-api": "npm:1.18.0"
-    "@backstage/core-compat-api": "npm:0.4.5-next.1"
-    "@backstage/core-components": "npm:0.17.5-next.0"
+    "@backstage/core-compat-api": "npm:0.5.0-next.2"
+    "@backstage/core-components": "npm:0.17.5-next.1"
     "@backstage/core-plugin-api": "npm:1.10.9"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.11.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.20.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.11.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.20.0-next.2"
     "@backstage/plugin-signals-react": "npm:0.0.15"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
     "@backstage/theme": "npm:0.6.8-next.0"
@@ -6683,7 +6924,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/041954988df2f6350de2d4527001667e09e30e5216a42aee80b0b0039f4c2163a76562150578fc2f30a9ea900f6ad86555c3d7c4745a19d55c82bb55dad78c61
+  checksum: 10/10fdb87d69e2619a1eaa114db62bec12216e3a8982ed9b6493ef7c0c855860f22d8cd92384695f0ba7900e50cdbb4677013359262f91e08d9813663a8dcd382f
   languageName: node
   linkType: hard
 
@@ -6752,7 +6993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.42.0-next.1&npm=0.6.8-next.0, @backstage/theme@npm:0.6.8-next.0, @backstage/theme@npm:^0.6.8-next.0":
+"@backstage/theme@backstage:^::backstage=1.42.0-next.2&npm=0.6.8-next.0, @backstage/theme@npm:0.6.8-next.0, @backstage/theme@npm:^0.6.8-next.0":
   version: 0.6.8-next.0
   resolution: "@backstage/theme@npm:0.6.8-next.0"
   dependencies:
@@ -6799,9 +7040,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.42.0-next.1&npm=0.7.0-next.1, @backstage/ui@npm:^0.7.0-next.1":
-  version: 0.7.0-next.1
-  resolution: "@backstage/ui@npm:0.7.0-next.1"
+"@backstage/ui@backstage:^::backstage=1.42.0-next.2&npm=0.7.0-next.2, @backstage/ui@npm:^0.7.0-next.2":
+  version: 0.7.0-next.2
+  resolution: "@backstage/ui@npm:0.7.0-next.2"
   dependencies:
     "@base-ui-components/react": "npm:1.0.0-alpha.7"
     "@gsap/react": "npm:^2.1.2"
@@ -6818,7 +7059,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6756233b09166a01519b56d8b6b5d788ccd5ae53a75f29827bcdc585f04836fbcbe1d7ac6aa83b2167c30efad80d12e411dca792aa2d083d1a279e3ca5c0bb03
+  checksum: 10/0ceb05d7d71030a7e46d75eef5ff21fc1f96ab96324b6bf22c8572368627efd874fc8262d31c590afcea58769ef97c04c7ee15c3e721f182faa1abdf81df2167
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.42.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.42.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.42.0-next.2-changelog.md)
- Upgrade Helper: [From 1.42.0-next.1 to 1.42.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.42.0-next.1&to=1.42.0-next.2)
 
Created by [Version Bump 16773915346](https://github.com/backstage/demo/actions/runs/16773915346)
 