### PR TITLE
v1.45.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: a7960e90b20fe64de29d899d907dd9d539f4111357d84ce89eab20c01ea2941d4d4ee2a569d220be2f92f93d63cee18b85a6273cbb74980564fb80f7ee7c64d2
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.45.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.45.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.45.0-next.1"
+  "version": "1.45.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,7 +2474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.45.0-next.1&npm=1.7.2-next.0, @backstage/app-defaults@npm:^1.7.2-next.0":
+"@backstage/app-defaults@backstage:^::backstage=1.45.0-next.2&npm=1.7.2-next.0, @backstage/app-defaults@npm:^1.7.2-next.0":
   version: 1.7.2-next.0
   resolution: "@backstage/app-defaults@npm:1.7.2-next.0"
   dependencies:
@@ -2497,14 +2497,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-app-api@npm:1.2.9-next.0":
-  version: 1.2.9-next.0
-  resolution: "@backstage/backend-app-api@npm:1.2.9-next.0"
+"@backstage/backend-app-api@npm:1.3.0-next.1":
+  version: 1.3.0-next.1
+  resolution: "@backstage/backend-app-api@npm:1.3.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-  checksum: 10/5aeb78c36615147bc089dce1ac75f80ec0656169cb2ff796211ee5efdfb7c5fd7b710ef3320751354b5d27f481630f08ee15173b6e04cd33108d82f96693a1da
+  checksum: 10/9ebe3af9dd1b83b8dcf90ca9276ed193c9da72d1e9147402b7757e2794dd3588202e117f48c287b633771870109372c4f6cfe77f34b8b1c89cd23b3de894c430
   languageName: node
   linkType: hard
 
@@ -2595,9 +2595,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.45.0-next.1&npm=0.13.1-next.0, @backstage/backend-defaults@npm:0.13.1-next.0, @backstage/backend-defaults@npm:^0.13.1-next.0":
-  version: 0.13.1-next.0
-  resolution: "@backstage/backend-defaults@npm:0.13.1-next.0"
+"@backstage/backend-defaults@backstage:^::backstage=1.45.0-next.2&npm=0.13.1-next.1, @backstage/backend-defaults@npm:0.13.1-next.1, @backstage/backend-defaults@npm:^0.13.1-next.1":
+  version: 0.13.1-next.1
+  resolution: "@backstage/backend-defaults@npm:0.13.1-next.1"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -2605,18 +2605,18 @@ __metadata:
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-app-api": "npm:1.2.9-next.0"
+    "@backstage/backend-app-api": "npm:1.3.0-next.1"
     "@backstage/backend-dev-utils": "npm:0.1.5"
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/cli-node": "npm:0.2.15-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/config-loader": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
     "@backstage/integration-aws-node": "npm:0.1.19-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.17-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.6-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.9-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.17-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.6-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/storage": "npm:^7.0.0"
     "@keyv/memcache": "npm:^2.0.1"
@@ -2675,7 +2675,7 @@ __metadata:
   peerDependenciesMeta:
     "@google-cloud/cloud-sql-connector":
       optional: true
-  checksum: 10/a8a3f6aeaffb4bd6f5ce3892641db299f2333c4371513529e9a954171aee29520f8a76d176088c2417b67a31ba168b821388cac6d87b5c405da5c4d6365f61f3
+  checksum: 10/568846836eff94dd3c03100a5c19a961b9481bd2914986d603582ae7ff6500cc39684861204cad57ccb3c5881322fa9f4ea4a942975d0166123b9dae2e7c18de
   languageName: node
   linkType: hard
 
@@ -2770,12 +2770,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-openapi-utils@npm:0.6.3-next.0":
-  version: 0.6.3-next.0
-  resolution: "@backstage/backend-openapi-utils@npm:0.6.3-next.0"
+"@backstage/backend-openapi-utils@npm:0.6.3-next.1":
+  version: 0.6.3-next.1
+  resolution: "@backstage/backend-openapi-utils@npm:0.6.3-next.1"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/types": "npm:1.2.2"
     "@types/express": "npm:^4.17.6"
@@ -2790,7 +2790,7 @@ __metadata:
     mockttp: "npm:^3.13.0"
     openapi-merge: "npm:^1.3.2"
     openapi3-ts: "npm:^3.1.2"
-  checksum: 10/59a2e46116f8230c3635faa6b4e69c7771dbd2f7a7b34fd90ffc51046a419c9efe13a0b60708b3cca7409343fade068347e7891741fcb499a543cba00054f821
+  checksum: 10/eea8d26e3a46ef1d07361e394a71a3c22b247ca6760d2d16251c76da9239e158b7a5f340f2af3a71f6521f0ceeda307ee72bd704fe4952f9487367a0f16bc5b3
   languageName: node
   linkType: hard
 
@@ -2818,16 +2818,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.45.0-next.1&npm=1.4.5-next.0, @backstage/backend-plugin-api@npm:1.4.5-next.0, @backstage/backend-plugin-api@npm:^1.4.5-next.0":
-  version: 1.4.5-next.0
-  resolution: "@backstage/backend-plugin-api@npm:1.4.5-next.0"
+"@backstage/backend-plugin-api@backstage:^::backstage=1.45.0-next.2&npm=1.5.0-next.1, @backstage/backend-plugin-api@npm:1.5.0-next.1, @backstage/backend-plugin-api@npm:^1.5.0-next.1":
+  version: 1.5.0-next.1
+  resolution: "@backstage/backend-plugin-api@npm:1.5.0-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.1.15"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.6-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.9-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.6-next.1"
     "@backstage/types": "npm:1.2.2"
     "@types/express": "npm:^4.17.6"
     "@types/json-schema": "npm:^7.0.6"
@@ -2836,7 +2836,7 @@ __metadata:
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/3a5b5c6b500aa9b266f2bd3403a0dc37a14bb879fb40d79107d4bc3f66183d94ca1837b2901dabb0a75ea64a94bd919440e0a0c8d814ae45dcb2ae47d558c38f
+  checksum: 10/f7ed2b9c54d816cb1f2c943395720f30932f9018ea5be623a631413ad75b49febf83309a66528522666254964ed57718657de1f680c0d5fa31829f74ccfb9337
   languageName: node
   linkType: hard
 
@@ -2905,7 +2905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.45.0-next.1&npm=1.7.6-next.0, @backstage/catalog-model@npm:1.7.6-next.0, @backstage/catalog-model@npm:^1.7.6-next.0":
+"@backstage/catalog-model@backstage:^::backstage=1.45.0-next.2&npm=1.7.6-next.0, @backstage/catalog-model@npm:1.7.6-next.0, @backstage/catalog-model@npm:^1.7.6-next.0":
   version: 1.7.6-next.0
   resolution: "@backstage/catalog-model@npm:1.7.6-next.0"
   dependencies:
@@ -2968,9 +2968,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.45.0-next.1&npm=0.34.5-next.0, @backstage/cli@npm:^0.34.5-next.0":
-  version: 0.34.5-next.0
-  resolution: "@backstage/cli@npm:0.34.5-next.0"
+"@backstage/cli@backstage:^::backstage=1.45.0-next.2&npm=0.34.5-next.1, @backstage/cli@npm:^0.34.5-next.1":
+  version: 0.34.5-next.1
+  resolution: "@backstage/cli@npm:0.34.5-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/cli-common": "npm:0.1.15"
@@ -3105,7 +3105,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/217e1e11483e9e2a0951c179d8dbac49a2cf82aeb396fe0422d56ee4bc8591ea2632237964da5b380a30ff7ae1f4ee1eda78ff989eecfc918d113b50b5062e3f
+  checksum: 10/de338cd6c1afb1f121682d721ef77ee388edccaaacf55a43851f35511fc1c48a13cc7d4d24ca8f8b947673f1893a2db1133489d4c22fcfe38fd6980ab6efcef1
   languageName: node
   linkType: hard
 
@@ -3155,7 +3155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.45.0-next.1&npm=1.3.6-next.0, @backstage/config@npm:1.3.6-next.0, @backstage/config@npm:^1.3.6-next.0":
+"@backstage/config@backstage:^::backstage=1.45.0-next.2&npm=1.3.6-next.0, @backstage/config@npm:1.3.6-next.0, @backstage/config@npm:^1.3.6-next.0":
   version: 1.3.6-next.0
   resolution: "@backstage/config@npm:1.3.6-next.0"
   dependencies:
@@ -3177,7 +3177,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.45.0-next.1&npm=1.19.2-next.0, @backstage/core-app-api@npm:1.19.2-next.0, @backstage/core-app-api@npm:^1.19.2-next.0":
+"@backstage/core-app-api@backstage:^::backstage=1.45.0-next.2&npm=1.19.2-next.1, @backstage/core-app-api@npm:^1.19.2-next.1":
+  version: 1.19.2-next.1
+  resolution: "@backstage/core-app-api@npm:1.19.2-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.6-next.0"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@types/prop-types": "npm:^15.7.3"
+    history: "npm:^5.0.0"
+    i18next: "npm:^22.4.15"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/589b532f380924886c8ab2b71d76220aed90ff459abb7ef33e8669a9e4746459ea20abf99742a47aba5d1ae77899f22ed330c2841a490ecdfd7e7c1542838f49
+  languageName: node
+  linkType: hard
+
+"@backstage/core-app-api@npm:1.19.2-next.0":
   version: 1.19.2-next.0
   resolution: "@backstage/core-app-api@npm:1.19.2-next.0"
   dependencies:
