### PR TITLE
v1.44.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: b613ebeede2fffe7e36d1d601014dbabc7cc61453ed942975c92152f6563a9ed3e3e3659b20e32f601b2062bbe4bfc53314dcace9d7c600ab5dd11d39a4e2f30
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.44.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.44.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.44.0-next.1"
+  "version": "1.44.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,15 +2474,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.44.0-next.1&npm=1.7.1-next.1, @backstage/app-defaults@npm:^1.7.1-next.1":
-  version: 1.7.1-next.1
-  resolution: "@backstage/app-defaults@npm:1.7.1-next.1"
+"@backstage/app-defaults@backstage:^::backstage=1.44.0-next.2&npm=1.7.1-next.2, @backstage/app-defaults@npm:^1.7.1-next.2":
+  version: 1.7.1-next.2
+  resolution: "@backstage/app-defaults@npm:1.7.1-next.2"
   dependencies:
     "@backstage/core-app-api": "npm:1.19.1-next.0"
-    "@backstage/core-components": "npm:0.18.2-next.1"
+    "@backstage/core-components": "npm:0.18.2-next.2"
     "@backstage/core-plugin-api": "npm:1.11.1-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.37-next.0"
-    "@backstage/theme": "npm:0.6.8"
+    "@backstage/theme": "npm:0.6.9-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -2493,7 +2493,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/24eee558f0fff987f74972a013e318aac7a7715cf6f6301f4b0c991b3c92a5cdfd1e09bed36a7cb059347febce2955329ff530c6b99979a05cbb3654660de21a
+  checksum: 10/7fbab40d4405cf407282f7b8094e46121c7ae6091e7a80498440fb83b5edd0b1fd3f2e894f70c651b462e6b6f003e618611bab043d5bc44d2627002075412479
   languageName: node
   linkType: hard
 
@@ -2595,7 +2595,91 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.44.0-next.1&npm=0.13.0-next.1, @backstage/backend-defaults@npm:0.13.0-next.1, @backstage/backend-defaults@npm:^0.13.0-next.1":
+"@backstage/backend-defaults@backstage:^::backstage=1.44.0-next.2&npm=0.13.0-next.2, @backstage/backend-defaults@npm:^0.13.0-next.2":
+  version: 0.13.0-next.2
+  resolution: "@backstage/backend-defaults@npm:0.13.0-next.2"
+  dependencies:
+    "@aws-sdk/abort-controller": "npm:^3.347.0"
+    "@aws-sdk/client-codecommit": "npm:^3.350.0"
+    "@aws-sdk/client-s3": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/backend-app-api": "npm:1.2.8-next.0"
+    "@backstage/backend-dev-utils": "npm:0.1.5"
+    "@backstage/backend-plugin-api": "npm:1.4.4-next.0"
+    "@backstage/cli-node": "npm:0.2.14"
+    "@backstage/config": "npm:1.3.5-next.0"
+    "@backstage/config-loader": "npm:1.10.5-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/integration": "npm:1.18.1-next.1"
+    "@backstage/integration-aws-node": "npm:0.1.18-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.8-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.16-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.5-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@google-cloud/storage": "npm:^7.0.0"
+    "@keyv/memcache": "npm:^2.0.1"
+    "@keyv/redis": "npm:^4.0.1"
+    "@keyv/valkey": "npm:^1.0.1"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@octokit/rest": "npm:^19.0.3"
+    "@opentelemetry/api": "npm:^1.9.0"
+    "@types/cors": "npm:^2.8.6"
+    "@types/express": "npm:^4.17.6"
+    archiver: "npm:^7.0.0"
+    base64-stream: "npm:^1.0.0"
+    better-sqlite3: "npm:^12.0.0"
+    compression: "npm:^1.7.4"
+    concat-stream: "npm:^2.0.0"
+    cookie: "npm:^0.7.0"
+    cors: "npm:^2.8.5"
+    cron: "npm:^3.0.0"
+    express: "npm:^4.17.1"
+    express-promise-router: "npm:^4.1.0"
+    express-rate-limit: "npm:^7.5.0"
+    fs-extra: "npm:^11.2.0"
+    git-url-parse: "npm:^15.0.0"
+    helmet: "npm:^6.0.0"
+    infinispan: "npm:^0.12.0"
+    is-glob: "npm:^4.0.3"
+    jose: "npm:^5.0.0"
+    keyv: "npm:^5.2.1"
+    knex: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    logform: "npm:^2.3.2"
+    luxon: "npm:^3.0.0"
+    minimatch: "npm:^9.0.0"
+    mysql2: "npm:^3.0.0"
+    node-fetch: "npm:^2.7.0"
+    node-forge: "npm:^1.3.1"
+    p-limit: "npm:^3.1.0"
+    path-to-regexp: "npm:^8.0.0"
+    pg: "npm:^8.11.3"
+    pg-connection-string: "npm:^2.3.0"
+    pg-format: "npm:^1.0.4"
+    rate-limit-redis: "npm:^4.2.0"
+    raw-body: "npm:^2.4.1"
+    selfsigned: "npm:^2.0.0"
+    tar: "npm:^6.1.12"
+    triple-beam: "npm:^1.4.1"
+    uuid: "npm:^11.0.0"
+    winston: "npm:^3.2.1"
+    winston-transport: "npm:^4.5.0"
+    yauzl: "npm:^3.0.0"
+    yn: "npm:^4.0.0"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.20.4"
+  peerDependencies:
+    "@google-cloud/cloud-sql-connector": ^1.4.0
+  peerDependenciesMeta:
+    "@google-cloud/cloud-sql-connector":
+      optional: true
+  checksum: 10/04a2d0d564564ed72ce692e945823dacfe1121f92bc5b7373f116f7bc593ba8c152472fe1733712e07e1eac630eda6b7472b11257aa7d36acb3eea1ae3626704
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-defaults@npm:0.13.0-next.1":
   version: 0.13.0-next.1
   resolution: "@backstage/backend-defaults@npm:0.13.0-next.1"
   dependencies:
@@ -2877,7 +2961,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-openapi-utils@npm:^0.6.0, @backstage/backend-openapi-utils@npm:^0.6.1":
+"@backstage/backend-openapi-utils@npm:^0.6.0":
   version: 0.6.1
   resolution: "@backstage/backend-openapi-utils@npm:0.6.1"
   dependencies:
