### PR TITLE
v1.45.0-next.1 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: a7960e90b20fe64de29d899d907dd9d539f4111357d84ce89eab20c01ea2941d4d4ee2a569d220be2f92f93d63cee18b85a6273cbb74980564fb80f7ee7c64d2
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.45.0-next.0/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.45.0-next.1/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.45.0-next.0"
+  "version": "1.45.0-next.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,7 +2474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.45.0-next.0&npm=1.7.2-next.0, @backstage/app-defaults@npm:^1.7.2-next.0":
+"@backstage/app-defaults@backstage:^::backstage=1.45.0-next.1&npm=1.7.2-next.0, @backstage/app-defaults@npm:^1.7.2-next.0":
   version: 1.7.2-next.0
   resolution: "@backstage/app-defaults@npm:1.7.2-next.0"
   dependencies:
@@ -2595,7 +2595,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.45.0-next.0&npm=0.13.1-next.0, @backstage/backend-defaults@npm:0.13.1-next.0, @backstage/backend-defaults@npm:^0.13.1-next.0":
+"@backstage/backend-defaults@backstage:^::backstage=1.45.0-next.1&npm=0.13.1-next.0, @backstage/backend-defaults@npm:0.13.1-next.0, @backstage/backend-defaults@npm:^0.13.1-next.0":
   version: 0.13.1-next.0
   resolution: "@backstage/backend-defaults@npm:0.13.1-next.0"
   dependencies:
@@ -2818,7 +2818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.45.0-next.0&npm=1.4.5-next.0, @backstage/backend-plugin-api@npm:1.4.5-next.0, @backstage/backend-plugin-api@npm:^1.4.5-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.45.0-next.1&npm=1.4.5-next.0, @backstage/backend-plugin-api@npm:1.4.5-next.0, @backstage/backend-plugin-api@npm:^1.4.5-next.0":
   version: 1.4.5-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.4.5-next.0"
   dependencies:
@@ -2905,7 +2905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.45.0-next.0&npm=1.7.6-next.0, @backstage/catalog-model@npm:1.7.6-next.0, @backstage/catalog-model@npm:^1.7.6-next.0":
+"@backstage/catalog-model@backstage:^::backstage=1.45.0-next.1&npm=1.7.6-next.0, @backstage/catalog-model@npm:1.7.6-next.0, @backstage/catalog-model@npm:^1.7.6-next.0":
   version: 1.7.6-next.0
   resolution: "@backstage/catalog-model@npm:1.7.6-next.0"
   dependencies:
@@ -2968,7 +2968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.45.0-next.0&npm=0.34.5-next.0, @backstage/cli@npm:^0.34.5-next.0":
+"@backstage/cli@backstage:^::backstage=1.45.0-next.1&npm=0.34.5-next.0, @backstage/cli@npm:^0.34.5-next.0":
   version: 0.34.5-next.0
   resolution: "@backstage/cli@npm:0.34.5-next.0"
   dependencies:
@@ -3155,7 +3155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.45.0-next.0&npm=1.3.6-next.0, @backstage/config@npm:1.3.6-next.0, @backstage/config@npm:^1.3.6-next.0":
+"@backstage/config@backstage:^::backstage=1.45.0-next.1&npm=1.3.6-next.0, @backstage/config@npm:1.3.6-next.0, @backstage/config@npm:^1.3.6-next.0":
   version: 1.3.6-next.0
   resolution: "@backstage/config@npm:1.3.6-next.0"
   dependencies:
@@ -3177,7 +3177,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.45.0-next.0&npm=1.19.2-next.0, @backstage/core-app-api@npm:1.19.2-next.0, @backstage/core-app-api@npm:^1.19.2-next.0":
+"@backstage/core-app-api@backstage:^::backstage=1.45.0-next.1&npm=1.19.2-next.0, @backstage/core-app-api@npm:1.19.2-next.0, @backstage/core-app-api@npm:^1.19.2-next.0":
   version: 1.19.2-next.0
   resolution: "@backstage/core-app-api@npm:1.19.2-next.0"
   dependencies:
@@ -3233,7 +3233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.45.0-next.0&npm=0.5.4-next.0, @backstage/core-compat-api@npm:0.5.4-next.0, @backstage/core-compat-api@npm:^0.5.4-next.0":
+"@backstage/core-compat-api@backstage:^::backstage=1.45.0-next.1&npm=0.5.4-next.0, @backstage/core-compat-api@npm:0.5.4-next.0, @backstage/core-compat-api@npm:^0.5.4-next.0":
   version: 0.5.4-next.0
   resolution: "@backstage/core-compat-api@npm:0.5.4-next.0"
   dependencies:
@@ -3275,7 +3275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.45.0-next.0&npm=0.18.3-next.0, @backstage/core-components@npm:0.18.3-next.0, @backstage/core-components@npm:^0.18.3-next.0":
+"@backstage/core-components@backstage:^::backstage=1.45.0-next.1&npm=0.18.3-next.0, @backstage/core-components@npm:0.18.3-next.0, @backstage/core-components@npm:^0.18.3-next.0":
   version: 0.18.3-next.0
   resolution: "@backstage/core-components@npm:0.18.3-next.0"
   dependencies:
@@ -3439,7 +3439,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.45.0-next.0&npm=1.11.2-next.0, @backstage/core-plugin-api@npm:1.11.2-next.0, @backstage/core-plugin-api@npm:^1.11.2-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.45.0-next.1&npm=1.11.2-next.0, @backstage/core-plugin-api@npm:1.11.2-next.0, @backstage/core-plugin-api@npm:^1.11.2-next.0":
   version: 1.11.2-next.0
   resolution: "@backstage/core-plugin-api@npm:1.11.2-next.0"
   dependencies:
@@ -3481,7 +3481,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.45.0-next.0&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.45.0-next.1&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -3568,7 +3568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.45.0-next.0&npm=0.3.3-next.0, @backstage/frontend-defaults@npm:0.3.3-next.0, @backstage/frontend-defaults@npm:^0.3.3-next.0":
+"@backstage/frontend-defaults@backstage:^::backstage=1.45.0-next.1&npm=0.3.3-next.0, @backstage/frontend-defaults@npm:0.3.3-next.0, @backstage/frontend-defaults@npm:^0.3.3-next.0":
   version: 0.3.3-next.0
   resolution: "@backstage/frontend-defaults@npm:0.3.3-next.0"
   dependencies:
@@ -3614,7 +3614,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.45.0-next.0&npm=0.12.2-next.0, @backstage/frontend-plugin-api@npm:0.12.2-next.0, @backstage/frontend-plugin-api@npm:^0.12.2-next.0":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.45.0-next.1&npm=0.12.2-next.0, @backstage/frontend-plugin-api@npm:0.12.2-next.0, @backstage/frontend-plugin-api@npm:^0.12.2-next.0":
   version: 0.12.2-next.0
   resolution: "@backstage/frontend-plugin-api@npm:0.12.2-next.0"
   dependencies:
@@ -3766,7 +3766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.45.0-next.0&npm=1.2.12-next.0, @backstage/integration-react@npm:1.2.12-next.0, @backstage/integration-react@npm:^1.2.12-next.0":
+"@backstage/integration-react@backstage:^::backstage=1.45.0-next.1&npm=1.2.12-next.0, @backstage/integration-react@npm:1.2.12-next.0, @backstage/integration-react@npm:^1.2.12-next.0":
   version: 1.2.12-next.0
   resolution: "@backstage/integration-react@npm:1.2.12-next.0"
   dependencies:
@@ -3844,7 +3844,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.45.0-next.0&npm=0.13.1-next.0, @backstage/plugin-api-docs@npm:^0.13.1-next.0":
+"@backstage/plugin-api-docs@backstage:^::backstage=1.45.0-next.1&npm=0.13.1-next.0, @backstage/plugin-api-docs@npm:^0.13.1-next.0":
   version: 0.13.1-next.0
   resolution: "@backstage/plugin-api-docs@npm:0.13.1-next.0"
   dependencies:
@@ -3879,7 +3879,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.45.0-next.0&npm=0.5.8-next.0, @backstage/plugin-app-backend@npm:^0.5.8-next.0":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.45.0-next.1&npm=0.5.8-next.0, @backstage/plugin-app-backend@npm:^0.5.8-next.0":
   version: 0.5.8-next.0
   resolution: "@backstage/plugin-app-backend@npm:0.5.8-next.0"
   dependencies:
@@ -3976,7 +3976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.45.0-next.0&npm=0.3.9-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.9-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.45.0-next.1&npm=0.3.9-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.9-next.0":
   version: 0.3.9-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.9-next.0"
   dependencies:
@@ -3988,7 +3988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.45.0-next.0&npm=0.2.14-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.14-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.45.0-next.1&npm=0.2.14-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.14-next.0":
   version: 0.2.14-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.14-next.0"
   dependencies:
@@ -4001,7 +4001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.45.0-next.0&npm=0.25.6-next.0, @backstage/plugin-auth-backend@npm:^0.25.6-next.0":
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.45.0-next.1&npm=0.25.6-next.0, @backstage/plugin-auth-backend@npm:^0.25.6-next.0":
   version: 0.25.6-next.0
   resolution: "@backstage/plugin-auth-backend@npm:0.25.6-next.0"
   dependencies:
@@ -4132,7 +4132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.45.0-next.0&npm=0.11.2-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.11.2-next.0":
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.45.0-next.1&npm=0.11.2-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.11.2-next.0":
   version: 0.11.2-next.0
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.11.2-next.0"
   dependencies:
@@ -4155,7 +4155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.45.0-next.0&npm=0.1.16-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.16-next.0":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.45.0-next.1&npm=0.1.16-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.16-next.0":
   version: 0.1.16-next.0
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.16-next.0"
   dependencies:
@@ -4166,7 +4166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.45.0-next.0&npm=0.2.14-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.14-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.14-next.0":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.45.0-next.1&npm=0.2.14-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.14-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.14-next.0":
   version: 0.2.14-next.0
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.14-next.0"
   dependencies:
@@ -4179,7 +4179,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.45.0-next.0&npm=3.1.3-next.0, @backstage/plugin-catalog-backend@npm:3.1.3-next.0, @backstage/plugin-catalog-backend@npm:^3.1.3-next.0":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.45.0-next.1&npm=3.1.3-next.0, @backstage/plugin-catalog-backend@npm:3.1.3-next.0, @backstage/plugin-catalog-backend@npm:^3.1.3-next.0":
   version: 3.1.3-next.0
   resolution: "@backstage/plugin-catalog-backend@npm:3.1.3-next.0"
   dependencies:
@@ -4218,7 +4218,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.45.0-next.0&npm=1.1.7-next.0, @backstage/plugin-catalog-common@npm:1.1.7-next.0, @backstage/plugin-catalog-common@npm:^1.1.7-next.0":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.45.0-next.1&npm=1.1.7-next.0, @backstage/plugin-catalog-common@npm:1.1.7-next.0, @backstage/plugin-catalog-common@npm:^1.1.7-next.0":
   version: 1.1.7-next.0
   resolution: "@backstage/plugin-catalog-common@npm:1.1.7-next.0"
   dependencies:
@@ -4240,7 +4240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.45.0-next.0&npm=0.5.3-next.0, @backstage/plugin-catalog-graph@npm:^0.5.3-next.0":
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.45.0-next.1&npm=0.5.3-next.0, @backstage/plugin-catalog-graph@npm:^0.5.3-next.0":
   version: 0.5.3-next.0
   resolution: "@backstage/plugin-catalog-graph@npm:0.5.3-next.0"
   dependencies:
@@ -4272,7 +4272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.45.0-next.0&npm=1.19.2-next.0, @backstage/plugin-catalog-node@npm:1.19.2-next.0, @backstage/plugin-catalog-node@npm:^1.19.2-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.45.0-next.1&npm=1.19.2-next.0, @backstage/plugin-catalog-node@npm:1.19.2-next.0, @backstage/plugin-catalog-node@npm:^1.19.2-next.0":
   version: 1.19.2-next.0
   resolution: "@backstage/plugin-catalog-node@npm:1.19.2-next.0"
   dependencies:
@@ -4308,7 +4308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.45.0-next.0&npm=1.21.3-next.0, @backstage/plugin-catalog-react@npm:1.21.3-next.0, @backstage/plugin-catalog-react@npm:^1.21.3-next.0":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.45.0-next.1&npm=1.21.3-next.0, @backstage/plugin-catalog-react@npm:1.21.3-next.0, @backstage/plugin-catalog-react@npm:^1.21.3-next.0":
   version: 1.21.3-next.0
   resolution: "@backstage/plugin-catalog-react@npm:1.21.3-next.0"
   dependencies:
@@ -4390,7 +4390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.45.0-next.0&npm=1.31.5-next.0, @backstage/plugin-catalog@npm:1.31.5-next.0, @backstage/plugin-catalog@npm:^1.31.5-next.0":
+"@backstage/plugin-catalog@backstage:^::backstage=1.45.0-next.1&npm=1.31.5-next.0, @backstage/plugin-catalog@npm:1.31.5-next.0, @backstage/plugin-catalog@npm:^1.31.5-next.0":
   version: 1.31.5-next.0
   resolution: "@backstage/plugin-catalog@npm:1.31.5-next.0"
   dependencies:
@@ -4436,7 +4436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.45.0-next.0&npm=0.4.6-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.6-next.0":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.45.0-next.1&npm=0.4.6-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.6-next.0":
   version: 0.4.6-next.0
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.6-next.0"
   dependencies:
@@ -4453,7 +4453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.45.0-next.0&npm=0.5.8-next.0, @backstage/plugin-events-backend@npm:^0.5.8-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.45.0-next.1&npm=0.5.8-next.0, @backstage/plugin-events-backend@npm:^0.5.8-next.0":
   version: 0.5.8-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.5.8-next.0"
   dependencies:
@@ -4528,7 +4528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.45.0-next.0&npm=0.8.14-next.0, @backstage/plugin-home@npm:^0.8.14-next.0":
+"@backstage/plugin-home@backstage:^::backstage=1.45.0-next.1&npm=0.8.14-next.0, @backstage/plugin-home@npm:^0.8.14-next.0":
   version: 0.8.14-next.0
   resolution: "@backstage/plugin-home@npm:0.8.14-next.0"
   dependencies:
@@ -4568,7 +4568,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.45.0-next.0&npm=0.20.4-next.0, @backstage/plugin-kubernetes-backend@npm:^0.20.4-next.0":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.45.0-next.1&npm=0.20.4-next.0, @backstage/plugin-kubernetes-backend@npm:^0.20.4-next.0":
   version: 0.20.4-next.0
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.20.4-next.0"
   dependencies:
@@ -4678,7 +4678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.45.0-next.0&npm=0.12.13-next.0, @backstage/plugin-kubernetes@npm:^0.12.13-next.0":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.45.0-next.1&npm=0.12.13-next.0, @backstage/plugin-kubernetes@npm:^0.12.13-next.0":
   version: 0.12.13-next.0
   resolution: "@backstage/plugin-kubernetes@npm:0.12.13-next.0"
   dependencies:
@@ -4704,7 +4704,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.45.0-next.0&npm=0.5.12-next.0, @backstage/plugin-notifications-backend@npm:^0.5.12-next.0":
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.45.0-next.1&npm=0.5.12-next.0, @backstage/plugin-notifications-backend@npm:^0.5.12-next.0":
   version: 0.5.12-next.0
   resolution: "@backstage/plugin-notifications-backend@npm:0.5.12-next.0"
   dependencies:
@@ -4737,7 +4737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.45.0-next.0&npm=0.2.21-next.0, @backstage/plugin-notifications-node@npm:0.2.21-next.0, @backstage/plugin-notifications-node@npm:^0.2.21-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.45.0-next.1&npm=0.2.21-next.0, @backstage/plugin-notifications-node@npm:0.2.21-next.0, @backstage/plugin-notifications-node@npm:^0.2.21-next.0":
   version: 0.2.21-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.21-next.0"
   dependencies:
@@ -4752,7 +4752,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.45.0-next.0&npm=0.5.11-next.0, @backstage/plugin-notifications@npm:^0.5.11-next.0":
+"@backstage/plugin-notifications@backstage:^::backstage=1.45.0-next.1&npm=0.5.11-next.0, @backstage/plugin-notifications@npm:^0.5.11-next.0":
   version: 0.5.11-next.0
   resolution: "@backstage/plugin-notifications@npm:0.5.11-next.0"
   dependencies:
@@ -4783,7 +4783,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.45.0-next.0&npm=0.6.46-next.0, @backstage/plugin-org@npm:^0.6.46-next.0":
+"@backstage/plugin-org@backstage:^::backstage=1.45.0-next.1&npm=0.6.46-next.0, @backstage/plugin-org@npm:^0.6.46-next.0":
   version: 0.6.46-next.0
   resolution: "@backstage/plugin-org@npm:0.6.46-next.0"
   dependencies:
@@ -4935,7 +4935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.45.0-next.0&npm=0.6.8-next.0, @backstage/plugin-proxy-backend@npm:^0.6.8-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.45.0-next.1&npm=0.6.8-next.0, @backstage/plugin-proxy-backend@npm:^0.6.8-next.0":
   version: 0.6.8-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.8-next.0"
   dependencies:
@@ -5051,7 +5051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.45.0-next.0&npm=0.9.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.2-next.0":
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.45.0-next.1&npm=0.9.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.2-next.0":
   version: 0.9.2-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.2-next.0"
   dependencies:
@@ -5091,7 +5091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.45.0-next.0&npm=0.1.16-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.16-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.45.0-next.1&npm=0.1.16-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.16-next.0":
   version: 0.1.16-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.16-next.0"
   dependencies:
@@ -5104,7 +5104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.45.0-next.0&npm=3.0.1-next.0, @backstage/plugin-scaffolder-backend@npm:^3.0.1-next.0":
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.45.0-next.1&npm=3.0.1-next.0, @backstage/plugin-scaffolder-backend@npm:^3.0.1-next.0":
   version: 3.0.1-next.0
   resolution: "@backstage/plugin-scaffolder-backend@npm:3.0.1-next.0"
   dependencies:
@@ -5262,7 +5262,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.45.0-next.0&npm=1.34.3-next.0, @backstage/plugin-scaffolder@npm:^1.34.3-next.0":
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.45.0-next.1&npm=1.34.3-next.0, @backstage/plugin-scaffolder@npm:^1.34.3-next.0":
   version: 1.34.3-next.0
   resolution: "@backstage/plugin-scaffolder@npm:1.34.3-next.0"
   dependencies:
@@ -5324,7 +5324,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.45.0-next.0&npm=0.3.10-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.10-next.0":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.45.0-next.1&npm=0.3.10-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.10-next.0":
   version: 0.3.10-next.0
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.10-next.0"
   dependencies:
@@ -5398,7 +5398,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.45.0-next.0&npm=2.0.8-next.0, @backstage/plugin-search-backend@npm:^2.0.8-next.0":
+"@backstage/plugin-search-backend@backstage:^::backstage=1.45.0-next.1&npm=2.0.8-next.0, @backstage/plugin-search-backend@npm:^2.0.8-next.0":
   version: 2.0.8-next.0
   resolution: "@backstage/plugin-search-backend@npm:2.0.8-next.0"
   dependencies:
@@ -5442,7 +5442,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.45.0-next.0&npm=1.9.6-next.0, @backstage/plugin-search-react@npm:1.9.6-next.0, @backstage/plugin-search-react@npm:^1.9.6-next.0":
+"@backstage/plugin-search-react@backstage:^::backstage=1.45.0-next.1&npm=1.9.6-next.0, @backstage/plugin-search-react@npm:1.9.6-next.0, @backstage/plugin-search-react@npm:^1.9.6-next.0":
   version: 1.9.6-next.0
   resolution: "@backstage/plugin-search-react@npm:1.9.6-next.0"
   dependencies:
@@ -5502,7 +5502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.45.0-next.0&npm=1.4.32-next.0, @backstage/plugin-search@npm:^1.4.32-next.0":
+"@backstage/plugin-search@backstage:^::backstage=1.45.0-next.1&npm=1.4.32-next.0, @backstage/plugin-search@npm:^1.4.32-next.0":
   version: 1.4.32-next.0
   resolution: "@backstage/plugin-search@npm:1.4.32-next.0"
   dependencies:
@@ -5532,7 +5532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.45.0-next.0&npm=0.3.10-next.0, @backstage/plugin-signals-backend@npm:^0.3.10-next.0":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.45.0-next.1&npm=0.3.10-next.0, @backstage/plugin-signals-backend@npm:^0.3.10-next.0":
   version: 0.3.10-next.0
   resolution: "@backstage/plugin-signals-backend@npm:0.3.10-next.0"
   dependencies:
@@ -5588,7 +5588,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.45.0-next.0&npm=0.0.25-next.0, @backstage/plugin-signals@npm:^0.0.25-next.0":
+"@backstage/plugin-signals@backstage:^::backstage=1.45.0-next.1&npm=0.0.25-next.0, @backstage/plugin-signals@npm:^0.0.25-next.0":
   version: 0.0.25-next.0
   resolution: "@backstage/plugin-signals@npm:0.0.25-next.0"
   dependencies:
@@ -5616,7 +5616,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.45.0-next.0&npm=2.1.2-next.0, @backstage/plugin-techdocs-backend@npm:^2.1.2-next.0":
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.45.0-next.1&npm=2.1.2-next.0, @backstage/plugin-techdocs-backend@npm:^2.1.2-next.0":
   version: 2.1.2-next.0
   resolution: "@backstage/plugin-techdocs-backend@npm:2.1.2-next.0"
   dependencies:
@@ -5652,7 +5652,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.45.0-next.0&npm=1.1.30-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.30-next.0":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.45.0-next.1&npm=1.1.30-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.30-next.0":
   version: 1.1.30-next.0
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.30-next.0"
   dependencies:
@@ -5679,7 +5679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.45.0-next.0&npm=1.13.9-next.0, @backstage/plugin-techdocs-node@npm:1.13.9-next.0, @backstage/plugin-techdocs-node@npm:^1.13.9-next.0":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.45.0-next.1&npm=1.13.9-next.0, @backstage/plugin-techdocs-node@npm:1.13.9-next.0, @backstage/plugin-techdocs-node@npm:^1.13.9-next.0":
   version: 1.13.9-next.0
   resolution: "@backstage/plugin-techdocs-node@npm:1.13.9-next.0"
   dependencies:
@@ -5716,7 +5716,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.45.0-next.0&npm=1.3.5-next.0, @backstage/plugin-techdocs-react@npm:1.3.5-next.0, @backstage/plugin-techdocs-react@npm:^1.3.5-next.0":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.45.0-next.1&npm=1.3.5-next.0, @backstage/plugin-techdocs-react@npm:1.3.5-next.0, @backstage/plugin-techdocs-react@npm:^1.3.5-next.0":
   version: 1.3.5-next.0
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.5-next.0"
   dependencies:
@@ -5774,9 +5774,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.45.0-next.0&npm=1.15.2-next.0, @backstage/plugin-techdocs@npm:^1.15.2-next.0":
-  version: 1.15.2-next.0
-  resolution: "@backstage/plugin-techdocs@npm:1.15.2-next.0"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.45.0-next.1&npm=1.15.3-next.0, @backstage/plugin-techdocs@npm:^1.15.3-next.0":
+  version: 1.15.3-next.0
+  resolution: "@backstage/plugin-techdocs@npm:1.15.3-next.0"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
@@ -5814,7 +5814,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/eaecb3f6388703283c70088259818ce333c0a10843f59417b4f5054758c4da122d753f931af77f0b235b1a1119f92a2e9a63200e2c794e7473d5f4e76ff259dd
+  checksum: 10/bed64ee8c638ba07118471476573accd2a3c9705e1394af0633cb47b56c841ceba9faf0f4fc20621e58bb61711b73437f0e8b8ac7fa8ee9b2736de54658d8536
   languageName: node
   linkType: hard
 
@@ -5825,7 +5825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.45.0-next.0&npm=0.8.29-next.0, @backstage/plugin-user-settings@npm:^0.8.29-next.0":
+"@backstage/plugin-user-settings@backstage:^::backstage=1.45.0-next.1&npm=0.8.29-next.0, @backstage/plugin-user-settings@npm:^0.8.29-next.0":
   version: 0.8.29-next.0
   resolution: "@backstage/plugin-user-settings@npm:0.8.29-next.0"
   dependencies:
@@ -5923,7 +5923,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.45.0-next.0&npm=0.7.0, @backstage/theme@npm:0.7.0, @backstage/theme@npm:^0.7.0":
+"@backstage/theme@backstage:^::backstage=1.45.0-next.1&npm=0.7.0, @backstage/theme@npm:0.7.0, @backstage/theme@npm:^0.7.0":
   version: 0.7.0
   resolution: "@backstage/theme@npm:0.7.0"
   dependencies:
@@ -5970,9 +5970,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.45.0-next.0&npm=0.8.2-next.0, @backstage/ui@npm:^0.8.2-next.0":
-  version: 0.8.2-next.0
-  resolution: "@backstage/ui@npm:0.8.2-next.0"
+"@backstage/ui@backstage:^::backstage=1.45.0-next.1&npm=0.9.0-next.1, @backstage/ui@npm:^0.9.0-next.1":
+  version: 0.9.0-next.1
+  resolution: "@backstage/ui@npm:0.9.0-next.1"
   dependencies:
     "@base-ui-components/react": "npm:1.0.0-alpha.7"
     "@remixicon/react": "npm:^4.6.0"
@@ -5987,7 +5987,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6d31139fbcde3a8f053d7c6d306d38d6af7e344f3830e9d000337543046b94e58675018468bd789a734404b59eb5ced14e65e1eb730f20deb9c870e73345bb31
+  checksum: 10/4fd637d51b97254b80e03c7d372f9b63dd2d8572780ef572238573284f3841303c5d4c6235cb0e11b163afa11cec72ed89f62b4ea3b9d4373c9e240d92b621ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.45.0-next.1 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.45.0-next.1](https://github.com/backstage/backstage/blob/master/docs/releases/v1.45.0-next.1-changelog.md)
- Upgrade Helper: [From 1.45.0-next.0 to 1.45.0-next.1](https://backstage.github.io/upgrade-helper/?from=1.45.0-next.0&to=1.45.0-next.1)
 
Created by [Version Bump 18904179158](https://github.com/backstage/demo/actions/runs/18904179158)
 