@@ -3233,7 +3261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.45.0-next.1&npm=0.5.4-next.0, @backstage/core-compat-api@npm:0.5.4-next.0, @backstage/core-compat-api@npm:^0.5.4-next.0":
+"@backstage/core-compat-api@backstage:^::backstage=1.45.0-next.2&npm=0.5.4-next.0, @backstage/core-compat-api@npm:0.5.4-next.0, @backstage/core-compat-api@npm:^0.5.4-next.0":
   version: 0.5.4-next.0
   resolution: "@backstage/core-compat-api@npm:0.5.4-next.0"
   dependencies:
@@ -3275,7 +3303,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.45.0-next.1&npm=0.18.3-next.0, @backstage/core-components@npm:0.18.3-next.0, @backstage/core-components@npm:^0.18.3-next.0":
+"@backstage/core-components@backstage:^::backstage=1.45.0-next.2&npm=0.18.3-next.1, @backstage/core-components@npm:0.18.3-next.1, @backstage/core-components@npm:^0.18.3-next.1":
+  version: 0.18.3-next.1
+  resolution: "@backstage/core-components@npm:0.18.3-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.6-next.0"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/theme": "npm:0.7.0"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.3.2"
+    linkifyjs: "npm:4.3.2"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-full-screen: "npm:^1.1.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/597cd81c7f285f8ee7562e57ada221806e7e4aca0d5b63ea3071105740a045c7b777c83341d3de38e367770bd3fcac2871cc89a946bd1a97729b2a33ea7dc078
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.18.3-next.0":
   version: 0.18.3-next.0
   resolution: "@backstage/core-components@npm:0.18.3-next.0"
   dependencies:
@@ -3439,7 +3522,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.45.0-next.1&npm=1.11.2-next.0, @backstage/core-plugin-api@npm:1.11.2-next.0, @backstage/core-plugin-api@npm:^1.11.2-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.45.0-next.2&npm=1.11.2-next.1, @backstage/core-plugin-api@npm:1.11.2-next.1, @backstage/core-plugin-api@npm:^1.11.2-next.1":
+  version: 1.11.2-next.1
+  resolution: "@backstage/core-plugin-api@npm:1.11.2-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.6-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    history: "npm:^5.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/be5113e1f3ee759aa65ec197e7fd9ab55a4e192c06e216ec4ec39b11c066b8eac90a308452e27af6a95dd915452044c685d081259899c9225ab2fc9f71fd7c81
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:1.11.2-next.0":
   version: 1.11.2-next.0
   resolution: "@backstage/core-plugin-api@npm:1.11.2-next.0"
   dependencies:
@@ -3481,7 +3585,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.45.0-next.1&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.45.0-next.2&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -3568,7 +3672,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.45.0-next.1&npm=0.3.3-next.0, @backstage/frontend-defaults@npm:0.3.3-next.0, @backstage/frontend-defaults@npm:^0.3.3-next.0":
+"@backstage/frontend-defaults@backstage:^::backstage=1.45.0-next.2&npm=0.3.3-next.0, @backstage/frontend-defaults@npm:0.3.3-next.0, @backstage/frontend-defaults@npm:^0.3.3-next.0":
   version: 0.3.3-next.0
   resolution: "@backstage/frontend-defaults@npm:0.3.3-next.0"
   dependencies:
@@ -3614,7 +3718,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.45.0-next.1&npm=0.12.2-next.0, @backstage/frontend-plugin-api@npm:0.12.2-next.0, @backstage/frontend-plugin-api@npm:^0.12.2-next.0":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.45.0-next.2&npm=0.12.2-next.1, @backstage/frontend-plugin-api@npm:0.12.2-next.1, @backstage/frontend-plugin-api@npm:^0.12.2-next.1":
+  version: 0.12.2-next.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.12.2-next.1"
+  dependencies:
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.4"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.21.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/a62e1b6f1ef051108b54c437fd1fb9a3bec547c85d7efb586c69e02d18ee828b4ea0060b64a3e686beafcb4ac87b2914b523bde5837ec80d57c4eaaca785a7fe
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:0.12.2-next.0":
   version: 0.12.2-next.0
   resolution: "@backstage/frontend-plugin-api@npm:0.12.2-next.0"
   dependencies:
@@ -3766,7 +3894,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.45.0-next.1&npm=1.2.12-next.0, @backstage/integration-react@npm:1.2.12-next.0, @backstage/integration-react@npm:^1.2.12-next.0":
+"@backstage/integration-react@backstage:^::backstage=1.45.0-next.2&npm=1.2.12-next.0, @backstage/integration-react@npm:1.2.12-next.0, @backstage/integration-react@npm:^1.2.12-next.0":
   version: 1.2.12-next.0
   resolution: "@backstage/integration-react@npm:1.2.12-next.0"
   dependencies:
@@ -3844,19 +3972,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.45.0-next.1&npm=0.13.1-next.0, @backstage/plugin-api-docs@npm:^0.13.1-next.0":
-  version: 0.13.1-next.0
-  resolution: "@backstage/plugin-api-docs@npm:0.13.1-next.0"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.45.0-next.2&npm=0.13.1-next.1, @backstage/plugin-api-docs@npm:^0.13.1-next.1":
+  version: 0.13.1-next.1
+  resolution: "@backstage/plugin-api-docs@npm:0.13.1-next.1"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/core-compat-api": "npm:0.5.4-next.0"
-    "@backstage/core-components": "npm:0.18.3-next.0"
-    "@backstage/core-plugin-api": "npm:1.11.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.12.2-next.0"
-    "@backstage/plugin-catalog": "npm:1.31.5-next.0"
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.12.2-next.1"
+    "@backstage/plugin-catalog": "npm:1.32.0-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.3-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.3-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.38-next.0"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -3875,20 +4003,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fa71a58ab187835054b12a8d7e5e0ee1051727f587b43f22e882cfa49389c937e3b80a51bdb84ae9838d29a9733648622c7f8d5638ea920ce905813338363d98
+  checksum: 10/22b092820f200aaf1c6cb5c97c090f6813a8a7cb57d173ad1e73b5c98fc1fb0aa45b708adef73d08e997ab7fe44b36455503f80ea768413280ffb55bb096bc0e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.45.0-next.1&npm=0.5.8-next.0, @backstage/plugin-app-backend@npm:^0.5.8-next.0":
-  version: 0.5.8-next.0
-  resolution: "@backstage/plugin-app-backend@npm:0.5.8-next.0"
+"@backstage/plugin-app-backend@backstage:^::backstage=1.45.0-next.2&npm=0.5.8-next.1, @backstage/plugin-app-backend@npm:^0.5.8-next.1":
+  version: 0.5.8-next.1
+  resolution: "@backstage/plugin-app-backend@npm:0.5.8-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/config-loader": "npm:1.10.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-app-node": "npm:0.1.39-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
+    "@backstage/plugin-app-node": "npm:0.1.39-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.9-next.1"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
@@ -3899,20 +4027,20 @@ __metadata:
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     yn: "npm:^4.0.0"
-  checksum: 10/f4e710ce3c036250b355d7ad371b7694c996b5fc0c311d3f0b583626549d80020a9f69c68f69098fc5e880829898562072cfab2e0533aefc5e27439a7012eaea
+  checksum: 10/f35add99f165c83642fbd7c89d657c14c747201abbd16b6d4c570e8a275a93b00cbf826f990cb78514f60c767971b5e4281de40e993cd09f965173a1339905f0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-node@npm:0.1.39-next.0":
-  version: 0.1.39-next.0
-  resolution: "@backstage/plugin-app-node@npm:0.1.39-next.0"
+"@backstage/plugin-app-node@npm:0.1.39-next.1":
+  version: 0.1.39-next.1
+  resolution: "@backstage/plugin-app-node@npm:0.1.39-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config-loader": "npm:1.10.6-next.0"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     fs-extra: "npm:^11.2.0"
-  checksum: 10/688b494ab19b5781d29edef501a3cc42cfbee30b5b65d971c9115df67ace74089bea1b6985489afd26a22b135125afdf2427b0180c7dd313f6f6a3bd2012528f
+  checksum: 10/4c1236fd113274cda5456c87c0f5a8a9b3345fde31728715c323d1114f5eb0708620ce829f95b62ac61747ac918ddd2b0a410396aa756e748b18638e595cfbc6
   languageName: node
   linkType: hard
 
@@ -3976,41 +4104,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.45.0-next.1&npm=0.3.9-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.9-next.0":
-  version: 0.3.9-next.0
-  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.9-next.0"
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.45.0-next.2&npm=0.3.9-next.1, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.9-next.1":
+  version: 0.3.9-next.1
+  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.9-next.1"
     passport-github2: "npm:^0.1.12"
     zod: "npm:^3.22.4"
-  checksum: 10/8b583d3bf1cebaade0ff205ccea2ea98dc9124bfceadfb099dc34e44fad09967832bd818060b6cae4917ed2a38d4ace18ba1d409a5f7f82881583577fa77034d
+  checksum: 10/13aa8754e343237135de2d366fc87507b94e6c905ae681aa74f474807b174f3cc48dd4b6fc023d42dcc1faef2ad745a2b8f4c03727a866ef4efc27834d2bc821
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.45.0-next.1&npm=0.2.14-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.14-next.0":
-  version: 0.2.14-next.0
-  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.14-next.0"
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.45.0-next.2&npm=0.2.14-next.1, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.14-next.1":
+  version: 0.2.14-next.1
+  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.14-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.9-next.1"
     passport-oauth2: "npm:^1.7.0"