@@ -2901,7 +2985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.44.0-next.1&npm=1.4.4-next.0, @backstage/backend-plugin-api@npm:1.4.4-next.0, @backstage/backend-plugin-api@npm:^1.4.4-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.44.0-next.2&npm=1.4.4-next.0, @backstage/backend-plugin-api@npm:1.4.4-next.0, @backstage/backend-plugin-api@npm:^1.4.4-next.0":
   version: 1.4.4-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.4.4-next.0"
   dependencies:
@@ -2976,7 +3060,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.44.0-next.1&npm=1.7.5, @backstage/catalog-model@npm:1.7.5, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.5":
+"@backstage/catalog-model@backstage:^::backstage=1.44.0-next.2&npm=1.7.5, @backstage/catalog-model@npm:1.7.5, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.5":
   version: 1.7.5
   resolution: "@backstage/catalog-model@npm:1.7.5"
   dependencies:
@@ -3011,15 +3095,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.44.0-next.1&npm=0.34.4-next.1, @backstage/cli@npm:^0.34.4-next.1":
-  version: 0.34.4-next.1
-  resolution: "@backstage/cli@npm:0.34.4-next.1"
+"@backstage/cli@backstage:^::backstage=1.44.0-next.2&npm=0.34.4-next.2, @backstage/cli@npm:^0.34.4-next.2":
+  version: 0.34.4-next.2
+  resolution: "@backstage/cli@npm:0.34.4-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.5"
     "@backstage/cli-common": "npm:0.1.15"
     "@backstage/cli-node": "npm:0.2.14"
-    "@backstage/config": "npm:1.3.4-next.0"
-    "@backstage/config-loader": "npm:1.10.4-next.0"
+    "@backstage/config": "npm:1.3.5-next.0"
+    "@backstage/config-loader": "npm:1.10.5-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/eslint-plugin": "npm:0.1.11"
     "@backstage/integration": "npm:1.18.1-next.1"
@@ -3151,7 +3235,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/373a418dcc1057481ab8d4b34cc1af36d113877abc55d46d473408dd17be74f1f60fb38cafb5df760b9020e2144b2117460938434faf6c6477a42a96a3c5cba9
+  checksum: 10/21689a27610c347d01ed4b3872d32a79f91d2052871877d26cfa2d9ad194e0ddaf8eee8cf0adc0ca2b714b4ce6889560113848b0830238af812016c544a2c9c0
   languageName: node
   linkType: hard
 
@@ -3178,6 +3262,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config-loader@npm:1.10.5-next.0":
+  version: 1.10.5-next.0
+  resolution: "@backstage/config-loader@npm:1.10.5-next.0"
+  dependencies:
+    "@backstage/cli-common": "npm:0.1.15"
+    "@backstage/config": "npm:1.3.5-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.2"
+    "@types/json-schema": "npm:^7.0.6"
+    ajv: "npm:^8.10.0"
+    chokidar: "npm:^3.5.2"
+    fs-extra: "npm:^11.2.0"
+    json-schema: "npm:^0.4.0"
+    json-schema-merge-allof: "npm:^0.8.1"
+    json-schema-traverse: "npm:^1.0.0"
+    lodash: "npm:^4.17.21"
+    minimist: "npm:^1.2.5"
+    typescript-json-schema: "npm:^0.65.0"
+    yaml: "npm:^2.0.0"
+  checksum: 10/abb76b9578641b0bfe83659471a283092bc093b166e7678750e285481ebe05f261f28e9d82fb821ffc45a9d6ed08ce120c58839fd4df6a2f7778e3aa63e48bb4
+  languageName: node
+  linkType: hard
+
 "@backstage/config-loader@npm:^1.10.2, @backstage/config-loader@npm:^1.10.3, @backstage/config-loader@npm:^1.8.1":
   version: 1.10.3
   resolution: "@backstage/config-loader@npm:1.10.3"
@@ -3201,14 +3308,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.44.0-next.1&npm=1.3.4-next.0, @backstage/config@npm:^1.3.4, @backstage/config@npm:^1.3.4-next.0":
-  version: 1.3.4
-  resolution: "@backstage/config@npm:1.3.4"
+"@backstage/config@backstage:^::backstage=1.44.0-next.2&npm=1.3.5-next.0, @backstage/config@npm:1.3.5-next.0, @backstage/config@npm:^1.3.5-next.0":
+  version: 1.3.5-next.0
+  resolution: "@backstage/config@npm:1.3.5-next.0"
   dependencies:
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.2"
     ms: "npm:^2.1.3"
-  checksum: 10/0e4d51f1661c5c65af7dcc4e425bbda19bd54c4d8fc8b14e7c73f398ceaabd00c8fd61ffc883114e9f1f597db70b8f38ac9cc009cbfc271c249b3c6d5d11fe3a
+  checksum: 10/f75e2faf0a56abe61ad70bf831529a5519c0d87d0f4b712d422735c369b96b047c497fd3d0f99e396b562132e010539c8bfc23bf9d59a5c7b4518e673d5eb5cb
   languageName: node
   linkType: hard
 
@@ -3234,7 +3341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.44.0-next.1&npm=1.19.1-next.0, @backstage/core-app-api@npm:1.19.1-next.0, @backstage/core-app-api@npm:^1.19.1-next.0":
+"@backstage/core-app-api@backstage:^::backstage=1.44.0-next.2&npm=1.19.1-next.0, @backstage/core-app-api@npm:1.19.1-next.0, @backstage/core-app-api@npm:^1.19.1-next.0":
   version: 1.19.1-next.0
   resolution: "@backstage/core-app-api@npm:1.19.1-next.0"
   dependencies:
@@ -3290,7 +3397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.44.0-next.1&npm=0.5.3-next.1, @backstage/core-compat-api@npm:0.5.3-next.1, @backstage/core-compat-api@npm:^0.5.3-next.1":
+"@backstage/core-compat-api@backstage:^::backstage=1.44.0-next.2&npm=0.5.3-next.1, @backstage/core-compat-api@npm:0.5.3-next.1, @backstage/core-compat-api@npm:^0.5.3-next.1":
   version: 0.5.3-next.1
   resolution: "@backstage/core-compat-api@npm:0.5.3-next.1"
   dependencies:
@@ -3332,7 +3439,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.44.0-next.1&npm=0.18.2-next.1, @backstage/core-components@npm:0.18.2-next.1, @backstage/core-components@npm:^0.18.2-next.1":
+"@backstage/core-components@backstage:^::backstage=1.44.0-next.2&npm=0.18.2-next.2, @backstage/core-components@npm:0.18.2-next.2, @backstage/core-components@npm:^0.18.2-next.2":
+  version: 0.18.2-next.2
+  resolution: "@backstage/core-components@npm:0.18.2-next.2"
+  dependencies:
+    "@backstage/config": "npm:1.3.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.11.1-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/theme": "npm:0.6.9-next.0"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.3.2"
+    linkifyjs: "npm:4.3.2"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-full-screen: "npm:^1.1.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/dd659894e0ce971d699383bc5ce333f43e5161d3bb24aa9c6e6ef10c3fd187e1d995915306d08dd13223c9e182c197beed06ef82c26d3592e5cf9ec00042fca3
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.18.2-next.1":
   version: 0.18.2-next.1
   resolution: "@backstage/core-components@npm:0.18.2-next.1"
   dependencies:
@@ -3496,7 +3658,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.44.0-next.1&npm=1.11.1-next.0, @backstage/core-plugin-api@npm:1.11.1-next.0, @backstage/core-plugin-api@npm:^1.11.1-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.44.0-next.2&npm=1.11.1-next.0, @backstage/core-plugin-api@npm:1.11.1-next.0, @backstage/core-plugin-api@npm:^1.11.1-next.0":
   version: 1.11.1-next.0
   resolution: "@backstage/core-plugin-api@npm:1.11.1-next.0"
   dependencies:
@@ -3538,7 +3700,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.44.0-next.1&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.44.0-next.2&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -3625,7 +3787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.44.0-next.1&npm=0.3.2-next.1, @backstage/frontend-defaults@npm:0.3.2-next.1, @backstage/frontend-defaults@npm:^0.3.2-next.1":
+"@backstage/frontend-defaults@backstage:^::backstage=1.44.0-next.2&npm=0.3.2-next.1, @backstage/frontend-defaults@npm:0.3.2-next.1, @backstage/frontend-defaults@npm:^0.3.2-next.1":
   version: 0.3.2-next.1
   resolution: "@backstage/frontend-defaults@npm:0.3.2-next.1"
   dependencies:
@@ -3671,7 +3833,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.44.0-next.1&npm=0.12.1-next.1, @backstage/frontend-plugin-api@npm:0.12.1-next.1, @backstage/frontend-plugin-api@npm:^0.12.1-next.1":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.44.0-next.2&npm=0.12.1-next.1, @backstage/frontend-plugin-api@npm:0.12.1-next.1, @backstage/frontend-plugin-api@npm:^0.12.1-next.1":
   version: 0.12.1-next.1
   resolution: "@backstage/frontend-plugin-api@npm:0.12.1-next.1"
   dependencies:
@@ -3847,7 +4009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.44.0-next.1&npm=1.2.11-next.1, @backstage/integration-react@npm:1.2.11-next.1, @backstage/integration-react@npm:^1.2.11-next.1":
+"@backstage/integration-react@backstage:^::backstage=1.44.0-next.2&npm=1.2.11-next.1, @backstage/integration-react@npm:1.2.11-next.1, @backstage/integration-react@npm:^1.2.11-next.1":
   version: 1.2.11-next.1
   resolution: "@backstage/integration-react@npm:1.2.11-next.1"
   dependencies:
@@ -3943,7 +4105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.44.0-next.1&npm=0.13.0-next.1, @backstage/plugin-api-docs@npm:^0.13.0-next.1":
+"@backstage/plugin-api-docs@backstage:^::backstage=1.44.0-next.2&npm=0.13.0-next.1, @backstage/plugin-api-docs@npm:^0.13.0-next.1":
   version: 0.13.0-next.1
   resolution: "@backstage/plugin-api-docs@npm:0.13.0-next.1"
   dependencies:
@@ -3978,7 +4140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.44.0-next.1&npm=0.5.7-next.0, @backstage/plugin-app-backend@npm:^0.5.7-next.0":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.44.0-next.2&npm=0.5.7-next.0, @backstage/plugin-app-backend@npm:^0.5.7-next.0":
   version: 0.5.7-next.0
   resolution: "@backstage/plugin-app-backend@npm:0.5.7-next.0"
   dependencies:
@@ -4075,7 +4237,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.44.0-next.1&npm=0.3.8-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.8-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.44.0-next.2&npm=0.3.8-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.8-next.0":
   version: 0.3.8-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.8-next.0"
   dependencies:
@@ -4087,7 +4249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.44.0-next.1&npm=0.2.13-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.13-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.44.0-next.2&npm=0.2.13-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.13-next.0":
   version: 0.2.13-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.13-next.0"
   dependencies:
@@ -4100,7 +4262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.44.0-next.1&npm=0.25.5-next.0, @backstage/plugin-auth-backend@npm:^0.25.5-next.0":
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.44.0-next.2&npm=0.25.5-next.0, @backstage/plugin-auth-backend@npm:^0.25.5-next.0":
   version: 0.25.5-next.0
   resolution: "@backstage/plugin-auth-backend@npm:0.25.5-next.0"
   dependencies:
@@ -4231,7 +4393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.44.0-next.1&npm=0.11.1-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.11.1-next.1":
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.44.0-next.2&npm=0.11.1-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.11.1-next.1":
   version: 0.11.1-next.1
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.11.1-next.1"
   dependencies:
@@ -4256,7 +4418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.44.0-next.1&npm=0.1.15-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.15-next.1":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.44.0-next.2&npm=0.1.15-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.15-next.1":
   version: 0.1.15-next.1
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.15-next.1"
   dependencies:
@@ -4267,7 +4429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.44.0-next.1&npm=0.2.13-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.13-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.13-next.1":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.44.0-next.2&npm=0.2.13-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.13-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.13-next.1":
   version: 0.2.13-next.1
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.13-next.1"
   dependencies:
@@ -4280,23 +4442,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.44.0-next.1&npm=3.1.1-next.1, @backstage/plugin-catalog-backend@npm:^3.1.1-next.1":
-  version: 3.1.1
-  resolution: "@backstage/plugin-catalog-backend@npm:3.1.1"
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.44.0-next.2&npm=3.1.2-next.2, @backstage/plugin-catalog-backend@npm:^3.1.2-next.2":
+  version: 3.1.2-next.2
+  resolution: "@backstage/plugin-catalog-backend@npm:3.1.2-next.2"
   dependencies:
-    "@backstage/backend-openapi-utils": "npm:^0.6.1"
-    "@backstage/backend-plugin-api": "npm:^1.4.3"
-    "@backstage/catalog-client": "npm:^1.12.0"
-    "@backstage/catalog-model": "npm:^1.7.5"
-    "@backstage/config": "npm:^1.3.4"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/integration": "npm:^1.18.0"
-    "@backstage/plugin-catalog-common": "npm:^1.1.5"
-    "@backstage/plugin-catalog-node": "npm:^1.19.0"
-    "@backstage/plugin-events-node": "npm:^0.4.15"
-    "@backstage/plugin-permission-common": "npm:^0.9.1"
-    "@backstage/plugin-permission-node": "npm:^0.10.4"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/backend-openapi-utils": "npm:0.6.2-next.0"
+    "@backstage/backend-plugin-api": "npm:1.4.4-next.0"
+    "@backstage/catalog-client": "npm:1.12.0"
+    "@backstage/catalog-model": "npm:1.7.5"
+    "@backstage/config": "npm:1.3.5-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/integration": "npm:1.18.1-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.6-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.19.1-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.16-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.2-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.5-next.0"
+    "@backstage/types": "npm:1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     codeowners-utils: "npm:^1.0.2"
     core-js: "npm:^3.6.5"
@@ -4315,7 +4477,7 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/2492467325bd632c71a4df86c3fa24dba5dbe7b26f12e01d57d99d1a746aaf8735fe92f79e96af02ab141c206e07715ffe99e3281438a8dd906270cebbd51e40
+  checksum: 10/598d88735c0fd47b1b80162194d7a04a965c650b4c8e7f731d92b1725f1a590f971d1b1c9b905323a8d82394f4958a9fd8c369ba6dc534af5c358fc5d188babe
   languageName: node
   linkType: hard
 
@@ -4358,7 +4520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.44.0-next.1&npm=1.1.6-next.0, @backstage/plugin-catalog-common@npm:1.1.6-next.0, @backstage/plugin-catalog-common@npm:^1.1.6-next.0":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.44.0-next.2&npm=1.1.6-next.0, @backstage/plugin-catalog-common@npm:1.1.6-next.0, @backstage/plugin-catalog-common@npm:^1.1.6-next.0":
   version: 1.1.6-next.0
   resolution: "@backstage/plugin-catalog-common@npm:1.1.6-next.0"
   dependencies:
@@ -4380,7 +4542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.44.0-next.1&npm=0.5.2-next.1, @backstage/plugin-catalog-graph@npm:^0.5.2-next.1":
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.44.0-next.2&npm=0.5.2-next.1, @backstage/plugin-catalog-graph@npm:^0.5.2-next.1":
   version: 0.5.2-next.1
   resolution: "@backstage/plugin-catalog-graph@npm:0.5.2-next.1"
   dependencies:
@@ -4412,7 +4574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.44.0-next.1&npm=1.19.1-next.0, @backstage/plugin-catalog-node@npm:1.19.1-next.0, @backstage/plugin-catalog-node@npm:^1.19.1-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.44.0-next.2&npm=1.19.1-next.0, @backstage/plugin-catalog-node@npm:1.19.1-next.0, @backstage/plugin-catalog-node@npm:^1.19.1-next.0":
   version: 1.19.1-next.0
   resolution: "@backstage/plugin-catalog-node@npm:1.19.1-next.0"
   dependencies:
@@ -4430,7 +4592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^1.12.4, @backstage/plugin-catalog-node@npm:^1.18.0, @backstage/plugin-catalog-node@npm:^1.19.0":
+"@backstage/plugin-catalog-node@npm:^1.12.4, @backstage/plugin-catalog-node@npm:^1.18.0":
   version: 1.19.0
   resolution: "@backstage/plugin-catalog-node@npm:1.19.0"
   dependencies:
@@ -4448,7 +4610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.44.0-next.1&npm=1.21.2-next.1, @backstage/plugin-catalog-react@npm:1.21.2-next.1, @backstage/plugin-catalog-react@npm:^1.21.2-next.1":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.44.0-next.2&npm=1.21.2-next.1, @backstage/plugin-catalog-react@npm:1.21.2-next.1, @backstage/plugin-catalog-react@npm:^1.21.2-next.1":
   version: 1.21.2-next.1
   resolution: "@backstage/plugin-catalog-react@npm:1.21.2-next.1"
   dependencies:
@@ -4530,7 +4692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.44.0-next.1&npm=1.31.4-next.1, @backstage/plugin-catalog@npm:1.31.4-next.1, @backstage/plugin-catalog@npm:^1.31.4-next.1":
+"@backstage/plugin-catalog@backstage:^::backstage=1.44.0-next.2&npm=1.31.4-next.1, @backstage/plugin-catalog@npm:1.31.4-next.1, @backstage/plugin-catalog@npm:^1.31.4-next.1":
   version: 1.31.4-next.1
   resolution: "@backstage/plugin-catalog@npm:1.31.4-next.1"
   dependencies:
@@ -4576,7 +4738,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.44.0-next.1&npm=0.4.5-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.5-next.1":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.44.0-next.2&npm=0.4.5-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.5-next.1":
   version: 0.4.5-next.1
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.5-next.1"
   dependencies:
@@ -4593,7 +4755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.44.0-next.1&npm=0.5.7-next.0, @backstage/plugin-events-backend@npm:^0.5.7-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.44.0-next.2&npm=0.5.7-next.0, @backstage/plugin-events-backend@npm:^0.5.7-next.0":
   version: 0.5.7-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.5.7-next.0"
   dependencies:
@@ -4668,21 +4830,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.44.0-next.1&npm=0.8.13-next.1, @backstage/plugin-home@npm:^0.8.13-next.1":
-  version: 0.8.13-next.1
-  resolution: "@backstage/plugin-home@npm:0.8.13-next.1"
+"@backstage/plugin-home@backstage:^::backstage=1.44.0-next.2&npm=0.8.13-next.2, @backstage/plugin-home@npm:^0.8.13-next.2":
+  version: 0.8.13-next.2
+  resolution: "@backstage/plugin-home@npm:0.8.13-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.0"
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/config": "npm:1.3.4-next.0"
+    "@backstage/config": "npm:1.3.5-next.0"
     "@backstage/core-app-api": "npm:1.19.1-next.0"
     "@backstage/core-compat-api": "npm:0.5.3-next.1"
-    "@backstage/core-components": "npm:0.18.2-next.1"
+    "@backstage/core-components": "npm:0.18.2-next.2"
     "@backstage/core-plugin-api": "npm:1.11.1-next.0"
     "@backstage/frontend-plugin-api": "npm:0.12.1-next.1"
     "@backstage/plugin-catalog-react": "npm:1.21.2-next.1"
     "@backstage/plugin-home-react": "npm:0.1.31-next.1"
-    "@backstage/theme": "npm:0.6.8"
+    "@backstage/theme": "npm:0.6.9-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -4704,11 +4866,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8b40313f3b4a5fff61348a805f5fd9e39eb13f6efaf9486192ddd1696c620dc9ad96ed42732eb0049f88d55c776d71bdaf5d5c217350c90370bf244decc15daf
+  checksum: 10/c25f66e6e9b4b6f62dba62e1612cb701da0404341ec071137fdcfaa37747d7d6d198984be1ff794d5da4478d7e0d56e93a4c710df599ef85723eb3b00a5938ed
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.44.0-next.1&npm=0.20.3-next.1, @backstage/plugin-kubernetes-backend@npm:^0.20.3-next.1":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.44.0-next.2&npm=0.20.3-next.1, @backstage/plugin-kubernetes-backend@npm:^0.20.3-next.1":
   version: 0.20.3-next.1
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.20.3-next.1"
   dependencies:
@@ -4818,7 +4980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.44.0-next.1&npm=0.12.12-next.1, @backstage/plugin-kubernetes@npm:^0.12.12-next.1":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.44.0-next.2&npm=0.12.12-next.1, @backstage/plugin-kubernetes@npm:^0.12.12-next.1":
   version: 0.12.12-next.1
   resolution: "@backstage/plugin-kubernetes@npm:0.12.12-next.1"
   dependencies:
@@ -4855,13 +5017,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.44.0-next.1&npm=0.5.11-next.0, @backstage/plugin-notifications-backend@npm:^0.5.11-next.0":
-  version: 0.5.11-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.5.11-next.0"
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.44.0-next.2&npm=0.5.11-next.1, @backstage/plugin-notifications-backend@npm:^0.5.11-next.1":
+  version: 0.5.11-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.5.11-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.4.4-next.0"
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/config": "npm:1.3.4-next.0"
+    "@backstage/config": "npm:1.3.5-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-auth-node": "npm:0.6.8-next.0"
     "@backstage/plugin-catalog-node": "npm:1.19.1-next.0"
@@ -4877,7 +5039,7 @@ __metadata:
     uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     yn: "npm:^4.0.0"
-  checksum: 10/a55f4bb0316fabf45a0b58e0e1d0faeb0232304b55648edf8b10aba7c78a97430ba5cedda6a5f54168e8bfa0b7f17303dbb487e95aaa4c9a32a37994d82eadf8
+  checksum: 10/61f942518d9cb1434bae4df01e52f56f81fcd8fe967e1f05ed22e9d67f9b77922f9ec14fd8b5669eb3a6598891963ced5c7a1b9e2a02c206097134d9089642c5
   languageName: node
   linkType: hard
 
@@ -4892,7 +5054,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.44.0-next.1&npm=0.2.20-next.0, @backstage/plugin-notifications-node@npm:0.2.20-next.0, @backstage/plugin-notifications-node@npm:^0.2.20-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.44.0-next.2&npm=0.2.20-next.0, @backstage/plugin-notifications-node@npm:0.2.20-next.0, @backstage/plugin-notifications-node@npm:^0.2.20-next.0":
   version: 0.2.20-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.20-next.0"
   dependencies:
@@ -4907,18 +5069,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.44.0-next.1&npm=0.5.10-next.1, @backstage/plugin-notifications@npm:^0.5.10-next.1":
-  version: 0.5.10-next.1
-  resolution: "@backstage/plugin-notifications@npm:0.5.10-next.1"
+"@backstage/plugin-notifications@backstage:^::backstage=1.44.0-next.2&npm=0.5.10-next.2, @backstage/plugin-notifications@npm:^0.5.10-next.2":
+  version: 0.5.10-next.2
+  resolution: "@backstage/plugin-notifications@npm:0.5.10-next.2"
   dependencies:
     "@backstage/core-compat-api": "npm:0.5.3-next.1"
-    "@backstage/core-components": "npm:0.18.2-next.1"
+    "@backstage/core-components": "npm:0.18.2-next.2"
     "@backstage/core-plugin-api": "npm:1.11.1-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.12.1-next.1"
     "@backstage/plugin-notifications-common": "npm:0.1.1-next.0"
     "@backstage/plugin-signals-react": "npm:0.0.16-next.0"
-    "@backstage/theme": "npm:0.6.8"
+    "@backstage/theme": "npm:0.6.9-next.0"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4936,17 +5098,17 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0d913c4f6a507435fe450cb74e5f083dbda9fa130f8d0d8c31a6330d37ebe8416a8a5fc7bd20900a1bd79b505ab0eb253a3a5233c8a32c945023b7e86df056da
+  checksum: 10/978f0e25317faaa3b0baf8d273d42274b5a5f9c40f72d2f0349201d37ead2de080d8a6e30382d11239362cb5ce7489ca01a77e18102cead78849b447c4e2867b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.44.0-next.1&npm=0.6.45-next.1, @backstage/plugin-org@npm:^0.6.45-next.1":
-  version: 0.6.45-next.1
-  resolution: "@backstage/plugin-org@npm:0.6.45-next.1"
+"@backstage/plugin-org@backstage:^::backstage=1.44.0-next.2&npm=0.6.45-next.2, @backstage/plugin-org@npm:^0.6.45-next.2":
+  version: 0.6.45-next.2
+  resolution: "@backstage/plugin-org@npm:0.6.45-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.5"
     "@backstage/core-compat-api": "npm:0.5.3-next.1"