-  checksum: 10/5fec1d880c2393e49d70909452e609da62cc84c519b3b109e6707ee9f6f3497a3e0c18b8db1db7128f7bc70f382861e0d222c604d481c0cc9fd1676091eb7680
+  checksum: 10/4753a61cf03fabac5942b8c2a9a3f927b3bbf965b3a2af61338985b30a55ba66b3e2086ea6e6a6284401de651b4976682f4d528903cdfd51a40e100bd571d18e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.45.0-next.1&npm=0.25.6-next.0, @backstage/plugin-auth-backend@npm:^0.25.6-next.0":
-  version: 0.25.6-next.0
-  resolution: "@backstage/plugin-auth-backend@npm:0.25.6-next.0"
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.45.0-next.2&npm=0.25.6-next.1, @backstage/plugin-auth-backend@npm:^0.25.6-next.1":
+  version: 0.25.6-next.1
+  resolution: "@backstage/plugin-auth-backend@npm:0.25.6-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.9-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/firestore": "npm:^7.0.0"
     connect-session-knex: "npm:^4.0.0"
@@ -4026,15 +4154,15 @@ __metadata:
     minimatch: "npm:^9.0.0"
     passport: "npm:^0.7.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/f9ea148f601b329868c3f3cb365524c6e7077f8e7dcdfe14b47a7c05b365b26bc798b98b7fabe7d2acdb14ba863211a42ed44ac3a93c86385fa45f5fc74304b4
+  checksum: 10/77c772bf941d0da697352bcd0dfc8aa1d2c69b69de56fea65dbed83b478c95adc7f60705dcb671c0002bf7ffd4ce50fd91ca9123be06fb7ca6b42acc3d5244f3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:0.6.9-next.0":
-  version: 0.6.9-next.0
-  resolution: "@backstage/plugin-auth-node@npm:0.6.9-next.0"
+"@backstage/plugin-auth-node@npm:0.6.9-next.1":
+  version: 0.6.9-next.1
+  resolution: "@backstage/plugin-auth-node@npm:0.6.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
@@ -4049,7 +4177,7 @@ __metadata:
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.21.4"
     zod-validation-error: "npm:^3.4.0"
-  checksum: 10/c75803b2d62d0c0df32d4c1f81f7825d64b5dcf44acce6bfa06472a19600175189005474ee6b4b566cfc07b3e9361db0f1cd41ffdfde11c1550a195c359580f1
+  checksum: 10/6773677a385a1d4104fb5d6326654a74eae8f85fd60fdb19ab923846bb8bac3237b405f04e19533c045f4ed7b933790382d7693f4c278719ada2105a10ae4b0e
   languageName: node
   linkType: hard
 
@@ -4132,17 +4260,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.45.0-next.1&npm=0.11.2-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.11.2-next.0":
-  version: 0.11.2-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.11.2-next.0"
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.45.0-next.2&npm=0.11.2-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.11.2-next.1":
+  version: 0.11.2-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.11.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/integration": "npm:1.18.2-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.17-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.17-next.1"
     "@octokit/core": "npm:^5.2.0"
     "@octokit/graphql": "npm:^7.0.2"
     "@octokit/plugin-throttling": "npm:^8.1.3"
@@ -4151,50 +4279,50 @@ __metadata:
     lodash: "npm:^4.17.21"
     minimatch: "npm:^9.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/88e595181334c56f0d1286e4be1e01c0c54cf4dba38a4fe11e09ed946370b5e73dd6cf41f713ccc491652996b737a76ac5129f3ec788973c6ffb9834c976240b
+  checksum: 10/90410da1a36f43c760bc711beedc67684d04b6ee572fc6c49b7f286fb17cdfe3c43d15a08fd8642e26f5887ce43175e5facc53ba6dd7f73335f44e9a1307a70c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.45.0-next.1&npm=0.1.16-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.16-next.0":
-  version: 0.1.16-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.16-next.0"
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.45.0-next.2&npm=0.1.16-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.16-next.1":
+  version: 0.1.16-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
-    "@backstage/plugin-catalog-backend": "npm:3.1.3-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.17-next.0"
-  checksum: 10/f4f5bf04c3e5285ca6c59f74716a08623742c8e95f625fda7344b8076795774388cae0aaeaf7b80a152270dc2ac4e158fb64f104a030ae3cb97767f837c2be84
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
+    "@backstage/plugin-catalog-backend": "npm:3.2.0-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.17-next.1"
+  checksum: 10/a1938095a9c943e8c738595f203bb69af5720a385d908a7d8b59fbd67c7771be7ba40550ea55a5a94700118aab532b12bfa53340b15dba68b7283ee0af368e46
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.45.0-next.1&npm=0.2.14-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.14-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.14-next.0":
-  version: 0.2.14-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.14-next.0"
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.45.0-next.2&npm=0.2.14-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.14-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.14-next.1":
+  version: 0.2.14-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.14-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.7.3-next.0"
-  checksum: 10/71e7f6577f9aa9be56808969e382945cdc3936e1aa5ac296488a961135652b7a72d47cc1bc3d94cb417f6b0fdbe1ecc85b6804d086d7426b3e78ed840cb0d1ad
+  checksum: 10/4946e86e62e19c1efc80ddd35f49745fe000973d892348cd7a2b9ca9e24111be83255a7ed0244d4db4da364fbf878563cf75306282ccea601b6e62cf276ef8c5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.45.0-next.1&npm=3.1.3-next.0, @backstage/plugin-catalog-backend@npm:3.1.3-next.0, @backstage/plugin-catalog-backend@npm:^3.1.3-next.0":
-  version: 3.1.3-next.0
-  resolution: "@backstage/plugin-catalog-backend@npm:3.1.3-next.0"
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.45.0-next.2&npm=3.2.0-next.1, @backstage/plugin-catalog-backend@npm:3.2.0-next.1, @backstage/plugin-catalog-backend@npm:^3.2.0-next.1":
+  version: 3.2.0-next.1
+  resolution: "@backstage/plugin-catalog-backend@npm:3.2.0-next.1"
   dependencies:
-    "@backstage/backend-openapi-utils": "npm:0.6.3-next.0"
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-openapi-utils": "npm:0.6.3-next.1"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.17-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.6-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.17-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.6-next.1"
     "@backstage/types": "npm:1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     codeowners-utils: "npm:^1.0.2"
@@ -4214,11 +4342,11 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/ae1d251025e7fc1edd43fc9b7b6ee49b1bfecb33120d95a8cec61cdd97667daaa9bfef44f852b5f74ad8c7e033e270dc2f7f1bebc5771ddc77e3d49b1a77e17c
+  checksum: 10/4129555319cf42d11f759f58b03eb0f9014d250fa12d059da5db9b046da2c336b3f395dd3f3b51b0af1dd41a6b644072b1e225a1ef9ad2af8c17ef71759a311d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.45.0-next.1&npm=1.1.7-next.0, @backstage/plugin-catalog-common@npm:1.1.7-next.0, @backstage/plugin-catalog-common@npm:^1.1.7-next.0":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.45.0-next.2&npm=1.1.7-next.0, @backstage/plugin-catalog-common@npm:1.1.7-next.0, @backstage/plugin-catalog-common@npm:^1.1.7-next.0":
   version: 1.1.7-next.0
   resolution: "@backstage/plugin-catalog-common@npm:1.1.7-next.0"
   dependencies:
@@ -4240,17 +4368,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.45.0-next.1&npm=0.5.3-next.0, @backstage/plugin-catalog-graph@npm:^0.5.3-next.0":
-  version: 0.5.3-next.0
-  resolution: "@backstage/plugin-catalog-graph@npm:0.5.3-next.0"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.45.0-next.2&npm=0.5.3-next.1, @backstage/plugin-catalog-graph@npm:^0.5.3-next.1":
+  version: 0.5.3-next.1
+  resolution: "@backstage/plugin-catalog-graph@npm:0.5.3-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/core-compat-api": "npm:0.5.4-next.0"
-    "@backstage/core-components": "npm:0.18.3-next.0"
-    "@backstage/core-plugin-api": "npm:1.11.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.12.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.3-next.0"
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.12.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.21.3-next.1"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4268,25 +4396,25 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/bd59d435d4d106a90348790f6201d8c50868bdfa96f34937568db228c83809777f54dd9fc4b821faf2ea24615da1d58721e2d0f18567ffc152d29ee87dfecbd7
+  checksum: 10/79ab9b93daa89eabaf7eedba67f93f9eebfdc4d2cc65c73d56abea445c3f5cad5eae61c8b274060a0ddc4e4685443620f588dd41b63e31fc5e6a86fb90de6ca5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.45.0-next.1&npm=1.19.2-next.0, @backstage/plugin-catalog-node@npm:1.19.2-next.0, @backstage/plugin-catalog-node@npm:^1.19.2-next.0":
-  version: 1.19.2-next.0
-  resolution: "@backstage/plugin-catalog-node@npm:1.19.2-next.0"
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.45.0-next.2&npm=1.20.0-next.1, @backstage/plugin-catalog-node@npm:1.20.0-next.1, @backstage/plugin-catalog-node@npm:^1.20.0-next.1":
+  version: 1.20.0-next.1
+  resolution: "@backstage/plugin-catalog-node@npm:1.20.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.6-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.6-next.1"
     "@backstage/types": "npm:1.2.2"
     lodash: "npm:^4.17.21"
     yaml: "npm:^2.0.0"
-  checksum: 10/efbcb4753320a5345830e51169ee7280053e932c37f8d19f295fd3cac618728b041c6a56e45ce6940bb474406a9826f81e9a4b488d351df34ca8828a12bed433
+  checksum: 10/7ec84502708a49199088a82609189bb40d1a8360d9c3064327882d41e028664ade61277c3ac3b5b62696d1b70deb43e4b5605aae961edf8118d82ee88f64b13a
   languageName: node
   linkType: hard
 
@@ -4308,7 +4436,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.45.0-next.1&npm=1.21.3-next.0, @backstage/plugin-catalog-react@npm:1.21.3-next.0, @backstage/plugin-catalog-react@npm:^1.21.3-next.0":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.45.0-next.2&npm=1.21.3-next.1, @backstage/plugin-catalog-react@npm:1.21.3-next.1, @backstage/plugin-catalog-react@npm:^1.21.3-next.1":
+  version: 1.21.3-next.1
+  resolution: "@backstage/plugin-catalog-react@npm:1.21.3-next.1"
+  dependencies:
+    "@backstage/catalog-client": "npm:1.12.1-next.0"
+    "@backstage/catalog-model": "npm:1.7.6-next.0"
+    "@backstage/core-compat-api": "npm:0.5.4-next.0"
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-plugin-api": "npm:0.12.2-next.1"
+    "@backstage/frontend-test-utils": "npm:0.4.1-next.0"
+    "@backstage/integration-react": "npm:1.2.12-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
+    "@backstage/plugin-permission-react": "npm:0.4.38-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    classnames: "npm:^2.2.6"
+    lodash: "npm:^4.17.21"
+    material-ui-popup-state: "npm:^5.3.6"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.2.4"
+    yaml: "npm:^2.0.0"
+    zen-observable: "npm:^0.10.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/c93c912bc7fa146aea8df0b40825b30391cf1b50547b8365068d4834c3253b0ee7e57fff140a22e81ea18526bfc4f149d85ef079d97103e40abee41f03265e6f
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-react@npm:1.21.3-next.0":
   version: 1.21.3-next.0
   resolution: "@backstage/plugin-catalog-react@npm:1.21.3-next.0"
   dependencies:
@@ -4390,24 +4559,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.45.0-next.1&npm=1.31.5-next.0, @backstage/plugin-catalog@npm:1.31.5-next.0, @backstage/plugin-catalog@npm:^1.31.5-next.0":
-  version: 1.31.5-next.0
-  resolution: "@backstage/plugin-catalog@npm:1.31.5-next.0"
+"@backstage/plugin-catalog@backstage:^::backstage=1.45.0-next.2&npm=1.32.0-next.1, @backstage/plugin-catalog@npm:1.32.0-next.1, @backstage/plugin-catalog@npm:^1.32.0-next.1":
+  version: 1.32.0-next.1
+  resolution: "@backstage/plugin-catalog@npm:1.32.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/core-compat-api": "npm:0.5.4-next.0"
-    "@backstage/core-components": "npm:0.18.3-next.0"
-    "@backstage/core-plugin-api": "npm:1.11.2-next.0"
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.12.2-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.12.2-next.1"
     "@backstage/integration-react": "npm:1.2.12-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.3-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.3-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.38-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.7.3-next.0"
     "@backstage/plugin-search-common": "npm:1.2.21-next.0"
-    "@backstage/plugin-search-react": "npm:1.9.6-next.0"
+    "@backstage/plugin-search-react": "npm:1.10.0-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.5-next.0"
     "@backstage/types": "npm:1.2.2"
@@ -4432,51 +4601,51 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c1b0c4982ce87d7d134815c3c260adba6dbda081006e4ee8c5e5fd2b512af7a3d9563c864f3d6a0f285aa2b2651d452cb10397c3b142d3504907b4562abe6dce
+  checksum: 10/b36f763dc822c6b3c63332f18664ca5e0a0ee3d062b9f646bf0d0007b1a3672d7cfad8026ceeac5610be3b3b6b5cf49bfe18f4b6530cf2f35ec5d25830a6f86f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.45.0-next.1&npm=0.4.6-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.6-next.0":
-  version: 0.4.6-next.0
-  resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.6-next.0"
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.45.0-next.2&npm=0.4.6-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.6-next.1":
+  version: 0.4.6-next.1
+  resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.6-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.17-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.17-next.1"
     "@backstage/types": "npm:1.2.2"
     "@octokit/auth-callback": "npm:^5.0.0"
     "@octokit/webhooks-methods": "npm:^3.0.0"
     lodash: "npm:^4.17.21"
     octokit: "npm:^3.0.0"
-  checksum: 10/f969147117d0bd9ef6533b45a3e693fbc806cdab122b15c79924257fe62f67b2634bd526ea9faf3b78fb0c5f0a85c50f2e753b084074a6e3d29f9f999b705018
+  checksum: 10/498a8b3a3d98b160a154ca30b8f17e1f9ced386e8ae73b3cb8fba58b0e8dc1acc444455c015b2dfd38a8e2085b758349ab9bb128fc8c71bfb4b1658a4aec497f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.45.0-next.1&npm=0.5.8-next.0, @backstage/plugin-events-backend@npm:^0.5.8-next.0":
-  version: 0.5.8-next.0
-  resolution: "@backstage/plugin-events-backend@npm:0.5.8-next.0"
+"@backstage/plugin-events-backend@backstage:^::backstage=1.45.0-next.2&npm=0.5.8-next.1, @backstage/plugin-events-backend@npm:^0.5.8-next.1":
+  version: 0.5.8-next.1
+  resolution: "@backstage/plugin-events-backend@npm:0.5.8-next.1"
   dependencies:
-    "@backstage/backend-openapi-utils": "npm:0.6.3-next.0"
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-openapi-utils": "npm:0.6.3-next.1"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-events-node": "npm:0.4.17-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.17-next.1"
     "@backstage/types": "npm:1.2.2"
     "@types/express": "npm:^4.17.6"
     content-type: "npm:^1.0.5"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
-  checksum: 10/55db3aedfb436eb612ec72998c6eeec86a6d1e83f6da91ffd0a427285b15556ae167091980f282a53244c0be7ac529e0e19192083479abd23c36779a39f3e151
+  checksum: 10/f6657d19413518d1769edc544bd512da52c778e3d6c914203909e386e65bf70363643bbde86827c8f3b6dd4d710b312f3ce273f9e68598a3c515b7b22c35d251
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-node@npm:0.4.17-next.0":
-  version: 0.4.17-next.0
-  resolution: "@backstage/plugin-events-node@npm:0.4.17-next.0"
+"@backstage/plugin-events-node@npm:0.4.17-next.1":
+  version: 0.4.17-next.1
+  resolution: "@backstage/plugin-events-node@npm:0.4.17-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/types": "npm:1.2.2"
     "@types/content-type": "npm:^1.1.8"
@@ -4485,7 +4654,7 @@ __metadata:
     cross-fetch: "npm:^4.0.0"
     express: "npm:^4.17.1"
     uri-template: "npm:^2.0.0"
-  checksum: 10/9aa1b089deb79b0614d2cd1e9a5326786ce0270071a18a8d63c88f450f21d6d83a888d8f99bb8345170762d701c9f0b2c32d1ed483e695a219f26c46dd66768a
+  checksum: 10/9700d2432a8e816e96fa42bb848b893d25dba60799e8a62e6a2f9ae08215ed11c65666c04a9198a88e27ca7945aa28a970f77ef025c4f5926528b6542837069f
   languageName: node
   linkType: hard
 
@@ -4528,7 +4697,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.45.0-next.1&npm=0.8.14-next.0, @backstage/plugin-home@npm:^0.8.14-next.0":
+"@backstage/plugin-home@backstage:^::backstage=1.45.0-next.2&npm=0.8.14-next.0, @backstage/plugin-home@npm:^0.8.14-next.0":
   version: 0.8.14-next.0
   resolution: "@backstage/plugin-home@npm:0.8.14-next.0"
   dependencies:
@@ -4568,46 +4737,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.45.0-next.1&npm=0.20.4-next.0, @backstage/plugin-kubernetes-backend@npm:^0.20.4-next.0":
-  version: 0.20.4-next.0
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.20.4-next.0"
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.45.0-next.2&npm=0.20.4-next.1, @backstage/plugin-kubernetes-backend@npm:^0.20.4-next.1":
+  version: 0.20.4-next.1
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.20.4-next.1"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@aws-sdk/signature-v4": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration-aws-node": "npm:0.1.19-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
     "@backstage/plugin-kubernetes-common": "npm:0.9.8-next.0"
-    "@backstage/plugin-kubernetes-node": "npm:0.3.6-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.6-next.0"
+    "@backstage/plugin-kubernetes-node": "npm:0.3.6-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.6-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/container": "npm:^5.0.0"
     "@jest-mock/express": "npm:^2.0.1"
     "@kubernetes/client-node": "npm:1.1.2"
     "@types/http-proxy-middleware": "npm:^1.0.0"
-    compression: "npm:^1.7.4"
-    cors: "npm:^2.8.5"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
-    helmet: "npm:^6.0.0"
     http-proxy-middleware: "npm:^2.0.6"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-    morgan: "npm:^1.10.0"
     node-fetch: "npm:^2.7.0"
-    stream-buffers: "npm:^3.0.2"
-    winston: "npm:^3.2.1"
-    yn: "npm:^4.0.0"
-  checksum: 10/c91a769a645d453a1440951e36f8205be47811f677d68e6db5f2b20a54c48ba8ccb7a400d4180a7aae7e81f2f18a6d26fc495f6a13c03fbedf49fe629cfcc877
+  checksum: 10/f091f19e22e886b1714f4d7b544adc627fbbd45276fc4e4561ee1b53f65e0cbafa760f0e51f4f8e722496a48915bded895c0c80554a16ee17f68a80937f53389
   languageName: node
   linkType: hard
 