-    "@backstage/core-components": "npm:0.18.2-next.1"
+    "@backstage/core-components": "npm:0.18.2-next.2"
     "@backstage/core-plugin-api": "npm:1.11.1-next.0"
     "@backstage/frontend-plugin-api": "npm:0.12.1-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.6-next.0"
@@ -4967,7 +5129,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0f7d44e16023d607eb6585b3d8e71ec2c79bcd6a018ab6e47479a99bf5c386c97e730f74960ea61cbb099d255bae5e4e927915f1a83ab8563c9132387a11d66d
+  checksum: 10/76e9529cfd16df2faa7d474fc37d754145c8eddabf1cc8b70f299ed7580e0b71224f2e4561778084d5a4ef7c16f6105b19a2530d1face75d9df0b130ebedf0bd
   languageName: node
   linkType: hard
 
@@ -5092,7 +5254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.44.0-next.1&npm=0.6.7-next.0, @backstage/plugin-proxy-backend@npm:^0.6.7-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.44.0-next.2&npm=0.6.7-next.0, @backstage/plugin-proxy-backend@npm:^0.6.7-next.0":
   version: 0.6.7-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.7-next.0"
   dependencies:
@@ -5209,7 +5371,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.44.0-next.1&npm=0.9.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.1-next.1":
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.44.0-next.2&npm=0.9.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.1-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.1-next.1":
   version: 0.9.1-next.1
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.1-next.1"
   dependencies:
@@ -5250,7 +5412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.44.0-next.1&npm=0.1.15-next.1, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.15-next.1":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.44.0-next.2&npm=0.1.15-next.1, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.15-next.1":
   version: 0.1.15-next.1
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.15-next.1"
   dependencies:
@@ -5263,7 +5425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.44.0-next.1&npm=3.0.0-next.1, @backstage/plugin-scaffolder-backend@npm:^3.0.0-next.1":
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.44.0-next.2&npm=3.0.0-next.1, @backstage/plugin-scaffolder-backend@npm:^3.0.0-next.1":
   version: 3.0.0-next.1
   resolution: "@backstage/plugin-scaffolder-backend@npm:3.0.0-next.1"
   dependencies:
@@ -5369,19 +5531,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.19.2-next.1":
-  version: 1.19.2-next.1
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.19.2-next.1"
+"@backstage/plugin-scaffolder-react@npm:1.19.2-next.2":
+  version: 1.19.2-next.2
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.19.2-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.0"
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/core-components": "npm:0.18.2-next.1"
+    "@backstage/core-components": "npm:0.18.2-next.2"
     "@backstage/core-plugin-api": "npm:1.11.1-next.0"
     "@backstage/frontend-plugin-api": "npm:0.12.1-next.1"
     "@backstage/plugin-catalog-react": "npm:1.21.2-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.37-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.7.2-next.1"
-    "@backstage/theme": "npm:0.6.8"
+    "@backstage/theme": "npm:0.6.9-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -5417,18 +5579,18 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/81bca405aaae5672787d5ef04f221f4ef3c0ed0a68e15c5bd6283f1d28226273775dffbf81bd5f0e8c10e7d02966aa27fb62fa7cbdbb100473f395f862a21257
+  checksum: 10/6653323aecae8b1ddabbd22a96d876c9e12f890115f57eaf808d9f119cf656309d1ca5af4e06c29931e1fdb67552f8faaf3777de759404bd99c6e012888a9c0f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.44.0-next.1&npm=1.34.2-next.1, @backstage/plugin-scaffolder@npm:^1.34.2-next.1":
-  version: 1.34.2-next.1
-  resolution: "@backstage/plugin-scaffolder@npm:1.34.2-next.1"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.44.0-next.2&npm=1.34.2-next.2, @backstage/plugin-scaffolder@npm:^1.34.2-next.2":
+  version: 1.34.2-next.2
+  resolution: "@backstage/plugin-scaffolder@npm:1.34.2-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.0"
     "@backstage/catalog-model": "npm:1.7.5"
     "@backstage/core-compat-api": "npm:0.5.3-next.1"
-    "@backstage/core-components": "npm:0.18.2-next.1"
+    "@backstage/core-components": "npm:0.18.2-next.2"
     "@backstage/core-plugin-api": "npm:1.11.1-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.12.1-next.1"
@@ -5438,7 +5600,7 @@ __metadata:
     "@backstage/plugin-catalog-react": "npm:1.21.2-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.37-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.7.2-next.1"
-    "@backstage/plugin-scaffolder-react": "npm:1.19.2-next.1"
+    "@backstage/plugin-scaffolder-react": "npm:1.19.2-next.2"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.4-next.1"
     "@backstage/types": "npm:1.2.2"
@@ -5479,11 +5641,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6cb63fe16fdfffe1da6b513b68b29dbf5f8405a722c4e45ef6a9d8a12c3fe237602ada71ddf9baa2709db8500c5d8325d332bd456850113f45bc851bbbb6d892
+  checksum: 10/72bb4b4298d944edafce44605150d5580136d952674fadac9e33c840d79e06dc4d83408b2cf089db6f27586b5343189d52a93bf77f38404293fa3ed916f6b6e8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.44.0-next.1&npm=0.3.9-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.9-next.0":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.44.0-next.2&npm=0.3.9-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.9-next.0":
   version: 0.3.9-next.0
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.9-next.0"
   dependencies:
@@ -5557,7 +5719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.44.0-next.1&npm=2.0.7-next.1, @backstage/plugin-search-backend@npm:^2.0.7-next.1":
+"@backstage/plugin-search-backend@backstage:^::backstage=1.44.0-next.2&npm=2.0.7-next.1, @backstage/plugin-search-backend@npm:^2.0.7-next.1":
   version: 2.0.7-next.1
   resolution: "@backstage/plugin-search-backend@npm:2.0.7-next.1"
   dependencies:
@@ -5601,7 +5763,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.44.0-next.1&npm=1.9.5-next.1, @backstage/plugin-search-react@npm:1.9.5-next.1, @backstage/plugin-search-react@npm:^1.9.5-next.1":
+"@backstage/plugin-search-react@backstage:^::backstage=1.44.0-next.2&npm=1.9.5-next.2, @backstage/plugin-search-react@npm:1.9.5-next.2, @backstage/plugin-search-react@npm:^1.9.5-next.2":
+  version: 1.9.5-next.2
+  resolution: "@backstage/plugin-search-react@npm:1.9.5-next.2"
+  dependencies:
+    "@backstage/core-components": "npm:0.18.2-next.2"
+    "@backstage/core-plugin-api": "npm:1.11.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.12.1-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.20-next.0"
+    "@backstage/theme": "npm:0.6.9-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    lodash: "npm:^4.17.21"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.3.2"
+    uuid: "npm:^11.0.2"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/cbe9edb7249de7cd83c47c857f04803c969d0dc0c9b6c507cdac9c618079be568471cba325cfaf553068a87b231a11ded55edb13d3862ce687f7aca72661583f
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-react@npm:1.9.5-next.1":
   version: 1.9.5-next.1
   resolution: "@backstage/plugin-search-react@npm:1.9.5-next.1"
   dependencies:
@@ -5661,7 +5853,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.44.0-next.1&npm=1.4.31-next.1, @backstage/plugin-search@npm:^1.4.31-next.1":
+"@backstage/plugin-search@backstage:^::backstage=1.44.0-next.2&npm=1.4.31-next.1, @backstage/plugin-search@npm:^1.4.31-next.1":
   version: 1.4.31-next.1
   resolution: "@backstage/plugin-search@npm:1.4.31-next.1"
   dependencies:
@@ -5691,7 +5883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.44.0-next.1&npm=0.3.9-next.0, @backstage/plugin-signals-backend@npm:^0.3.9-next.0":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.44.0-next.2&npm=0.3.9-next.0, @backstage/plugin-signals-backend@npm:^0.3.9-next.0":
   version: 0.3.9-next.0
   resolution: "@backstage/plugin-signals-backend@npm:0.3.9-next.0"
   dependencies:
@@ -5747,16 +5939,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.44.0-next.1&npm=0.0.24-next.1, @backstage/plugin-signals@npm:^0.0.24-next.1":
-  version: 0.0.24-next.1
-  resolution: "@backstage/plugin-signals@npm:0.0.24-next.1"
+"@backstage/plugin-signals@backstage:^::backstage=1.44.0-next.2&npm=0.0.24-next.2, @backstage/plugin-signals@npm:^0.0.24-next.2":
+  version: 0.0.24-next.2
+  resolution: "@backstage/plugin-signals@npm:0.0.24-next.2"
   dependencies:
     "@backstage/core-compat-api": "npm:0.5.3-next.1"
-    "@backstage/core-components": "npm:0.18.2-next.1"
+    "@backstage/core-components": "npm:0.18.2-next.2"
     "@backstage/core-plugin-api": "npm:1.11.1-next.0"
     "@backstage/frontend-plugin-api": "npm:0.12.1-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.16-next.0"
-    "@backstage/theme": "npm:0.6.8"
+    "@backstage/theme": "npm:0.6.9-next.0"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5771,11 +5963,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a85c349ce7221c5fdbc9209a444ee54142c6827e2c0b784ac05cb4a2fbd860c27c9f74f8b7ce83f7ea97e0782fe0e6b9106135dce974434cfea3fc85f5be082c
+  checksum: 10/0f0cc204ad15575940b96583f1aa8631f50be41c7553c0dc5477ecb9bdf8fda07460e78c5a89de50f5fd5b0ba2aa028bdf0d2a98c3be257f33ec32f400657ea5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.44.0-next.1&npm=2.1.1-next.1, @backstage/plugin-techdocs-backend@npm:^2.1.1-next.1":
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.44.0-next.2&npm=2.1.1-next.1, @backstage/plugin-techdocs-backend@npm:^2.1.1-next.1":
   version: 2.1.1-next.1
   resolution: "@backstage/plugin-techdocs-backend@npm:2.1.1-next.1"
   dependencies:
@@ -5811,7 +6003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.44.0-next.1&npm=1.1.29-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.29-next.1":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.44.0-next.2&npm=1.1.29-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.29-next.1":
   version: 1.1.29-next.1
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.29-next.1"
   dependencies:
@@ -5838,7 +6030,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.44.0-next.1&npm=1.13.8-next.1, @backstage/plugin-techdocs-node@npm:1.13.8-next.1, @backstage/plugin-techdocs-node@npm:^1.13.8-next.1":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.44.0-next.2&npm=1.13.8-next.1, @backstage/plugin-techdocs-node@npm:1.13.8-next.1, @backstage/plugin-techdocs-node@npm:^1.13.8-next.1":
   version: 1.13.8-next.1
   resolution: "@backstage/plugin-techdocs-node@npm:1.13.8-next.1"
   dependencies:
@@ -5875,7 +6067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.44.0-next.1&npm=1.3.4-next.1, @backstage/plugin-techdocs-react@npm:1.3.4-next.1, @backstage/plugin-techdocs-react@npm:^1.3.4-next.1":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.44.0-next.2&npm=1.3.4-next.1, @backstage/plugin-techdocs-react@npm:1.3.4-next.1, @backstage/plugin-techdocs-react@npm:^1.3.4-next.1":
   version: 1.3.4-next.1
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.4-next.1"
   dependencies:
@@ -5933,15 +6125,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.44.0-next.1&npm=1.15.1-next.1, @backstage/plugin-techdocs@npm:^1.15.1-next.1":
-  version: 1.15.1-next.1
-  resolution: "@backstage/plugin-techdocs@npm:1.15.1-next.1"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.44.0-next.2&npm=1.15.1-next.2, @backstage/plugin-techdocs@npm:^1.15.1-next.2":
+  version: 1.15.1-next.2
+  resolution: "@backstage/plugin-techdocs@npm:1.15.1-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.0"
     "@backstage/catalog-model": "npm:1.7.5"