@@ -4626,18 +4787,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-node@npm:0.3.6-next.0":
-  version: 0.3.6-next.0
-  resolution: "@backstage/plugin-kubernetes-node@npm:0.3.6-next.0"
+"@backstage/plugin-kubernetes-node@npm:0.3.6-next.1":
+  version: 0.3.6-next.1
+  resolution: "@backstage/plugin-kubernetes-node@npm:0.3.6-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/plugin-kubernetes-common": "npm:0.9.8-next.0"
     "@backstage/types": "npm:1.2.2"
     "@kubernetes/client-node": "npm:1.1.2"
     node-fetch: "npm:^2.7.0"
     winston: "npm:^3.2.1"
-  checksum: 10/8cb6dca09a291cd04d3562fbe2224fb33535a8704b9b622b123ca21c62139b216537d201773f2c8c6b81b52475f7399b31c144a35b0f3dfe015db0af6b22ec05
+  checksum: 10/aab42e828bcae55ba799e4e26e63cb72096dcfe36f059b3cf1bf037f43ebf1f77fcb6b29690f3de95ddddd39331b8a15121d1c15a70112b3f3a05e6645ad2332
   languageName: node
   linkType: hard
 
@@ -4678,7 +4839,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.45.0-next.1&npm=0.12.13-next.0, @backstage/plugin-kubernetes@npm:^0.12.13-next.0":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.45.0-next.2&npm=0.12.13-next.0, @backstage/plugin-kubernetes@npm:^0.12.13-next.0":
   version: 0.12.13-next.0
   resolution: "@backstage/plugin-kubernetes@npm:0.12.13-next.0"
   dependencies:
@@ -4704,25 +4865,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.45.0-next.1&npm=0.5.12-next.0, @backstage/plugin-notifications-backend@npm:^0.5.12-next.0":
-  version: 0.5.12-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.5.12-next.0"
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.45.0-next.2&npm=0.5.12-next.1, @backstage/plugin-notifications-backend@npm:^0.5.12-next.1":
+  version: 0.5.12-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.5.12-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
     "@backstage/plugin-notifications-common": "npm:0.1.2-next.0"
-    "@backstage/plugin-notifications-node": "npm:0.2.21-next.0"
-    "@backstage/plugin-signals-node": "npm:0.1.26-next.0"
+    "@backstage/plugin-notifications-node": "npm:0.2.21-next.1"
+    "@backstage/plugin-signals-node": "npm:0.1.26-next.1"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     p-throttle: "npm:^4.1.1"
     uuid: "npm:^11.0.0"
-  checksum: 10/10250001abae1dda02342ddeb7b4686bf342cc3cc0e0661820abcdbe369f210927add512b01f434195f60f5e79e85d43533200ef49542f8eb91278241c06345f
+  checksum: 10/7a19392434e63f886d63c51e53d0548ee31b4507afd90e9e4ee600adea71553ab0d59057b95e3c9c15aaffaad4093083e26d99ea50129e0e8c30378776bf7adf
   languageName: node
   linkType: hard
 
@@ -4737,22 +4898,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.45.0-next.1&npm=0.2.21-next.0, @backstage/plugin-notifications-node@npm:0.2.21-next.0, @backstage/plugin-notifications-node@npm:^0.2.21-next.0":
-  version: 0.2.21-next.0
-  resolution: "@backstage/plugin-notifications-node@npm:0.2.21-next.0"
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.45.0-next.2&npm=0.2.21-next.1, @backstage/plugin-notifications-node@npm:0.2.21-next.1, @backstage/plugin-notifications-node@npm:^0.2.21-next.1":
+  version: 0.2.21-next.1
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.21-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/plugin-notifications-common": "npm:0.1.2-next.0"
-    "@backstage/plugin-signals-node": "npm:0.1.26-next.0"
+    "@backstage/plugin-signals-node": "npm:0.1.26-next.1"
     knex: "npm:^3.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/225eedb4c5da4ca04fea0515a6ec73a6937510e2f34432b41be66d8ebe3a8ffba639b7383670bfd059f30514984df64def30aa6ce07c225c9b37d57a5f35603e
+  checksum: 10/ed1ea21712645ce0441a47c12fd81f9699ced48bc37ad8261d7347c008daab99473aa27165481ce09b55681eaa07c6671c1cd1087378b7aee39294cd1a51f8df
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.45.0-next.1&npm=0.5.11-next.0, @backstage/plugin-notifications@npm:^0.5.11-next.0":
+"@backstage/plugin-notifications@backstage:^::backstage=1.45.0-next.2&npm=0.5.11-next.0, @backstage/plugin-notifications@npm:^0.5.11-next.0":
   version: 0.5.11-next.0
   resolution: "@backstage/plugin-notifications@npm:0.5.11-next.0"
   dependencies:
@@ -4783,7 +4944,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.45.0-next.1&npm=0.6.46-next.0, @backstage/plugin-org@npm:^0.6.46-next.0":
+"@backstage/plugin-org@backstage:^::backstage=1.45.0-next.2&npm=0.6.46-next.0, @backstage/plugin-org@npm:^0.6.46-next.0":
   version: 0.6.46-next.0
   resolution: "@backstage/plugin-org@npm:0.6.46-next.0"
   dependencies:
@@ -4829,6 +4990,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:0.9.3-next.1":
+  version: 0.9.3-next.1
+  resolution: "@backstage/plugin-permission-common@npm:0.9.3-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.6-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.2"
+    cross-fetch: "npm:^4.0.0"
+    uuid: "npm:^11.0.0"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.20.4"
+  checksum: 10/5a718792a0842842a2083f2e66e02174c3e103ea0079bb2707630a2bd8b7101dce70174590c52147b23bf29f755cf45c5521b1709bffa376a70caf2ca01562ca
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-common@npm:^0.8.0":
   version: 0.8.4
   resolution: "@backstage/plugin-permission-common@npm:0.8.4"
@@ -4859,21 +5035,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:0.10.6-next.0":
-  version: 0.10.6-next.0
-  resolution: "@backstage/plugin-permission-node@npm:0.10.6-next.0"
+"@backstage/plugin-permission-node@npm:0.10.6-next.1":
+  version: 0.10.6-next.1
+  resolution: "@backstage/plugin-permission-node@npm:0.10.6-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.9-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/bfdcc0d27c735ccc06a41ac898c1943c804d4ce764d4a0bfb8a40a13442df09f02774d8df0c60444b111d80fdd681bbc13a66fd4255de1cb4910e743ea94c979
+  checksum: 10/a52e325c62cd45ce088f7aa0d6c4bc0a8c0318ffd96b69dadd54bcd703631da6e48c4d0729758a62829192301e946a24770d0715c5416540cd2c3334c96c4075
   languageName: node
   linkType: hard
 
@@ -4935,133 +5111,133 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.45.0-next.1&npm=0.6.8-next.0, @backstage/plugin-proxy-backend@npm:^0.6.8-next.0":
-  version: 0.6.8-next.0
-  resolution: "@backstage/plugin-proxy-backend@npm:0.6.8-next.0"
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.45.0-next.2&npm=0.6.8-next.1, @backstage/plugin-proxy-backend@npm:^0.6.8-next.1":
+  version: 0.6.8-next.1
+  resolution: "@backstage/plugin-proxy-backend@npm:0.6.8-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
-    "@backstage/plugin-proxy-node": "npm:0.1.10-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
+    "@backstage/plugin-proxy-node": "npm:0.1.10-next.1"
     "@backstage/types": "npm:1.2.2"
     express-promise-router: "npm:^4.1.0"
     http-proxy-middleware: "npm:^2.0.0"
-  checksum: 10/46405357a990aefa440e9969fb2291437afbda5cf03c33e480e27cfd58f0d71d08e599aced101ed56cb2d566c5edf2c7d718c62b8668f9de5755a3cfc3073778
+  checksum: 10/bf556cb2797823e140ef721c5516a76c4e83e00a883964ef9a4c456d2ab436dfa504120df1cde3d90aa8b95053acd52a1441cbe2cdae1aa80f71b6e831af6deb
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-node@npm:0.1.10-next.0":
-  version: 0.1.10-next.0
-  resolution: "@backstage/plugin-proxy-node@npm:0.1.10-next.0"
+"@backstage/plugin-proxy-node@npm:0.1.10-next.1":
+  version: 0.1.10-next.1
+  resolution: "@backstage/plugin-proxy-node@npm:0.1.10-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     http-proxy-middleware: "npm:^2.0.0"
-  checksum: 10/fb4ef919a86e04e490994b1ba18a1c32cea39325097a497d1fff0c669f016db76fbf59415963baccefefe2f1177ba62e62db6436acfaef42b51d453877a4a33e
+  checksum: 10/d147fd077f8e7069c72ac80cd953a9cb54d93960cfc81ea705b8d45dbe95e0f57d6f9f99cc9326076bf17656714cb21f972700a171898a4745085b0a3f18bbaf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.15-next.0":
-  version: 0.2.15-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.15-next.0"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.15-next.1":
+  version: 0.2.15-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.15-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     azure-devops-node-api: "npm:^14.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/6912ec2cc6ff10a63da7d49fb091fffc7a6334c1e657cb6e491f86d18756362dc9c722129ac1dd4ddc0839b0d15d9580ab59751b4b7348cc81c529517d2fecee
+  checksum: 10/8226f6d4d7e276758d9d17ea33cc4a8db4f58ed352deb1b833a130bc7f5a08e9c4b19017c94c6a643095e199927231df9904ca2be66b871a6e2e24021a9395a3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.15-next.0":
-  version: 0.2.15-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.15-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.15-next.1":
+  version: 0.2.15-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.15-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
     "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.4-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     bitbucket: "npm:^2.12.0"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/744a3d8b3ea31afc077148cc0619d7055fe4e2002584a8e88b459904b6c5a89192a5da494a936942507ff6c271f37919a06d70e3ae1151dd8eeecb6e50217ef9
+  checksum: 10/79630a138cd35589b34cd9228477041d6c0873478a1b26420beaad6314c8c20cd751ac92e6f6779eb6a5d6d1de4f475feb65e727e67320aa7d888b7cb3f549d8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.15-next.0":
-  version: 0.2.15-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.15-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.15-next.1":
+  version: 0.2.15-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.15-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/9726dbcd8d4b0f9071d7e0b6a2801e4ff944c176608553756ad8b960f8733bfbfe39ce23e5228898e41239688fd285d8962663b74feefc18d3dc1a27d4183871
+  checksum: 10/b0c3a017b58fb7545fc9fe05bfe32a2b4200b202dd4bc1129819c250c8af334b2d17e8387d7ea533ce2e0bc59baa6bda3bc5db578c8da11695053de0c6d3210b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.16-next.0":
-  version: 0.3.16-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.16-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.16-next.1":
+  version: 0.3.16-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.15-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.15-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.15-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.15-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/b0f18223668bc37d6bb1bc06fea393733f400e789b4ba1d770e4181ca5484739b2fb20098639864b9363bf93801686517dfe29b6132069398376d245babf1fde
+  checksum: 10/6970604871522cf51bdd0b106598543fcb7ee96cfab12edda2dbeec02a3a6c2c89ed5413849dcd2453ce7fcf595c096e78ae356309ff2318f39f0d75a53c529d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.15-next.0":
-  version: 0.2.15-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.15-next.0"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.15-next.1":
+  version: 0.2.15-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.15-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/5fbb0a8ba6eaa46a5b7bb5fc5c1141d97e35a551a19a139cd813716bb47ecef559d7e8f20fbc23ef7928e9742f35c9f44345b8137d83deeac58d6eb9ed1aefd8
+  checksum: 10/b09a69ae268c2487375b4017f66cb386f587faabcaad6f17a98028d5a087774e238e966c0782b419e09c992a756d00affc47a2dfb5ea9f561da9541b3e22c1bf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.15-next.0":
-  version: 0.2.15-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.15-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.15-next.1":
+  version: 0.2.15-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.15-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/b2972a71f45893f5835f749cce34d4d8f801707a88e7e734d7e23854257300df16e476755d5e887479d3b2cf94a727a2bbeff80f2076b27a3408d1a0513192ee
+  checksum: 10/6261de6d8663163a3929aceb9a8106b1fbe11fedfa5445e0caf59cfe4a245c971f89f5d3c1e73ff82bea6172a8f04d8f89eea0b29268d9256dea2f2cb481a03d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.45.0-next.1&npm=0.9.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.2-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.2-next.0":
-  version: 0.9.2-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.2-next.0"
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.45.0-next.2&npm=0.9.2-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.2-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.2-next.1":
+  version: 0.9.2-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     "@backstage/types": "npm:1.2.2"
     "@octokit/webhooks": "npm:^10.9.2"
     libsodium-wrappers: "npm:^0.7.11"
@@ -5069,69 +5245,69 @@ __metadata:
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/f79d79b8001e367caa644b0248ad6a929307d508941fb02e25c2d18b909ffa88283cf003092bf37d0282a67d02e6d7c7617908a0140c0fd701a30d1a1c0247d9
+  checksum: 10/1f28aa8fbf5a456413b7ff073eafec6fbfdcc4a27cf58de959ed60ee7b91f6ebc31fbee000ae5da5207d533909bfbb1afb32d5cc002bec0fe99aaa4bb8c1f370
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.7-next.0":
-  version: 0.9.7-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.9.7-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.10.0-next.1":
+  version: 0.10.0-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.10.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     "@gitbeaker/requester-utils": "npm:^41.2.0"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/7a77669c1cf8993f5c12a04d3f260bcd8ba1ed444ccdc5290fd5161e9254b9a1ef32758546785e2558e277b6d8f31ee3210a1d025af6a222d2077b2270ff7223
+  checksum: 10/398bd6b6cef27b316527a06ac6e6a927748d11b0b88bc197bf98efcf41377497bdaff08bfb063fd000cc83675999873f5ffda15849f183ab784c5c689c562a8b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.45.0-next.1&npm=0.1.16-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.16-next.0":
-  version: 0.1.16-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.16-next.0"
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.45.0-next.2&npm=0.1.16-next.1, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.16-next.1":
+  version: 0.1.16-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/plugin-notifications-common": "npm:0.1.2-next.0"
-    "@backstage/plugin-notifications-node": "npm:0.2.21-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-notifications-node": "npm:0.2.21-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/3c1545a88de43b464e814cc2e8011469b38c311e39718a5ecb4f0db26cf700d8c05338a6ca433471e343d23df64b357d41802bef5ddaccc0ce552184be38b819
+  checksum: 10/2bf8b6f1562ca46f6bb1352e3cebbf7f9eb3e363d08ee26d70098b4fe98f7b342eaca81a86678d7529761b142fb7f4f7849ce9b6371d7dae9019ab06fb2fc6c5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.45.0-next.1&npm=3.0.1-next.0, @backstage/plugin-scaffolder-backend@npm:^3.0.1-next.0":
-  version: 3.0.1-next.0
-  resolution: "@backstage/plugin-scaffolder-backend@npm:3.0.1-next.0"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.45.0-next.2&npm=3.0.1-next.1, @backstage/plugin-scaffolder-backend@npm:^3.0.1-next.1":
+  version: 3.0.1-next.1
+  resolution: "@backstage/plugin-scaffolder-backend@npm:3.0.1-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.13.1-next.0"
-    "@backstage/backend-openapi-utils": "npm:0.6.3-next.0"
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-defaults": "npm:0.13.1-next.1"
+    "@backstage/backend-openapi-utils": "npm:0.6.3-next.1"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.9-next.1"
     "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.4-next.0"
-    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.14-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.17-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.6-next.0"
-    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.15-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.16-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.15-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.15-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.15-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.15-next.0"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.9.2-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.9.7-next.0"
+    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.14-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.17-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.6-next.1"
+    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.15-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.16-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.15-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.15-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.15-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.15-next.1"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.9.2-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.10.0-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.7.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.1-next.1"
     "@backstage/types": "npm:1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/luxon": "npm:^3.0.0"
@@ -5159,7 +5335,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/735d5d5fdd879c827adba5a94f672a14cbd4f7ae667dc6b8b440cab1ba862e4b58d5b1a2ec7306bbd3e880f4fbdf09f91023746c646bdd47de228bf6169219b9
+  checksum: 10/49d39f2eb8e4c198fea9194cdbb3e2e222dbf478ad5c9f14fac6421c6302570f55c5c9b713b3d6c0685cbda87c1cc5b9d5a96b1d05255825924d5dcd6bc94890
   languageName: node
   linkType: hard
 
@@ -5182,15 +5358,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:0.12.1-next.0":
-  version: 0.12.1-next.0
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.12.1-next.0"
+"@backstage/plugin-scaffolder-node@npm:0.12.1-next.1":
+  version: 0.12.1-next.1
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.12.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.7.3-next.0"
     "@backstage/types": "npm:1.2.2"
     "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
@@ -5206,7 +5382,7 @@ __metadata:
     winston-transport: "npm:^4.7.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/6b67d1a2b760d4ea516cc06f56a8960b0f6420e245f8e5fc8fcec761a01970ff0c4cd20fbe77631cd4f67666f6fd530c4034471b81b4b72abcdd873f04f6946c
+  checksum: 10/28dd39a78430224045f05426f043f28755103351ed1abec388825ed87b0b33952fdf3bb8ed24e2abaef677b7d7da29c06ecb5acd9873c89c5c13eccee520b979
   languageName: node
   linkType: hard
 
@@ -5262,7 +5438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.45.0-next.1&npm=1.34.3-next.0, @backstage/plugin-scaffolder@npm:^1.34.3-next.0":
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.45.0-next.2&npm=1.34.3-next.0, @backstage/plugin-scaffolder@npm:^1.34.3-next.0":
   version: 1.34.3-next.0
   resolution: "@backstage/plugin-scaffolder@npm:1.34.3-next.0"
   dependencies:
@@ -5324,59 +5500,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.45.0-next.1&npm=0.3.10-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.10-next.0":
-  version: 0.3.10-next.0
-  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.10-next.0"
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.45.0-next.2&npm=0.3.10-next.1, @backstage/plugin-search-backend-module-catalog@npm:^0.3.10-next.1":
+  version: 0.3.10-next.1
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.10-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
-    "@backstage/plugin-search-backend-node": "npm:1.3.17-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
+    "@backstage/plugin-search-backend-node": "npm:1.3.17-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21-next.0"
-  checksum: 10/76b2070ca9d634f4f7d175e409b3ba482404c807d2e5b4bcf8f1781155db693117dbe16993f26fdfa78e71070b15487ec877857cef41b0fab29f9fe99f95c1d6
+  checksum: 10/6615b901a0e3e89625cdc6ec6e4e77f1f04c1a2c5bff1efad369b63ed897b5b203b411ae2be85f527b4777ceac30bb89a7044061b81be139cd6067e9f9e76333
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-techdocs@npm:0.4.8-next.0":
-  version: 0.4.8-next.0
-  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.4.8-next.0"
+"@backstage/plugin-search-backend-node@npm:1.3.17-next.1":
+  version: 1.3.17-next.1
+  resolution: "@backstage/plugin-search-backend-node@npm:1.3.17-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
-    "@backstage/catalog-client": "npm:1.12.1-next.0"
-    "@backstage/catalog-model": "npm:1.7.6-next.0"
-    "@backstage/config": "npm:1.3.6-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
-    "@backstage/plugin-search-backend-node": "npm:1.3.17-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.21-next.0"
-    "@backstage/plugin-techdocs-node": "npm:1.13.9-next.0"
-    lodash: "npm:^4.17.21"
-    p-limit: "npm:^3.1.0"
-  checksum: 10/c3494cdd0dc29c718afaae28602c6a6b3ea59941cef347d3d85038ddf9dd932d106c7620352aa4a513009cf92434d9088bd27eb1faa9147214763ffe072ba8c5
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-search-backend-node@npm:1.3.17-next.0":
-  version: 1.3.17-next.0
-  resolution: "@backstage/plugin-search-backend-node@npm:1.3.17-next.0"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21-next.0"
     "@types/lunr": "npm:^2.3.3"
     lodash: "npm:^4.17.21"
     lunr: "npm:^2.3.9"
     ndjson: "npm:^2.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/111f17538ce460ff332563231cce9ab9d0448229ba3a7f887fe2cf6de83435028ead24d2657ea665bfcfabdfaa98b8a6ea5e5940be8179d3ac663ccb0eb8cdb4
+  checksum: 10/5155d00e8ffbdfc043a6e016fdbf223d4ef92a6e0530085c1d5411c8c6ad69d19f8d5687bcb5523aaaedc002acaa4d955e8031471f6371af4765327122440b5d
   languageName: node
   linkType: hard
 
@@ -5398,18 +5554,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.45.0-next.1&npm=2.0.8-next.0, @backstage/plugin-search-backend@npm:^2.0.8-next.0":
-  version: 2.0.8-next.0
-  resolution: "@backstage/plugin-search-backend@npm:2.0.8-next.0"
+"@backstage/plugin-search-backend@backstage:^::backstage=1.45.0-next.2&npm=2.0.8-next.1, @backstage/plugin-search-backend@npm:^2.0.8-next.1":
+  version: 2.0.8-next.1
+  resolution: "@backstage/plugin-search-backend@npm:2.0.8-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.13.1-next.0"
-    "@backstage/backend-openapi-utils": "npm:0.6.3-next.0"
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-defaults": "npm:0.13.1-next.1"
+    "@backstage/backend-openapi-utils": "npm:0.6.3-next.1"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.6-next.0"
-    "@backstage/plugin-search-backend-node": "npm:1.3.17-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.3-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.6-next.1"
+    "@backstage/plugin-search-backend-node": "npm:1.3.17-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21-next.0"
     "@backstage/types": "npm:1.2.2"
     dataloader: "npm:^2.0.0"
@@ -5418,7 +5574,7 @@ __metadata:
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/0eadf543e4bb14a4e6ae5e4e07c5b8c02658608e67504f60d03e69b32089f0084377ce519b808544836c3accc4adc335b6ae7dd8a79634a8af140bf5466d6cf9
+  checksum: 10/db38efa6f64dc6820052d9ea488f88b01c8b3b3999c2e32962206d54be43685792c86c7ef1bd0e6027a4a1cd3e9509a7954a46737126b08e8e01597eeecb7246
   languageName: node
   linkType: hard
 
@@ -5442,13 +5598,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.45.0-next.1&npm=1.9.6-next.0, @backstage/plugin-search-react@npm:1.9.6-next.0, @backstage/plugin-search-react@npm:^1.9.6-next.0":
-  version: 1.9.6-next.0
-  resolution: "@backstage/plugin-search-react@npm:1.9.6-next.0"
+"@backstage/plugin-search-react@backstage:^::backstage=1.45.0-next.2&npm=1.10.0-next.1, @backstage/plugin-search-react@npm:1.10.0-next.1, @backstage/plugin-search-react@npm:^1.10.0-next.1":
+  version: 1.10.0-next.1
+  resolution: "@backstage/plugin-search-react@npm:1.10.0-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.3-next.0"
-    "@backstage/core-plugin-api": "npm:1.11.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.12.2-next.0"
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.12.2-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21-next.0"
     "@backstage/theme": "npm:0.7.0"
     "@backstage/types": "npm:1.2.2"
@@ -5468,7 +5624,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0bacab4b566c90dfa9800310524b8a069a06c3b89cb5340c300ec168e5baf8f6e4eb0e89bd7621fb406760f164aa657a86f0584db10b44a87375a0a630e6b2ca
+  checksum: 10/57495af754a7366a121ec3389e135939fe35e3f1d62e740647c9c846c8476a05cdbf9483f6f43b373de7115c8e8afecd6086822942cc0e9d526e2a804a1e5e18
   languageName: node
   linkType: hard
 
@@ -5502,18 +5658,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.45.0-next.1&npm=1.4.32-next.0, @backstage/plugin-search@npm:^1.4.32-next.0":
-  version: 1.4.32-next.0
-  resolution: "@backstage/plugin-search@npm:1.4.32-next.0"
+"@backstage/plugin-search@backstage:^::backstage=1.45.0-next.2&npm=1.5.0-next.1, @backstage/plugin-search@npm:^1.5.0-next.1":
+  version: 1.5.0-next.1
+  resolution: "@backstage/plugin-search@npm:1.5.0-next.1"
   dependencies:
     "@backstage/core-compat-api": "npm:0.5.4-next.0"
-    "@backstage/core-components": "npm:0.18.3-next.0"
-    "@backstage/core-plugin-api": "npm:1.11.2-next.0"
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.12.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.12.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.21.3-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21-next.0"
-    "@backstage/plugin-search-react": "npm:1.9.6-next.0"
+    "@backstage/plugin-search-react": "npm:1.10.0-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -5528,44 +5684,40 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1437685dc5f33d1f295e03ff9236697e44708ff417e8fd08abdfe3a8bb0f0ed8cdaf1806b5120399abcdf72e92853b0955140f3247f1d371253cea6522c540e4
+  checksum: 10/fa76557a2a07809dc70527b4258e19a4c427d368c41a6ed3cebf17814435c47c2a0c311d2e54b8158141de2272f7399cc67a01778df8c7941bc9da243e28e9ce
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.45.0-next.1&npm=0.3.10-next.0, @backstage/plugin-signals-backend@npm:^0.3.10-next.0":
-  version: 0.3.10-next.0
-  resolution: "@backstage/plugin-signals-backend@npm:0.3.10-next.0"
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.45.0-next.2&npm=0.3.10-next.1, @backstage/plugin-signals-backend@npm:^0.3.10-next.1":
+  version: 0.3.10-next.1
+  resolution: "@backstage/plugin-signals-backend@npm:0.3.10-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.17-next.0"
-    "@backstage/plugin-signals-node": "npm:0.1.26-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.17-next.1"
+    "@backstage/plugin-signals-node": "npm:0.1.26-next.1"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
-    http-proxy-middleware: "npm:^2.0.0"
     uuid: "npm:^11.0.0"
-    winston: "npm:^3.2.1"
     ws: "npm:^8.18.0"
-    yn: "npm:^4.0.0"
-  checksum: 10/27507d9d6115b946836439700966b39b3a54678575e7c203e6d4ba5446a4114ed15c93bd08227f9fdb6b5a8f0008d73ca96db4e6ee3479cb50d0bc81d6433297
+  checksum: 10/98d52e925feb7c28a6686db003e24b1e34f4fe0008ac7cb707a848d60c4bf8514769cb7d57837e9a3858c5049259fbf7c81969f20a70358c4bf02997f7aa6569
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-node@npm:0.1.26-next.0":
-  version: 0.1.26-next.0
-  resolution: "@backstage/plugin-signals-node@npm:0.1.26-next.0"
+"@backstage/plugin-signals-node@npm:0.1.26-next.1":
+  version: 0.1.26-next.1
+  resolution: "@backstage/plugin-signals-node@npm:0.1.26-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/config": "npm:1.3.6-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.9-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.17-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.9-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.17-next.1"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.17.1"
     uuid: "npm:^11.0.0"
     ws: "npm:^8.18.0"
-  checksum: 10/4de97689042c72479b2aa238faec4b505a16b357365c046c74f4f4a2436a3d3da036e8e0c7d13432850864c976f2503cea5705211905d3ed69ea39959af9ce4c
+  checksum: 10/f9ff444550f4c3e17e8aec98f05a28a97337bf293982eed4bb45229c5c8d561477fa6134dd7e4b9a5405b39ac38b2ced1b45cc1e0c4626ff0a86b5834a1c65a8
   languageName: node
   linkType: hard
 
@@ -5588,21 +5740,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.45.0-next.1&npm=0.0.25-next.0, @backstage/plugin-signals@npm:^0.0.25-next.0":
-  version: 0.0.25-next.0
-  resolution: "@backstage/plugin-signals@npm:0.0.25-next.0"
+"@backstage/plugin-signals@backstage:^::backstage=1.45.0-next.2&npm=0.0.25-next.1, @backstage/plugin-signals@npm:^0.0.25-next.1":
+  version: 0.0.25-next.1
+  resolution: "@backstage/plugin-signals@npm:0.0.25-next.1"
   dependencies:
     "@backstage/core-compat-api": "npm:0.5.4-next.0"
-    "@backstage/core-components": "npm:0.18.3-next.0"
-    "@backstage/core-plugin-api": "npm:1.11.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.12.2-next.0"
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.12.2-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.17-next.0"
     "@backstage/theme": "npm:0.7.0"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.4"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:^4.0.0-alpha.61"