-    "@backstage/config": "npm:1.3.4-next.0"
+    "@backstage/config": "npm:1.3.5-next.0"
     "@backstage/core-compat-api": "npm:0.5.3-next.1"
-    "@backstage/core-components": "npm:0.18.2-next.1"
+    "@backstage/core-components": "npm:0.18.2-next.2"
     "@backstage/core-plugin-api": "npm:1.11.1-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.12.1-next.1"
@@ -5950,10 +6142,10 @@ __metadata:
     "@backstage/plugin-auth-react": "npm:0.1.20-next.1"
     "@backstage/plugin-catalog-react": "npm:1.21.2-next.1"
     "@backstage/plugin-search-common": "npm:1.2.20-next.0"
-    "@backstage/plugin-search-react": "npm:1.9.5-next.1"
+    "@backstage/plugin-search-react": "npm:1.9.5-next.2"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.4-next.1"
-    "@backstage/theme": "npm:0.6.8"
+    "@backstage/theme": "npm:0.6.9-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5973,7 +6165,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/acc5c0416ccc90bca169ad4328a87b177c09c6b24123437931ea64d3153ccf39573dcaf5d481c3210019410f605883fd05a2c9b7610a689d6c8b2d42d9b22053
+  checksum: 10/66ae05acfe2fd199768fd6a48667deabf2f577b3f23e9a06075f8a6783e4f4d8544720e76b4f0f4454ad0bec780e50d47b053a7c82f56aabf34afd1bb10234fb
   languageName: node
   linkType: hard
 
@@ -5984,21 +6176,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.44.0-next.1&npm=0.8.27-next.1, @backstage/plugin-user-settings@npm:^0.8.27-next.1":
-  version: 0.8.27-next.1
-  resolution: "@backstage/plugin-user-settings@npm:0.8.27-next.1"
+"@backstage/plugin-user-settings@backstage:^::backstage=1.44.0-next.2&npm=0.8.27-next.2, @backstage/plugin-user-settings@npm:^0.8.27-next.2":
+  version: 0.8.27-next.2
+  resolution: "@backstage/plugin-user-settings@npm:0.8.27-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.5"
     "@backstage/core-app-api": "npm:1.19.1-next.0"
     "@backstage/core-compat-api": "npm:0.5.3-next.1"
-    "@backstage/core-components": "npm:0.18.2-next.1"
+    "@backstage/core-components": "npm:0.18.2-next.2"
     "@backstage/core-plugin-api": "npm:1.11.1-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.12.1-next.1"
     "@backstage/plugin-catalog-react": "npm:1.21.2-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.16-next.0"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
-    "@backstage/theme": "npm:0.6.8"
+    "@backstage/theme": "npm:0.6.9-next.0"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -6013,7 +6205,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c6f49ac9c9e363787c3c0f6c97c6f824612fdf3ecd6ddc7a3085d3944786db09a0169ac9f19993de1e3130a1e970241917425fd8ac0b4034923de811a8e932e6
+  checksum: 10/31189b531c71764780629c7e16309550ea3577cff07877b329b71288d3aeba70552807da1ab0783de6aa6c3aa7834f8386793950e9aa31e64dbd44712e6d9aef
   languageName: node
   linkType: hard
 
@@ -6082,7 +6274,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.44.0-next.1&npm=0.6.8, @backstage/theme@npm:0.6.8, @backstage/theme@npm:^0.6.6, @backstage/theme@npm:^0.6.8":
+"@backstage/theme@backstage:^::backstage=1.44.0-next.2&npm=0.6.9-next.0, @backstage/theme@npm:0.6.9-next.0, @backstage/theme@npm:^0.6.9-next.0":
+  version: 0.6.9-next.0
+  resolution: "@backstage/theme@npm:0.6.9-next.0"
+  dependencies:
+    "@emotion/react": "npm:^11.10.5"
+    "@emotion/styled": "npm:^11.10.5"
+    "@mui/material": "npm:^5.12.2"
+  peerDependencies:
+    "@material-ui/core": ^4.12.2
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/6e5a2850962f76a5ded4b8fcdb10b76b83356d6b7248674ee3fce545d92813326f7e2731412659d02818a0552094a2120f7c69785ce68b61bc151bfad2b7e360
+  languageName: node
+  linkType: hard
+
+"@backstage/theme@npm:0.6.8, @backstage/theme@npm:^0.6.6, @backstage/theme@npm:^0.6.8":
   version: 0.6.8
   resolution: "@backstage/theme@npm:0.6.8"
   dependencies:
@@ -6109,9 +6321,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.44.0-next.1&npm=0.7.2-next.0, @backstage/ui@npm:^0.7.2-next.0":
-  version: 0.7.2-next.0
-  resolution: "@backstage/ui@npm:0.7.2-next.0"
+"@backstage/ui@backstage:^::backstage=1.44.0-next.2&npm=0.7.2-next.1, @backstage/ui@npm:^0.7.2-next.1":
+  version: 0.7.2-next.1
+  resolution: "@backstage/ui@npm:0.7.2-next.1"
   dependencies:
     "@base-ui-components/react": "npm:1.0.0-alpha.7"
     "@remixicon/react": "npm:^4.6.0"
@@ -6126,7 +6338,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e410915629c1204039705586266b99827ecb4c71c06bc886ee3b13fd4374a3b6403e7f6cd7984f5600bd01ddfc14e3d7a5132e317c7eafc90783eaac8efb95bb
+  checksum: 10/b28f5c577bcf617540a4607b0270ff1c152e07b2afb8b9817c3ccaa1836a7c303c8d651939e580925b5004c01be177b49cbc4ad7b93b6147fe608ab51213ab41
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.44.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.44.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.44.0-next.2-changelog.md)
- Upgrade Helper: [From 1.44.0-next.1 to 1.44.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.44.0-next.1&to=1.44.0-next.2)
 
Created by [Version Bump 18158707897](https://github.com/backstage/demo/actions/runs/18158707897)
 