-    react-use: "npm:^17.2.4"
     uuid: "npm:^11.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -5612,36 +5761,31 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3e032cfd60a724afeb276f3d12a27b2fe841002aeb202514dc2a25844896d599e8304988e5089d3a3906c458a7bbab34e5f748439a64daecbc63db99b398c5b4
+  checksum: 10/11911242b5a15ed91b933c3927ee409c8cef08c3148deb01cd7d4ca7df9a0264ae4aa2eaf6dd127ee4b03a0d3d6656f925c66b6749b4bcc4a2580db1c1a2492a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.45.0-next.1&npm=2.1.2-next.0, @backstage/plugin-techdocs-backend@npm:^2.1.2-next.0":
-  version: 2.1.2-next.0
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.1.2-next.0"
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.45.0-next.2&npm=2.1.2-next.1, @backstage/plugin-techdocs-backend@npm:^2.1.2-next.1":
+  version: 2.1.2-next.1
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.1.2-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.13.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-defaults": "npm:0.13.1-next.1"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration": "npm:1.18.2-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.7-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.19.2-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.3-next.0"
-    "@backstage/plugin-search-backend-module-techdocs": "npm:0.4.8-next.0"
-    "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-node": "npm:1.13.9-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.0-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.13.9-next.1"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
     knex: "npm:^3.0.0"
-    lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/9ec7ae714bd52ec97738b3ae26c957db0bc3d99c97835fee37adf510e7b28981a93169d6d8161683f72c96682594a10f6b95d6a5365b38bc9378353ddc3f02a6
+  checksum: 10/cf5d27b90b70d3f82b4e57d272453c7d4cb4723b097097c2a02e12da8f24659c72486f419678440a50d0baeeecb962083ba2bcf768e9b0675cac0bad625a77c9
   languageName: node
   linkType: hard
 
@@ -5652,13 +5796,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.45.0-next.1&npm=1.1.30-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.30-next.0":
-  version: 1.1.30-next.0
-  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.30-next.0"
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.45.0-next.2&npm=1.1.30-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.30-next.1":
+  version: 1.1.30-next.1
+  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.30-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.3-next.0"
-    "@backstage/core-plugin-api": "npm:1.11.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.12.2-next.0"
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.12.2-next.1"
     "@backstage/integration": "npm:1.18.2-next.0"
     "@backstage/integration-react": "npm:1.2.12-next.0"
     "@backstage/plugin-techdocs-react": "npm:1.3.5-next.0"
@@ -5675,13 +5819,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/02876902a9fe5b205f464b5c48e3dae96b9818adb502c23f27c248b2cc75e2a425d70a2e07daa4c1270f4eb171da4a17abe9e0f40d3cac51d67d7b8f543eccb6
+  checksum: 10/879dff8422ef647108a8cf474dfcdd9d74ebfeeb14df0d96d1ad2d56a2b0114b473af8675bc4806140b19d2eb832341ff8ae213e18a81eadf9fc5083c0b7316b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.45.0-next.1&npm=1.13.9-next.0, @backstage/plugin-techdocs-node@npm:1.13.9-next.0, @backstage/plugin-techdocs-node@npm:^1.13.9-next.0":
-  version: 1.13.9-next.0
-  resolution: "@backstage/plugin-techdocs-node@npm:1.13.9-next.0"
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.45.0-next.2&npm=1.13.9-next.1, @backstage/plugin-techdocs-node@npm:1.13.9-next.1, @backstage/plugin-techdocs-node@npm:^1.13.9-next.1":
+  version: 1.13.9-next.1
+  resolution: "@backstage/plugin-techdocs-node@npm:1.13.9-next.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -5689,7 +5833,7 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-plugin-api": "npm:1.4.5-next.0"
+    "@backstage/backend-plugin-api": "npm:1.5.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/errors": "npm:1.2.7"
@@ -5712,11 +5856,11 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/d1569996814f6f0ee23a6a6e74d977ecb42d61a8ca8d4e06571021e5c9f06cbff22b31f8792e0d3a17e3fc726f0689aa23d3f362a997174176e71dbf8ef68bb8
+  checksum: 10/62343d8b25591b6b8001ddef8de555adec7a5565ed3e71e504bf97cd5ed38eac78a89cbaea429400944cdf71eebde002437e69a0845b30b99d12199ee918ba74
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.45.0-next.1&npm=1.3.5-next.0, @backstage/plugin-techdocs-react@npm:1.3.5-next.0, @backstage/plugin-techdocs-react@npm:^1.3.5-next.0":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.45.0-next.2&npm=1.3.5-next.0, @backstage/plugin-techdocs-react@npm:1.3.5-next.0, @backstage/plugin-techdocs-react@npm:^1.3.5-next.0":
   version: 1.3.5-next.0
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.5-next.0"
   dependencies:
@@ -5774,24 +5918,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.45.0-next.1&npm=1.15.3-next.0, @backstage/plugin-techdocs@npm:^1.15.3-next.0":
-  version: 1.15.3-next.0
-  resolution: "@backstage/plugin-techdocs@npm:1.15.3-next.0"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.45.0-next.2&npm=1.16.0-next.1, @backstage/plugin-techdocs@npm:^1.16.0-next.1":
+  version: 1.16.0-next.1
+  resolution: "@backstage/plugin-techdocs@npm:1.16.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1-next.0"
     "@backstage/catalog-model": "npm:1.7.6-next.0"
     "@backstage/config": "npm:1.3.6-next.0"
     "@backstage/core-compat-api": "npm:0.5.4-next.0"
-    "@backstage/core-components": "npm:0.18.3-next.0"
-    "@backstage/core-plugin-api": "npm:1.11.2-next.0"
+    "@backstage/core-components": "npm:0.18.3-next.1"
+    "@backstage/core-plugin-api": "npm:1.11.2-next.1"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.12.2-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.12.2-next.1"
     "@backstage/integration": "npm:1.18.2-next.0"
     "@backstage/integration-react": "npm:1.2.12-next.0"
     "@backstage/plugin-auth-react": "npm:0.1.21-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.3-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.3-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21-next.0"
-    "@backstage/plugin-search-react": "npm:1.9.6-next.0"
+    "@backstage/plugin-search-react": "npm:1.10.0-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.5-next.0"
     "@backstage/theme": "npm:0.7.0"
@@ -5802,7 +5946,6 @@ __metadata:
     "@microsoft/fetch-event-source": "npm:^2.0.1"
     dompurify: "npm:^3.2.4"
     git-url-parse: "npm:^15.0.0"
-    jss: "npm:~10.10.0"
     lodash: "npm:^4.17.21"
     react-helmet: "npm:6.1.0"
     react-use: "npm:^17.2.4"
@@ -5814,7 +5957,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/bed64ee8c638ba07118471476573accd2a3c9705e1394af0633cb47b56c841ceba9faf0f4fc20621e58bb61711b73437f0e8b8ac7fa8ee9b2736de54658d8536
+  checksum: 10/911debdaa6bbaedaada2b86c0cf17b7054d3ffd2f8965d50003c57280710ab1a797a1feb5cb3099cba3dd5c6e5f1c25a66743e6d839fff0c5f70d1a929b50608
   languageName: node
   linkType: hard
 
@@ -5825,7 +5968,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.45.0-next.1&npm=0.8.29-next.0, @backstage/plugin-user-settings@npm:^0.8.29-next.0":
+"@backstage/plugin-user-settings@backstage:^::backstage=1.45.0-next.2&npm=0.8.29-next.0, @backstage/plugin-user-settings@npm:^0.8.29-next.0":
   version: 0.8.29-next.0
   resolution: "@backstage/plugin-user-settings@npm:0.8.29-next.0"
   dependencies:
@@ -5923,7 +6066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.45.0-next.1&npm=0.7.0, @backstage/theme@npm:0.7.0, @backstage/theme@npm:^0.7.0":
+"@backstage/theme@backstage:^::backstage=1.45.0-next.2&npm=0.7.0, @backstage/theme@npm:0.7.0, @backstage/theme@npm:^0.7.0":
   version: 0.7.0
   resolution: "@backstage/theme@npm:0.7.0"
   dependencies:
@@ -5970,9 +6113,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.45.0-next.1&npm=0.9.0-next.1, @backstage/ui@npm:^0.9.0-next.1":
-  version: 0.9.0-next.1
-  resolution: "@backstage/ui@npm:0.9.0-next.1"
+"@backstage/ui@backstage:^::backstage=1.45.0-next.2&npm=0.9.0-next.2, @backstage/ui@npm:^0.9.0-next.2":
+  version: 0.9.0-next.2
+  resolution: "@backstage/ui@npm:0.9.0-next.2"
   dependencies:
     "@base-ui-components/react": "npm:1.0.0-alpha.7"
     "@remixicon/react": "npm:^4.6.0"
@@ -5987,7 +6130,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/4fd637d51b97254b80e03c7d372f9b63dd2d8572780ef572238573284f3841303c5d4c6235cb0e11b163afa11cec72ed89f62b4ea3b9d4373c9e240d92b621ea
+  checksum: 10/7891b8b1371e6ef08a21d4ad27fe9229eb18818aaf7129444f0498b97d07d63684b79c01d82a8491a50cf6a7e8ef485c8a9232e4b5876aad8a4aeedc01c7a46d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.45.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.45.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.45.0-next.2-changelog.md)
- Upgrade Helper: [From 1.45.0-next.1 to 1.45.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.45.0-next.1&to=1.45.0-next.2)
 
Created by [Version Bump 19098357660](https://github.com/backstage/demo/actions/runs/19098357660)
 