### PR TITLE
v1.46.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: b3b00465cee9a55ea92b7555876084a6dbfb4b9dd2ce7617a0bca1c138dec6b33befabdff7f4035b2a2ad70d59a05dad3a8faf3a34d3bec21fa7949a497fdf48
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.46.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.46.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.46.0-next.1"
+  "version": "1.46.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2390,7 +2390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.46.0-next.1&npm=1.7.3-next.0, @backstage/app-defaults@npm:^1.7.3-next.0":
+"@backstage/app-defaults@backstage:^::backstage=1.46.0-next.2&npm=1.7.3-next.0, @backstage/app-defaults@npm:^1.7.3-next.0":
   version: 1.7.3-next.0
   resolution: "@backstage/app-defaults@npm:1.7.3-next.0"
   dependencies:
@@ -2413,14 +2413,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-app-api@npm:1.4.0-next.0":
-  version: 1.4.0-next.0
-  resolution: "@backstage/backend-app-api@npm:1.4.0-next.0"
+"@backstage/backend-app-api@npm:1.4.0-next.1":
+  version: 1.4.0-next.1
+  resolution: "@backstage/backend-app-api@npm:1.4.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-  checksum: 10/b24392dc2dacfaef273a84ab82abc06d0cfedb7478feba85fc1c2b35fd22ff3e07aae463a858de58be10abfbd21a933008212574027ba52f7c5b0ea64b6ac50d
+  checksum: 10/526db67c126abdeab6ec61a57c5535f207c19d2e3bdb1bf569a793bb1a663fca8c23bae3c4d15d3b921cc443be0e66682c01909ad8c8f67950a9676494e81b0f
   languageName: node
   linkType: hard
 
@@ -2511,9 +2511,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.46.0-next.1&npm=0.14.0-next.0, @backstage/backend-defaults@npm:0.14.0-next.0, @backstage/backend-defaults@npm:^0.14.0-next.0":
-  version: 0.14.0-next.0
-  resolution: "@backstage/backend-defaults@npm:0.14.0-next.0"
+"@backstage/backend-defaults@backstage:^::backstage=1.46.0-next.2&npm=0.14.0-next.1, @backstage/backend-defaults@npm:0.14.0-next.1, @backstage/backend-defaults@npm:^0.14.0-next.1":
+  version: 0.14.0-next.1
+  resolution: "@backstage/backend-defaults@npm:0.14.0-next.1"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -2521,18 +2521,18 @@ __metadata:
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-app-api": "npm:1.4.0-next.0"
-    "@backstage/backend-dev-utils": "npm:0.1.5"
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
-    "@backstage/cli-node": "npm:0.2.16-next.0"
+    "@backstage/backend-app-api": "npm:1.4.0-next.1"
+    "@backstage/backend-dev-utils": "npm:0.1.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
+    "@backstage/cli-node": "npm:0.2.16-next.1"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/config-loader": "npm:1.10.7-next.0"
+    "@backstage/config-loader": "npm:1.10.7-next.1"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
     "@backstage/integration-aws-node": "npm:0.1.19"
-    "@backstage/plugin-auth-node": "npm:0.6.10-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.18-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.7-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.10-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.18-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.7-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/storage": "npm:^7.0.0"
     "@keyv/memcache": "npm:^2.0.1"
@@ -2550,7 +2550,7 @@ __metadata:
     cookie: "npm:^0.7.0"
     cors: "npm:^2.8.5"
     cron: "npm:^3.0.0"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     express-rate-limit: "npm:^7.5.0"
     fs-extra: "npm:^11.2.0"
@@ -2567,7 +2567,7 @@ __metadata:
     minimatch: "npm:^9.0.0"
     mysql2: "npm:^3.0.0"
     node-fetch: "npm:^2.7.0"
-    node-forge: "npm:^1.3.1"
+    node-forge: "npm:^1.3.2"
     p-limit: "npm:^3.1.0"
     path-to-regexp: "npm:^8.0.0"
     pg: "npm:^8.11.3"
@@ -2593,7 +2593,7 @@ __metadata:
       optional: true
     better-sqlite3:
       optional: true
-  checksum: 10/f73312d841cbff91a555cdb4709226e20459502519430b42b11f5b17eb4f52947d9ed8f09ba958a4d6d93e8063a0012ce39d3f5f06d31551bb2c0245a3692ac8
+  checksum: 10/ed49f29ae32e58c1213cd288657791fe3a04f353a3fb7cb6c3b940b103c9c0be1b6ee8ddd16bc4c66e895112921f4d7657d97bd1f6e57f26915dbfbc51cad645
   languageName: node
   linkType: hard
 
@@ -2681,25 +2681,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-dev-utils@npm:0.1.5, @backstage/backend-dev-utils@npm:^0.1.4, @backstage/backend-dev-utils@npm:^0.1.5":
+"@backstage/backend-dev-utils@npm:0.1.6-next.0":
+  version: 0.1.6-next.0
+  resolution: "@backstage/backend-dev-utils@npm:0.1.6-next.0"
+  checksum: 10/2f7ab8f8fca74b2be6e95d6a6efab3f56ae687c1a6c7d6809d0e1950f9c90b6626d84fb1c7dc93473e0b75ca08d178106e0f0f868be3a1a2463bda9ff4b4ada5
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-dev-utils@npm:^0.1.4, @backstage/backend-dev-utils@npm:^0.1.5":
   version: 0.1.5
   resolution: "@backstage/backend-dev-utils@npm:0.1.5"
   checksum: 10/acd0992047b420dc2ffbfe1ab4c730c5804ad6888a8aa1648df96659c6a4acafbf67784acc9437350fe377ae4acb6b6e772fe77a5976a462d37d6ef2c91b9514
   languageName: node
   linkType: hard
 
-"@backstage/backend-openapi-utils@npm:0.6.4-next.0":
-  version: 0.6.4-next.0
-  resolution: "@backstage/backend-openapi-utils@npm:0.6.4-next.0"
+"@backstage/backend-openapi-utils@npm:0.6.4-next.1":
+  version: 0.6.4-next.1
+  resolution: "@backstage/backend-openapi-utils@npm:0.6.4-next.1"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/types": "npm:1.2.2"
     "@types/express": "npm:^4.17.6"
     "@types/express-serve-static-core": "npm:^4.17.5"
     ajv: "npm:^8.16.0"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-openapi-validator: "npm:^5.5.8"
     express-promise-router: "npm:^4.1.0"
     get-port: "npm:^5.1.1"
@@ -2708,7 +2715,7 @@ __metadata:
     mockttp: "npm:^3.13.0"
     openapi-merge: "npm:^1.3.2"
     openapi3-ts: "npm:^3.1.2"
-  checksum: 10/49b0abfdf7285543b6e9911a5143baaa1af198f491a6cea6e92167af9f8e6e5b60ef71b7c82a499cfb0b5d62bad772b043ac74f3beea19de983bd2e4193b96a8
+  checksum: 10/85b3be6209ea2e78e22b83152e41cc45b081fbf0d3925707825e9e8a9c4b336df947f0553a8503342ac2f8f70cdfb9c633555088a2457a7848e6d6351205918e
   languageName: node
   linkType: hard
 
@@ -2736,16 +2743,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.46.0-next.1&npm=1.5.1-next.0, @backstage/backend-plugin-api@npm:1.5.1-next.0, @backstage/backend-plugin-api@npm:^1.5.1-next.0":
-  version: 1.5.1-next.0
-  resolution: "@backstage/backend-plugin-api@npm:1.5.1-next.0"
+"@backstage/backend-plugin-api@backstage:^::backstage=1.46.0-next.2&npm=1.6.0-next.1, @backstage/backend-plugin-api@npm:1.6.0-next.1, @backstage/backend-plugin-api@npm:^1.6.0-next.1":
+  version: 1.6.0-next.1
+  resolution: "@backstage/backend-plugin-api@npm:1.6.0-next.1"
   dependencies:
-    "@backstage/cli-common": "npm:0.1.16-next.0"
+    "@backstage/cli-common": "npm:0.1.16-next.2"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.10-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.10-next.1"
     "@backstage/plugin-permission-common": "npm:0.9.3"
-    "@backstage/plugin-permission-node": "npm:0.10.7-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.7-next.1"
     "@backstage/types": "npm:1.2.2"
     "@types/express": "npm:^4.17.6"
     "@types/json-schema": "npm:^7.0.6"
@@ -2754,7 +2761,7 @@ __metadata:
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/f8203fa7f4e3ba0eee6fba0c05d0c5b5ad8c85fe9f54e5d9e60f8d294d51029305c2c0e56a0a468e60d4226edcf016d490180ff7d52e9899d1b3ee86f9dd2d83
+  checksum: 10/9f8d7014aecc69eb2c0b814557c7c53e2a14c77474f9260d78d347fe8f4adf6bbdd1f9666bcfb9d3dd561b6d7ee394cd169b8945ffc7f7d791e8b2bbe619fa31
   languageName: node
   linkType: hard
 
@@ -2811,7 +2818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.46.0-next.1&npm=1.7.6, @backstage/catalog-model@npm:1.7.6, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.5, @backstage/catalog-model@npm:^1.7.6":
+"@backstage/catalog-model@backstage:^::backstage=1.46.0-next.2&npm=1.7.6, @backstage/catalog-model@npm:1.7.6, @backstage/catalog-model@npm:^1.5.0, @backstage/catalog-model@npm:^1.7.5, @backstage/catalog-model@npm:^1.7.6":
   version: 1.7.6
   resolution: "@backstage/catalog-model@npm:1.7.6"
   dependencies:
@@ -2820,16 +2827,6 @@ __metadata:
     ajv: "npm:^8.10.0"
     lodash: "npm:^4.17.21"
   checksum: 10/002b26972537b14b7bee90d617cb174c6b036cfbdbed58a52ab02195b2045743e87b8ddf58fd1afa8056315c559a60203488e0f596db82f6c85b05145685a850
-  languageName: node
-  linkType: hard
-
-"@backstage/cli-common@npm:0.1.16-next.0":
-  version: 0.1.16-next.0
-  resolution: "@backstage/cli-common@npm:0.1.16-next.0"
-  dependencies:
-    global-agent: "npm:^3.0.0"
-    undici: "npm:^7.2.3"
-  checksum: 10/3fdec0ab8f1bba699ab0e207a093becb9438ff6ea8196280457b897bbd20d8044700a02946d808c66dcb42e78454d86a536f1c5e0bff9d8c7d9ca3f328270bc5
   languageName: node
   linkType: hard
 
@@ -2845,26 +2842,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/cli-common@npm:0.1.16-next.2":
+  version: 0.1.16-next.2
+  resolution: "@backstage/cli-common@npm:0.1.16-next.2"
+  dependencies:
+    "@backstage/errors": "npm:1.2.7"
+    cross-spawn: "npm:^7.0.3"
+    global-agent: "npm:^3.0.0"
+    undici: "npm:^7.2.3"
+  checksum: 10/83af5c38413072ed134a62b84fd0be8bb9220562944b4e21c072bdc699d3e460082728cb15012bd95c1c527bce2355cd9242c1cefe10d21d78709789693dd789
+  languageName: node
+  linkType: hard
+
 "@backstage/cli-common@npm:^0.1.14, @backstage/cli-common@npm:^0.1.15":
   version: 0.1.15
   resolution: "@backstage/cli-common@npm:0.1.15"
   checksum: 10/cb097348ce5c533125ab367d15fa7b663c1c8071b6ab2a83305fbe1ca9d754c6b6b68112decdbca9685b47a4e7512ebd30066ee8c310ae0d66524f8e484ee5be
-  languageName: node
-  linkType: hard
-
-"@backstage/cli-node@npm:0.2.16-next.0":
-  version: 0.2.16-next.0
-  resolution: "@backstage/cli-node@npm:0.2.16-next.0"
-  dependencies:
-    "@backstage/cli-common": "npm:0.1.16-next.0"
-    "@backstage/errors": "npm:1.2.7"
-    "@backstage/types": "npm:1.2.2"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    "@yarnpkg/parsers": "npm:^3.0.0"
-    fs-extra: "npm:^11.2.0"
-    semver: "npm:^7.5.3"
-    zod: "npm:^3.22.4"
-  checksum: 10/1634882f01d51616fd236f30cf5888752c00891a1d3077b11c6d40b5d948e2f1ff0f98f00f9808e85ad47d0e1fb43cfb131153832c453833763341be27cdfd72
   languageName: node
   linkType: hard
 
@@ -2900,18 +2893,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.46.0-next.1&npm=0.34.6-next.1, @backstage/cli@npm:^0.34.6-next.1":
-  version: 0.34.6-next.1
-  resolution: "@backstage/cli@npm:0.34.6-next.1"
+"@backstage/cli@backstage:^::backstage=1.46.0-next.2&npm=0.35.0-next.2, @backstage/cli@npm:^0.35.0-next.2":
+  version: 0.35.0-next.2
+  resolution: "@backstage/cli@npm:0.35.0-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/cli-common": "npm:0.1.16-next.1"
+    "@backstage/cli-common": "npm:0.1.16-next.2"
     "@backstage/cli-node": "npm:0.2.16-next.1"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/config-loader": "npm:1.10.7-next.0"
+    "@backstage/config-loader": "npm:1.10.7-next.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/eslint-plugin": "npm:0.2.0"
-    "@backstage/integration": "npm:1.18.3-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
     "@backstage/release-manifests": "npm:0.0.13"
     "@backstage/types": "npm:1.2.2"
     "@manypkg/get-packages": "npm:^1.1.3"
@@ -2945,7 +2938,7 @@ __metadata:
     cross-spawn: "npm:^7.0.3"
     css-loader: "npm:^6.5.1"
     ctrlc-windows: "npm:^2.1.0"
-    esbuild: "npm:^0.25.0"
+    esbuild: "npm:^0.27.0"
     eslint: "npm:^8.6.0"
     eslint-config-prettier: "npm:^9.0.0"
     eslint-formatter-friendly: "npm:^7.0.0"
@@ -2957,7 +2950,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^5.0.0"
     eslint-plugin-unused-imports: "npm:^4.1.4"
     eslint-rspack-plugin: "npm:^4.2.1"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
     git-url-parse: "npm:^15.0.0"
     glob: "npm:^7.1.7"
@@ -3008,13 +3001,13 @@ __metadata:
     zod-validation-error: "npm:^3.4.0"
   peerDependencies:
     "@module-federation/enhanced": ^0.9.0
-    "@pmmmwh/react-refresh-webpack-plugin": ^0.5.7
+    "@pmmmwh/react-refresh-webpack-plugin": ^0.6.0
     esbuild-loader: ^4.0.0
     eslint-webpack-plugin: ^4.2.0
     fork-ts-checker-webpack-plugin: ^9.0.0
     mini-css-extract-plugin: ^2.4.2
     terser-webpack-plugin: ^5.1.3
-    webpack: ~5.96.0
+    webpack: ~5.103.0
     webpack-dev-server: ^5.0.0
   peerDependenciesMeta:
     "@module-federation/enhanced":
@@ -3037,15 +3030,15 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/5ba3a2f3b3eaff174890eed146c00ae5b5ef57693a6df4e6c96420ea6fa4c56b98ed754f180aaa70e637b4c82d8142232fa86b1bccd0de6e93d4d845d6f6a4ed
+  checksum: 10/cc449b0193b7312961d02854a91042a14337590ad8918deb445299c0f28ac6bb1d3cd7d1fe9faf933efaba542bba4e9cb9a2fea891692f8eac49d7efa0d1dd72
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:1.10.7-next.0":
-  version: 1.10.7-next.0
-  resolution: "@backstage/config-loader@npm:1.10.7-next.0"
+"@backstage/config-loader@npm:1.10.7-next.1":
+  version: 1.10.7-next.1
+  resolution: "@backstage/config-loader@npm:1.10.7-next.1"
   dependencies:
-    "@backstage/cli-common": "npm:0.1.16-next.0"
+    "@backstage/cli-common": "npm:0.1.16-next.2"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/types": "npm:1.2.2"
@@ -3058,9 +3051,9 @@ __metadata:
     json-schema-traverse: "npm:^1.0.0"
     lodash: "npm:^4.17.21"
     minimist: "npm:^1.2.5"
-    typescript-json-schema: "npm:^0.65.0"
+    typescript-json-schema: "npm:^0.67.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/e80e4d1790961e3aae0a38fc05a3ef43691926fd61886c7618b045fb1f4f745d04e7de4e28e372c712465205d163dc376158274fb432f0d9d927b82c7193078a
+  checksum: 10/3df37d6650a5f1e423cc00466469a96d51befb59ccc83e5893bd9bee95a51914e60367f546cf700216e3d460de4eb980c6d24d7f8056cb4f362e2f0f8ba661bf
   languageName: node
   linkType: hard
 
@@ -3087,7 +3080,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.46.0-next.1&npm=1.3.6, @backstage/config@npm:1.3.6, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2, @backstage/config@npm:^1.3.3, @backstage/config@npm:^1.3.5, @backstage/config@npm:^1.3.6":
+"@backstage/config@backstage:^::backstage=1.46.0-next.2&npm=1.3.6, @backstage/config@npm:1.3.6, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2, @backstage/config@npm:^1.3.3, @backstage/config@npm:^1.3.5, @backstage/config@npm:^1.3.6":
   version: 1.3.6
   resolution: "@backstage/config@npm:1.3.6"
   dependencies:
@@ -3098,7 +3091,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.46.0-next.1&npm=1.19.3-next.0, @backstage/core-app-api@npm:1.19.3-next.0, @backstage/core-app-api@npm:^1.19.3-next.0":
+"@backstage/core-app-api@backstage:^::backstage=1.46.0-next.2&npm=1.19.3-next.1, @backstage/core-app-api@npm:1.19.3-next.1, @backstage/core-app-api@npm:^1.19.3-next.1":
+  version: 1.19.3-next.1
+  resolution: "@backstage/core-app-api@npm:1.19.3-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/core-plugin-api": "npm:1.12.1-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@types/prop-types": "npm:^15.7.3"
+    history: "npm:^5.0.0"
+    i18next: "npm:^22.4.15"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/6d651364854fb6c9706e6367c51dbcaa431fbf705b6551e32607857e890783001eadd6703aed12c5176d7d6cd276d054f98b4ed5b96f616dcd4192b6270d7a15
+  languageName: node
+  linkType: hard
+
+"@backstage/core-app-api@npm:1.19.3-next.0":
   version: 1.19.3-next.0
   resolution: "@backstage/core-app-api@npm:1.19.3-next.0"
   dependencies:
@@ -3126,7 +3147,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.46.0-next.1&npm=0.5.5-next.0, @backstage/core-compat-api@npm:0.5.5-next.0, @backstage/core-compat-api@npm:^0.5.5-next.0":
+"@backstage/core-compat-api@backstage:^::backstage=1.46.0-next.2&npm=0.5.5-next.0, @backstage/core-compat-api@npm:0.5.5-next.0, @backstage/core-compat-api@npm:^0.5.5-next.0":
   version: 0.5.5-next.0
   resolution: "@backstage/core-compat-api@npm:0.5.5-next.0"
   dependencies:
@@ -3170,9 +3191,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.46.0-next.1&npm=0.18.4-next.1, @backstage/core-components@npm:0.18.4-next.1, @backstage/core-components@npm:^0.18.4-next.1":
-  version: 0.18.4-next.1
-  resolution: "@backstage/core-components@npm:0.18.4-next.1"
+"@backstage/core-components@backstage:^::backstage=1.46.0-next.2&npm=0.18.4-next.2, @backstage/core-components@npm:0.18.4-next.2, @backstage/core-components@npm:^0.18.4-next.2":
+  version: 0.18.4-next.2
+  resolution: "@backstage/core-components@npm:0.18.4-next.2"
   dependencies:
     "@backstage/config": "npm:1.3.6"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
@@ -3221,7 +3242,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/08fe091001d6f51be8ff866cabb5b1a0577e3ffff583806467b7b766de7778eb93c84893d07ea703ef376b0859d2d5206a68fc20a0c799fe86669af337db11b2
+  checksum: 10/0471f8aecd3f73a2d1da43e22404d8486a84192424a6f38792e4a19961ea86d412a4e690593e44b44b513fddf8432730fc0ec0079e0421b43ad14f48eb5e05be
   languageName: node
   linkType: hard
 
@@ -3277,6 +3298,61 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/ed598cd2119a315329ee8bd1a7cefb70acabcc3283881deec3289ac5c9ef6a5239dae4c2f03662ea1baf85463628019df944b39d15e706f3ca4b610fc57e250c
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.18.4-next.1":
+  version: 0.18.4-next.1
+  resolution: "@backstage/core-components@npm:0.18.4-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/core-plugin-api": "npm:1.12.1-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/theme": "npm:0.7.1-next.0"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.3.2"
+    linkifyjs: "npm:4.3.2"
+    lodash: "npm:^4.17.21"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-full-screen: "npm:^1.1.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/08fe091001d6f51be8ff866cabb5b1a0577e3ffff583806467b7b766de7778eb93c84893d07ea703ef376b0859d2d5206a68fc20a0c799fe86669af337db11b2
   languageName: node
   linkType: hard
 
@@ -3389,7 +3465,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.46.0-next.1&npm=1.12.1-next.0, @backstage/core-plugin-api@npm:1.12.1-next.0, @backstage/core-plugin-api@npm:^1.12.1-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.46.0-next.2&npm=1.12.1-next.0, @backstage/core-plugin-api@npm:1.12.1-next.0, @backstage/core-plugin-api@npm:^1.12.1-next.0":
   version: 1.12.1-next.0
   resolution: "@backstage/core-plugin-api@npm:1.12.1-next.0"
   dependencies:
@@ -3433,7 +3509,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.46.0-next.1&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.46.0-next.2&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -3494,7 +3570,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.46.0-next.1&npm=0.3.4-next.0, @backstage/frontend-defaults@npm:0.3.4-next.0, @backstage/frontend-defaults@npm:^0.3.4-next.0":
+"@backstage/frontend-defaults@backstage:^::backstage=1.46.0-next.2&npm=0.3.4-next.0, @backstage/frontend-defaults@npm:0.3.4-next.0, @backstage/frontend-defaults@npm:^0.3.4-next.0":
   version: 0.3.4-next.0
   resolution: "@backstage/frontend-defaults@npm:0.3.4-next.0"
   dependencies:
@@ -3517,7 +3593,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.46.0-next.1&npm=0.13.2-next.0, @backstage/frontend-plugin-api@npm:0.13.2-next.0, @backstage/frontend-plugin-api@npm:^0.13.2-next.0":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.46.0-next.2&npm=0.13.2-next.1, @backstage/frontend-plugin-api@npm:0.13.2-next.1, @backstage/frontend-plugin-api@npm:^0.13.2-next.1":
+  version: 0.13.2-next.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.13.2-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/core-components": "npm:0.18.4-next.2"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.4"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.22.4"
+    zod-to-json-schema: "npm:^3.21.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/e8a9563b60e067a9a8aef02cfc6ed17b35fb467f1985852f2e17ae460887c640950ebcd7d037c0d208fc358668d6295f7abc937ff47d8ee5b447ba1618da2698
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:0.13.2-next.0":
   version: 0.13.2-next.0
   resolution: "@backstage/frontend-plugin-api@npm:0.13.2-next.0"
   dependencies:
@@ -3630,7 +3731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.46.0-next.1&npm=1.2.13-next.0, @backstage/integration-react@npm:1.2.13-next.0, @backstage/integration-react@npm:^1.2.13-next.0":
+"@backstage/integration-react@backstage:^::backstage=1.46.0-next.2&npm=1.2.13-next.0, @backstage/integration-react@npm:1.2.13-next.0, @backstage/integration-react@npm:^1.2.13-next.0":
   version: 1.2.13-next.0
   resolution: "@backstage/integration-react@npm:1.2.13-next.0"
   dependencies:
@@ -3690,6 +3791,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration@npm:1.18.3-next.1":
+  version: 1.18.3-next.1
+  resolution: "@backstage/integration@npm:1.18.3-next.1"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+  checksum: 10/bfdb554958c42097695a111ac5653003555b140b611da386a2c3b34aadbb24b5c55fad645323be5af18cc0be6ceb84bc9a97637fd4034bc4a1b68ef484a46be1
+  languageName: node
+  linkType: hard
+
 "@backstage/integration@npm:^1.13.0, @backstage/integration@npm:^1.18.1":
   version: 1.18.1
   resolution: "@backstage/integration@npm:1.18.1"
@@ -3708,18 +3827,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.46.0-next.1&npm=0.13.2-next.0, @backstage/plugin-api-docs@npm:^0.13.2-next.0":
-  version: 0.13.2-next.0
-  resolution: "@backstage/plugin-api-docs@npm:0.13.2-next.0"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.46.0-next.2&npm=0.13.2-next.1, @backstage/plugin-api-docs@npm:^0.13.2-next.1":
+  version: 0.13.2-next.1
+  resolution: "@backstage/plugin-api-docs@npm:0.13.2-next.1"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4-next.0"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
-    "@backstage/plugin-catalog": "npm:1.32.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
+    "@backstage/plugin-catalog": "npm:1.32.1-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-react": "npm:1.21.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.4-next.2"
     "@backstage/plugin-permission-react": "npm:0.4.39-next.0"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -3738,22 +3857,22 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/07cbc2405a3e11b45d44d57bd03c51acdeb080e0f942ccabb23cf19090ab019a91c8faa69891a4c85e351a842063a70390605b9acee7056725599856e11f899a
+  checksum: 10/b18c36813fe4cd8a05fa9dff63ff3658f8b283a2083515cd6cfe2fec0f31abad00eb45332f9b23df72509e987ad32a789e0a8bb6c86f68493c3321839732df73
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.46.0-next.1&npm=0.5.9-next.0, @backstage/plugin-app-backend@npm:^0.5.9-next.0":
-  version: 0.5.9-next.0
-  resolution: "@backstage/plugin-app-backend@npm:0.5.9-next.0"
+"@backstage/plugin-app-backend@backstage:^::backstage=1.46.0-next.2&npm=0.5.9-next.1, @backstage/plugin-app-backend@npm:^0.5.9-next.1":
+  version: 0.5.9-next.1
+  resolution: "@backstage/plugin-app-backend@npm:0.5.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/config-loader": "npm:1.10.7-next.0"
+    "@backstage/config-loader": "npm:1.10.7-next.1"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-app-node": "npm:0.1.40-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.10-next.0"
+    "@backstage/plugin-app-node": "npm:0.1.40-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.10-next.1"
     "@backstage/types": "npm:1.2.2"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
     globby: "npm:^11.0.0"
@@ -3762,20 +3881,20 @@ __metadata:
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     yn: "npm:^4.0.0"
-  checksum: 10/060a0303056808956ff8c7fa1c4dc802c422cb0c5015178d18c044c7fce08d1b5960ffa57e423106381066128097197c947cf6b9b06439fb3dd886889a9a1bfb
+  checksum: 10/0cc1d8697531358c9d322c5659c6793e83cec943624329b9eca6d67ca895d124c5b09f8dee9cace5f290052c851184c812eed29fdb179662f2f22592f4ed412d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-node@npm:0.1.40-next.0":
-  version: 0.1.40-next.0
-  resolution: "@backstage/plugin-app-node@npm:0.1.40-next.0"
+"@backstage/plugin-app-node@npm:0.1.40-next.1":
+  version: 0.1.40-next.1
+  resolution: "@backstage/plugin-app-node@npm:0.1.40-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
-    "@backstage/config-loader": "npm:1.10.7-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
+    "@backstage/config-loader": "npm:1.10.7-next.1"
     "@types/express": "npm:^4.17.6"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
-  checksum: 10/0631c76edf1b2119a475e7e570f80d8cbb3dd234ba3100a412e24f94b03adffa862bd41797a1b21502e2ddf8a1ded09544c2f369679226c6a22cd41c62f46932
+  checksum: 10/30edd9c655fb79fb666375c0251c3bd668ff55d331348019633f73addc273135efad54cf80448fd556dcf16ee7712cecd54bece3837e1049baa09d382ab7179c
   languageName: node
   linkType: hard
 
@@ -3809,46 +3928,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.46.0-next.1&npm=0.3.10-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.10-next.0":
-  version: 0.3.10-next.0
-  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.10-next.0"
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.46.0-next.2&npm=0.3.10-next.1, @backstage/plugin-auth-backend-module-github-provider@npm:^0.3.10-next.1":
+  version: 0.3.10-next.1
+  resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.3.10-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.10-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.10-next.1"
     passport-github2: "npm:^0.1.12"
     zod: "npm:^3.22.4"
-  checksum: 10/8c0523a9340af5b2f75163f1f3fad1123bc41f3ca411acd9de7df0254e564f12bea44854718550bc283f937f721d93308c0d012c7d740c0a76b2ab538aa4367e
+  checksum: 10/72e46d42c12981f143c8a3a8cf0e96dd1a42455fb0945dce257b5f51f4510447d1d7508558c351e6f92700d047c57a5b24c7443bbb8900a733a8627512c7b6f5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.46.0-next.1&npm=0.2.15-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.15-next.0":
-  version: 0.2.15-next.0
-  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.15-next.0"
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.46.0-next.2&npm=0.2.15-next.1, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.15-next.1":
+  version: 0.2.15-next.1
+  resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.15-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.10-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.10-next.1"
     passport-oauth2: "npm:^1.7.0"
-  checksum: 10/421447c8f8339b5b77c3771be63e0d80dff3e04aa59f6b7329de766d833726d85d7325024f7890bad2c430341f3a38048d8e3f2bde9082d2aa357564cfe7ad04
+  checksum: 10/66d56b640c989b6b0f5b97d4135d1840ae1759a149cb178b8c9f666f07301de2083e23c4aa1edddd874c4925c65a813d4a8c91518ddeb5a50e529ad43a876989
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.46.0-next.1&npm=0.25.7-next.0, @backstage/plugin-auth-backend@npm:^0.25.7-next.0":
-  version: 0.25.7-next.0
-  resolution: "@backstage/plugin-auth-backend@npm:0.25.7-next.0"
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.46.0-next.2&npm=0.25.7-next.1, @backstage/plugin-auth-backend@npm:^0.25.7-next.1":
+  version: 0.25.7-next.1
+  resolution: "@backstage/plugin-auth-backend@npm:0.25.7-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.10-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.10-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/firestore": "npm:^7.0.0"
     connect-session-knex: "npm:^4.0.0"
     cookie-parser: "npm:^1.4.5"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     express-session: "npm:^1.17.1"
     jose: "npm:^5.0.0"
@@ -3859,15 +3978,15 @@ __metadata:
     minimatch: "npm:^9.0.0"
     passport: "npm:^0.7.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/706a898f17067893b7c8fcdbbe92c7712f584776677bdf6323821185f010bc2082e4e0fe7d78caa23a4f9a2da6d425adcd20676b85a82d2205bbe33a5331f481
+  checksum: 10/77b4502c96360d9a729c3de31f13f5e623f2e78983782ceed434fdeb723fa60772396fcbd1e208e33097b30fc07b3ff2996036dd5f4a24d8348d4225acb00896
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:0.6.10-next.0":
-  version: 0.6.10-next.0
-  resolution: "@backstage/plugin-auth-node@npm:0.6.10-next.0"
+"@backstage/plugin-auth-node@npm:0.6.10-next.1":
+  version: 0.6.10-next.1
+  resolution: "@backstage/plugin-auth-node@npm:0.6.10-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
@@ -3875,14 +3994,14 @@ __metadata:
     "@backstage/types": "npm:1.2.2"
     "@types/express": "npm:^4.17.6"
     "@types/passport": "npm:^1.0.3"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     jose: "npm:^5.0.0"
     lodash: "npm:^4.17.21"
     passport: "npm:^0.7.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.21.4"
     zod-validation-error: "npm:^3.4.0"
-  checksum: 10/0279ffb195544c46baaf8f83043790f158fca910fbd25f3310c3ef9fca0318d7d9602530afff42a51c8651991c9bace03039c6acf3dd090707ad8df543afedcc
+  checksum: 10/57b897c6bbb94b4b634aa2b41c36bcf89fa5f0ded49a26fbb7f2fcbe8f005d0c2f58fc97a34179e95c467bfb564c682655b1eafc609ca17ce998dcff17250023
   languageName: node
   linkType: hard
 
@@ -3965,17 +4084,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.46.0-next.1&npm=0.11.3-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.11.3-next.1":
-  version: 0.11.3-next.1
-  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.11.3-next.1"
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.46.0-next.2&npm=0.11.3-next.2, @backstage/plugin-catalog-backend-module-github@npm:^0.11.3-next.2":
+  version: 0.11.3-next.2
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.11.3-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/integration": "npm:1.18.3-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.18-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.18-next.1"
     "@octokit/core": "npm:^5.2.0"
     "@octokit/graphql": "npm:^7.0.2"
     "@octokit/plugin-throttling": "npm:^8.1.3"
@@ -3984,55 +4103,55 @@ __metadata:
     lodash: "npm:^4.17.21"
     minimatch: "npm:^9.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/426c73bc6d5e20adeed0b678312a2706fcafbbe555974964f6009b6d21f8f8a0a7efbc571f6c401f33980554684f0974fbc9d5d165f5d0fd67e30e015a774185
+  checksum: 10/ac31be39ff0e11e555c23ba90176250fdcd47df22ebba6687361adf6727da0aa023c04a4bc1c77e1b9338d2b89e395b64795658786a828a0d117392592f3843e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.46.0-next.1&npm=0.1.17-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.17-next.0":
-  version: 0.1.17-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.17-next.0"
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.46.0-next.2&npm=0.1.17-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.17-next.1":
+  version: 0.1.17-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.17-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
-    "@backstage/plugin-catalog-backend": "npm:3.2.1-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.18-next.0"
-  checksum: 10/1b18296fbd7a30e8fcc7785963eefd4d221f09d190eb5e3633473544b3b337e239620e0364018ccf18895bbf67fd26694148570f1326b5316c37077578cfdece
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
+    "@backstage/plugin-catalog-backend": "npm:3.2.1-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.18-next.1"
+  checksum: 10/5bd405b90d63723e674ac74197caa872fcbf1d847dab4dffa69670fbf971b9d6e4dab41b3842618fd398f35d04f5416dcf8a1b279f344f5247cdf6c07012e199
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.46.0-next.1&npm=0.2.15-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.15-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.15-next.0":
-  version: 0.2.15-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.15-next.0"
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.46.0-next.2&npm=0.2.15-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.15-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.15-next.1":
+  version: 0.2.15-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.15-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.7.4-next.0"
-  checksum: 10/fa46c8b99bc89dc698ea461dc5a423805f0b5b0a0bac43705cec214f5493cef2007e16f34a84d6999de154bc25f9cb8a8186c0fced9708781f3f8819fe3a7718
+  checksum: 10/724bf99126a5f22c0bce690a430bb458753dc3cb4a5d127a48ef0c2dfa527db6bee64c30f054df05b14165a27c69a7152cd217786b09e8b80e3aab3b4d405d2d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.46.0-next.1&npm=3.2.1-next.0, @backstage/plugin-catalog-backend@npm:3.2.1-next.0, @backstage/plugin-catalog-backend@npm:^3.2.1-next.0":
-  version: 3.2.1-next.0
-  resolution: "@backstage/plugin-catalog-backend@npm:3.2.1-next.0"
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.46.0-next.2&npm=3.2.1-next.1, @backstage/plugin-catalog-backend@npm:3.2.1-next.1, @backstage/plugin-catalog-backend@npm:^3.2.1-next.1":
+  version: 3.2.1-next.1
+  resolution: "@backstage/plugin-catalog-backend@npm:3.2.1-next.1"
   dependencies:
-    "@backstage/backend-openapi-utils": "npm:0.6.4-next.0"
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-openapi-utils": "npm:0.6.4-next.1"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.18-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.18-next.1"
     "@backstage/plugin-permission-common": "npm:0.9.3"
-    "@backstage/plugin-permission-node": "npm:0.10.7-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.7-next.1"
     "@backstage/types": "npm:1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     codeowners-utils: "npm:^1.0.2"
     core-js: "npm:^3.6.5"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     fast-json-stable-stringify: "npm:^2.1.0"
     fs-extra: "npm:^11.2.0"
     git-url-parse: "npm:^15.0.0"
@@ -4047,11 +4166,11 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/d798ccdb115326dc6f22fc93b84d34ada5ae2132fb39208ddd474303c34c2c7d66a7786978d4867c0dd1c06382635b809e8c7fb3b1b920c2cdb2ce3b27e9639d
+  checksum: 10/2b13119f123ee77546495b04d863502d405c250cb9ce9f3bd14752cb9ae1efdbdb20ff6a42d3c79aad06b310664fe7e016b91b204dda644ae6a46d0a7be4403b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.46.0-next.1&npm=1.1.7, @backstage/plugin-catalog-common@npm:1.1.7, @backstage/plugin-catalog-common@npm:^1.1.6, @backstage/plugin-catalog-common@npm:^1.1.7":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.46.0-next.2&npm=1.1.7, @backstage/plugin-catalog-common@npm:1.1.7, @backstage/plugin-catalog-common@npm:^1.1.6, @backstage/plugin-catalog-common@npm:^1.1.7":
   version: 1.1.7
   resolution: "@backstage/plugin-catalog-common@npm:1.1.7"
   dependencies:
@@ -4062,16 +4181,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.46.0-next.1&npm=0.5.4-next.0, @backstage/plugin-catalog-graph@npm:^0.5.4-next.0":
-  version: 0.5.4-next.0
-  resolution: "@backstage/plugin-catalog-graph@npm:0.5.4-next.0"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.46.0-next.2&npm=0.5.4-next.1, @backstage/plugin-catalog-graph@npm:^0.5.4-next.1":
+  version: 0.5.4-next.1
+  resolution: "@backstage/plugin-catalog-graph@npm:0.5.4-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4-next.0"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.4-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.21.4-next.2"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4089,25 +4208,25 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7e135cd7eae7f61ac9bc1ded2c5cde5b727eaf5c871dbe382630bf08fb77cb445e4a0d3c4ace0ba797ef7709ba592b5918628ed71e165d82f25b002810a4f322
+  checksum: 10/edac675cf44f251f09ecab852bc3c011e4e321b3211b963a9775a94f6d7f8932e90ffd1564d00b8964a6aa96d2e808028e1300a9ad8d4938c3c7bb49d8bd1ec1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.46.0-next.1&npm=1.20.1-next.0, @backstage/plugin-catalog-node@npm:1.20.1-next.0, @backstage/plugin-catalog-node@npm:^1.20.1-next.0":
-  version: 1.20.1-next.0
-  resolution: "@backstage/plugin-catalog-node@npm:1.20.1-next.0"
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.46.0-next.2&npm=1.20.1-next.1, @backstage/plugin-catalog-node@npm:1.20.1-next.1, @backstage/plugin-catalog-node@npm:^1.20.1-next.1":
+  version: 1.20.1-next.1
+  resolution: "@backstage/plugin-catalog-node@npm:1.20.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
     "@backstage/plugin-permission-common": "npm:0.9.3"
-    "@backstage/plugin-permission-node": "npm:0.10.7-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.7-next.1"
     "@backstage/types": "npm:1.2.2"
     lodash: "npm:^4.17.21"
     yaml: "npm:^2.0.0"
-  checksum: 10/fb82a4f02aebaceedadb9af02487271e5b5ef46261531c9b65d232934ab45aae126adc250e70a9234d7b4e585ea50fce77b9b57bbc22af361dfe43f979fb4cb6
+  checksum: 10/66c3af699feaf01736f94eb8afdfca2e57142f0c182e7040af563bb6c729e1c4428dece269cef7e60407a08a3428898c8cf66b8dffc8bf4a29211b960dc40eaf
   languageName: node
   linkType: hard
 
@@ -4170,20 +4289,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.46.0-next.1&npm=1.32.1-next.0, @backstage/plugin-catalog@npm:1.32.1-next.0, @backstage/plugin-catalog@npm:^1.32.1-next.0":
-  version: 1.32.1-next.0
-  resolution: "@backstage/plugin-catalog@npm:1.32.1-next.0"
+"@backstage/plugin-catalog@backstage:^::backstage=1.46.0-next.2&npm=1.32.1-next.1, @backstage/plugin-catalog@npm:1.32.1-next.1, @backstage/plugin-catalog@npm:^1.32.1-next.1":
+  version: 1.32.1-next.1
+  resolution: "@backstage/plugin-catalog@npm:1.32.1-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/core-compat-api": "npm:0.5.5-next.0"
-    "@backstage/core-components": "npm:0.18.4-next.0"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
     "@backstage/integration-react": "npm:1.2.13-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-react": "npm:1.21.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.4-next.2"
     "@backstage/plugin-permission-react": "npm:0.4.39-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.7.4-next.0"
     "@backstage/plugin-search-common": "npm:1.2.21"
@@ -4212,60 +4331,60 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3e18ac83fc4923e53e49636c597f5433476e639989e5bc1770e9769fd0cbf409d7288c13a4a020f8dfafab925a39cfa68aa99bb2db6b121de5c546457ebd3929
+  checksum: 10/348d97ea3627fb488e023f43fabc84640f18c3e5dd7a640279c5849ec1ee7c188b863b98a1bc609d67a8f9693a1ba1593cc902d7f19ce81f324891496c56b600
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.46.0-next.1&npm=0.4.7-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.7-next.0":
-  version: 0.4.7-next.0
-  resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.7-next.0"
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.46.0-next.2&npm=0.4.7-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.7-next.1":
+  version: 0.4.7-next.1
+  resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.7-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.18-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.18-next.1"
     "@backstage/types": "npm:1.2.2"
     "@octokit/auth-callback": "npm:^5.0.0"
     "@octokit/webhooks-methods": "npm:^3.0.0"
     lodash: "npm:^4.17.21"
     octokit: "npm:^3.0.0"
-  checksum: 10/bd16d2ffa8aee1d258568bf079c797b20d228780073e8512844cbf1db4788ad6e27848b6a026fa0f53b133f697dd28c3e63aff844e89132061f3df06847446c0
+  checksum: 10/f91c770e01cf11e7bc337fa6901c80a2ba0e307922444cf33de9914a8196044df78dce60c69bd0da4e4e5aed994aac26c86aa512fd14af13b7be7b2afdbcdd80
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.46.0-next.1&npm=0.5.9-next.0, @backstage/plugin-events-backend@npm:^0.5.9-next.0":
-  version: 0.5.9-next.0
-  resolution: "@backstage/plugin-events-backend@npm:0.5.9-next.0"
+"@backstage/plugin-events-backend@backstage:^::backstage=1.46.0-next.2&npm=0.5.9-next.1, @backstage/plugin-events-backend@npm:^0.5.9-next.1":
+  version: 0.5.9-next.1
+  resolution: "@backstage/plugin-events-backend@npm:0.5.9-next.1"
   dependencies:
-    "@backstage/backend-openapi-utils": "npm:0.6.4-next.0"
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-openapi-utils": "npm:0.6.4-next.1"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-events-node": "npm:0.4.18-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.18-next.1"
     "@backstage/types": "npm:1.2.2"
     "@types/express": "npm:^4.17.6"
     content-type: "npm:^1.0.5"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
-  checksum: 10/b5da5b76780d1854de604c8d5b969cd967f06b27d98a737a8b4fd79dcfd606a4790141121422d12044843d8201a58435c64031c24ca092187e745cd44c8e82a2
+  checksum: 10/44318d681ca9655747ec01bce467c2e574fdbbc919dfd8414df3af4796274cb6c79bc86e700b8e6c625ecdb09582948ea183c066dd302ea8ce400be924d67f7c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-node@npm:0.4.18-next.0":
-  version: 0.4.18-next.0
-  resolution: "@backstage/plugin-events-node@npm:0.4.18-next.0"
+"@backstage/plugin-events-node@npm:0.4.18-next.1":
+  version: 0.4.18-next.1
+  resolution: "@backstage/plugin-events-node@npm:0.4.18-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/types": "npm:1.2.2"
     "@types/content-type": "npm:^1.1.8"
     "@types/express": "npm:^4.17.6"
     content-type: "npm:^1.0.5"
     cross-fetch: "npm:^4.0.0"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     uri-template: "npm:^2.0.0"
-  checksum: 10/0c5375dffc6cd47ae8aeb28d203ae0fd88eec1a04841059bdb39b1d06f6bee773fe337a5478c689c56fcf0e81e2273461b119b0394a39de270c36acd01d09ff2
+  checksum: 10/c31b4766addba9b1a2eb2011bdf9a043e9f8361a9ba6aa8a46bd985a32e84e5dc306cc25f0000078771368efefad40c17386970ccda8ba60d5f57e54a632247b
   languageName: node
   linkType: hard
 
@@ -4286,16 +4405,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@npm:0.1.33-next.0":
-  version: 0.1.33-next.0
-  resolution: "@backstage/plugin-home-react@npm:0.1.33-next.0"
+"@backstage/plugin-home-react@npm:0.1.33-next.1":
+  version: 0.1.33-next.1
+  resolution: "@backstage/plugin-home-react@npm:0.1.33-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.4-next.0"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
-    "@rjsf/utils": "npm:5.23.2"
+    "@rjsf/utils": "npm:5.24.13"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
@@ -4304,31 +4423,31 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8a2c2ab5c88d3a4d21f11852d466706052ef583bdd0a0c60c42df11b3b4aa5fad1b2b8d5221723e1812af9b9f27343089f18d1cf074d3524356d7a3fe47b76f7
+  checksum: 10/40e72409a2657c16556a615c3483ab571f9eb6467b61ebbaa782ec4ac2aa2bab3a6dad5c3fbeed076017987152ac475eb24ed4444b825cbd94a288d974bae669
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.46.0-next.1&npm=0.8.15-next.0, @backstage/plugin-home@npm:^0.8.15-next.0":
-  version: 0.8.15-next.0
-  resolution: "@backstage/plugin-home@npm:0.8.15-next.0"
+"@backstage/plugin-home@backstage:^::backstage=1.46.0-next.2&npm=0.8.15-next.1, @backstage/plugin-home@npm:^0.8.15-next.1":
+  version: 0.8.15-next.1
+  resolution: "@backstage/plugin-home@npm:0.8.15-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-app-api": "npm:1.19.3-next.0"
-    "@backstage/core-components": "npm:0.18.4-next.0"
+    "@backstage/core-app-api": "npm:1.19.3-next.1"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.4-next.0"
-    "@backstage/plugin-home-react": "npm:0.1.33-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.21.4-next.2"
+    "@backstage/plugin-home-react": "npm:0.1.33-next.1"
     "@backstage/theme": "npm:0.7.1-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@rjsf/core": "npm:5.23.2"
-    "@rjsf/material-ui": "npm:5.23.2"
-    "@rjsf/utils": "npm:5.23.2"
-    "@rjsf/validator-ajv8": "npm:5.23.2"
+    "@rjsf/core": "npm:5.24.13"
+    "@rjsf/material-ui": "npm:5.24.13"
+    "@rjsf/utils": "npm:5.24.13"
+    "@rjsf/validator-ajv8": "npm:5.24.13"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.4.3"
     react-grid-layout: "npm:1.3.4"
@@ -4343,42 +4462,42 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1790871ccf661088c830c6fa27080a48c31532ceafed612a19945ef80a38087ea73c3beb86196d055fd2546c4aa916e4b42d0f07940b9151c886fddc2c9090d0
+  checksum: 10/0463d1ff96ec81124b6c3b6d870801b0805afe5818eceeb1f67a9332228bf10a250fc472650f799445ec2b9f74626a8792565bfaa438ba8013f51a1c3c9e9474
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.46.0-next.1&npm=0.20.5-next.1, @backstage/plugin-kubernetes-backend@npm:^0.20.5-next.1":
-  version: 0.20.5-next.1
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.20.5-next.1"
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.46.0-next.2&npm=0.21.0-next.2, @backstage/plugin-kubernetes-backend@npm:^0.21.0-next.2":
+  version: 0.21.0-next.2
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.0-next.2"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@azure/identity": "npm:^4.0.0"
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration-aws-node": "npm:0.1.19"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
     "@backstage/plugin-kubernetes-common": "npm:0.9.9-next.0"
-    "@backstage/plugin-kubernetes-node": "npm:0.3.7-next.1"
+    "@backstage/plugin-kubernetes-node": "npm:0.4.0-next.2"
     "@backstage/plugin-permission-common": "npm:0.9.3"
-    "@backstage/plugin-permission-node": "npm:0.10.7-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.7-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/container": "npm:^5.0.0"
     "@jest-mock/express": "npm:^2.0.1"
     "@kubernetes/client-node": "npm:1.4.0"
     "@smithy/signature-v4": "npm:^4.1.0"
     "@types/http-proxy-middleware": "npm:^1.0.0"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
     http-proxy-middleware: "npm:^2.0.6"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     node-fetch: "npm:^2.7.0"
-  checksum: 10/8181af68ff979d6306c64d06047dd21238461f606d3be14072e26b03fc16e9706ac4bc3a926ab349d5055bebdf7950e24474afe9d9c8562aa7eae4611c687059
+  checksum: 10/f900f901632703fb964c996b5d5c638d5551aa6721d7a67f600af147140f3a858d8ed60b9579f1168f6bbc737c6fd1d9c27b52c6bb18e07aa7c4f926faca42f0
   languageName: node
   linkType: hard
 
@@ -4397,18 +4516,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-node@npm:0.3.7-next.1":
-  version: 0.3.7-next.1
-  resolution: "@backstage/plugin-kubernetes-node@npm:0.3.7-next.1"
+"@backstage/plugin-kubernetes-node@npm:0.4.0-next.2":
+  version: 0.4.0-next.2
+  resolution: "@backstage/plugin-kubernetes-node@npm:0.4.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/plugin-kubernetes-common": "npm:0.9.9-next.0"
     "@backstage/types": "npm:1.2.2"
     "@kubernetes/client-node": "npm:1.4.0"
+    "@types/express": "npm:^4.17.6"
     node-fetch: "npm:^2.7.0"
     winston: "npm:^3.2.1"
-  checksum: 10/7b5ddfae82f3da522e7d7f7b5858408f1b9b45c026396bdc23964defe8380b8f8951892217e3b53528bc163e629e0da535dc66948c66877a73e34e2d85ebc8ae
+  checksum: 10/9e89237ea048fcdbdd2ee2d5e8ef0566f9729552e0ce309ef72be31ba630025884f6203048c7982a630f7d76ac29e9277f2dc4f3a60fcf38e922c066b6cd8e97
   languageName: node
   linkType: hard
 
@@ -4449,7 +4569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.46.0-next.1&npm=0.12.14-next.1, @backstage/plugin-kubernetes@npm:^0.12.14-next.1":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.46.0-next.2&npm=0.12.14-next.1, @backstage/plugin-kubernetes@npm:^0.12.14-next.1":
   version: 0.12.14-next.1
   resolution: "@backstage/plugin-kubernetes@npm:0.12.14-next.1"
   dependencies:
@@ -4474,25 +4594,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.46.0-next.1&npm=0.6.1-next.0, @backstage/plugin-notifications-backend@npm:^0.6.1-next.0":
-  version: 0.6.1-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.6.1-next.0"
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.46.0-next.2&npm=0.6.1-next.1, @backstage/plugin-notifications-backend@npm:^0.6.1-next.1":
+  version: 0.6.1-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.6.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
     "@backstage/plugin-notifications-common": "npm:0.2.0"
-    "@backstage/plugin-notifications-node": "npm:0.2.22-next.0"
-    "@backstage/plugin-signals-node": "npm:0.1.27-next.0"
+    "@backstage/plugin-notifications-node": "npm:0.2.22-next.1"
+    "@backstage/plugin-signals-node": "npm:0.1.27-next.1"
     "@backstage/types": "npm:1.2.2"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     p-throttle: "npm:^4.1.1"
     uuid: "npm:^11.0.0"
-  checksum: 10/51238f17ae4da10cda01bbf354c5a3f877fc7c77faf808eeab88ff5c994758cf79a79981b7316c400b1b345ecec899b205bcba7d129259bd30b7af3baea5dc55
+  checksum: 10/b2f4f31cb6266ee35a1c5e82a71483e8e25340ccc0150bf6ca16c11708d28fa2571aff11b3fd284be74fb3dfb65bd8ed46864b0dd9cdfb5fa9fec475626dda2c
   languageName: node
   linkType: hard
 
@@ -4507,22 +4627,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.46.0-next.1&npm=0.2.22-next.0, @backstage/plugin-notifications-node@npm:0.2.22-next.0, @backstage/plugin-notifications-node@npm:^0.2.22-next.0":
-  version: 0.2.22-next.0
-  resolution: "@backstage/plugin-notifications-node@npm:0.2.22-next.0"
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.46.0-next.2&npm=0.2.22-next.1, @backstage/plugin-notifications-node@npm:0.2.22-next.1, @backstage/plugin-notifications-node@npm:^0.2.22-next.1":
+  version: 0.2.22-next.1
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.22-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/plugin-notifications-common": "npm:0.2.0"
-    "@backstage/plugin-signals-node": "npm:0.1.27-next.0"
+    "@backstage/plugin-signals-node": "npm:0.1.27-next.1"
     knex: "npm:^3.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/80e133507b245346c8369b2c8490d65cdb721c456bc3f8150c25be0df75ba05dee1dc987175860c03672f1862813e7ae304dee5205607a8c695a2afb6137dc35
+  checksum: 10/d9037bb2592280f96743e93ff3e4667379e9801021c3f94c4be77b3b93f53131e2d005446f5cd020d59b0b5e7c0955d142362b03907e6bcbc4b25473568626a4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.46.0-next.1&npm=0.5.12-next.0, @backstage/plugin-notifications@npm:^0.5.12-next.0":
+"@backstage/plugin-notifications@backstage:^::backstage=1.46.0-next.2&npm=0.5.12-next.0, @backstage/plugin-notifications@npm:^0.5.12-next.0":
   version: 0.5.12-next.0
   resolution: "@backstage/plugin-notifications@npm:0.5.12-next.0"
   dependencies:
@@ -4552,16 +4672,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.46.0-next.1&npm=0.6.47-next.0, @backstage/plugin-org@npm:^0.6.47-next.0":
-  version: 0.6.47-next.0
-  resolution: "@backstage/plugin-org@npm:0.6.47-next.0"
+"@backstage/plugin-org@backstage:^::backstage=1.46.0-next.2&npm=0.6.47-next.1, @backstage/plugin-org@npm:^0.6.47-next.1":
+  version: 0.6.47-next.1
+  resolution: "@backstage/plugin-org@npm:0.6.47-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4-next.0"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-react": "npm:1.21.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.4-next.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -4578,7 +4698,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6020ae040195a159a349a3fdaef49ae3d92da6b126ed0b4ef0d6665b9a8b88ffc966a81bc084d833bfd08be4c245d58e0776901ac151ca32f5b95b46469b6a2e
+  checksum: 10/308eb878e569779a54d35050e31cb383f4eb9f62614e3b7ad78ca5b07a1eced9576e1db0814de4d818e8459bfe8f9ffcc4fded544498cf01da2fe8d4a89b705f
   languageName: node
   linkType: hard
 
@@ -4612,21 +4732,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:0.10.7-next.0":
-  version: 0.10.7-next.0
-  resolution: "@backstage/plugin-permission-node@npm:0.10.7-next.0"
+"@backstage/plugin-permission-node@npm:0.10.7-next.1":
+  version: 0.10.7-next.1
+  resolution: "@backstage/plugin-permission-node@npm:0.10.7-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-auth-node": "npm:0.6.10-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.10-next.1"
     "@backstage/plugin-permission-common": "npm:0.9.3"
     "@types/express": "npm:^4.17.6"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/4504d7ed310ccc6bd148326c9213e01303fa451f9db9f32cd27e076366808b2159a2969d02319a13e08afe499c9e7128fee2c439c6c504ee56971e1240dff3d2
+  checksum: 10/91041754c39f06cfa06a5d11b0daf76ae04ff5e16273279077eef69fac49e32f7206bb8b7586f038fd8c007f31e3475677c22475e1d0f2071aaaa63cb8525919
   languageName: node
   linkType: hard
 
@@ -4668,133 +4788,133 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.46.0-next.1&npm=0.6.9-next.0, @backstage/plugin-proxy-backend@npm:^0.6.9-next.0":
-  version: 0.6.9-next.0
-  resolution: "@backstage/plugin-proxy-backend@npm:0.6.9-next.0"
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.46.0-next.2&npm=0.6.9-next.1, @backstage/plugin-proxy-backend@npm:^0.6.9-next.1":
+  version: 0.6.9-next.1
+  resolution: "@backstage/plugin-proxy-backend@npm:0.6.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
-    "@backstage/plugin-proxy-node": "npm:0.1.11-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
+    "@backstage/plugin-proxy-node": "npm:0.1.11-next.1"
     "@backstage/types": "npm:1.2.2"
     express-promise-router: "npm:^4.1.0"
     http-proxy-middleware: "npm:^2.0.0"
-  checksum: 10/1ddacf8cf13100ad31dcc3d8c68ece72298d0960fde628f490ca9bbefa61be2d376706920d3161cb5e5b2d6338f7dafc14818ab9554c7d05323dd95362c9f345
+  checksum: 10/d10c0787b5c1bf7f3e78cc228dfd1f001d02d17fdf7d42e7f4fea2e8d7ab0a02d6ab7f9dd96e32171c655fd0719f8552056d3a142e00480995e957837caa249c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-node@npm:0.1.11-next.0":
-  version: 0.1.11-next.0
-  resolution: "@backstage/plugin-proxy-node@npm:0.1.11-next.0"
+"@backstage/plugin-proxy-node@npm:0.1.11-next.1":
+  version: 0.1.11-next.1
+  resolution: "@backstage/plugin-proxy-node@npm:0.1.11-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     http-proxy-middleware: "npm:^2.0.0"
-  checksum: 10/add14670035e5fd94178a7f380ce17a62439f800dea1ac4ff2f8f4cba6e6f7355a4981d7ea6f52b9cd2be4eaeed99ffa32d3a0bce59fa17d5e0b1ae0d50cf618
+  checksum: 10/87b56306401b784087236331bead5da3a0aa26d0cf3830a32eb5494e8af644a4588d5df318629b91f1f3a6313879068dbf6d45df3602a549d0b738323e5cb1bf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.16-next.0":
-  version: 0.2.16-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.16-next.0"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.16-next.1":
+  version: 0.2.16-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     azure-devops-node-api: "npm:^14.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/99e804ea336e283554420bad92ec6896a20d62aa57e4dea66d0ab93951a09900471f71f24ccbf8708e7815e99d4d7974498c43b9c69758c0e960598bb4e1693e
+  checksum: 10/63d9ec2129c7c4cff5a84ea1569c81d3bb75954b1e5ceb9fd74b9fb2afb6d537778dacd7ce0c9f71d5bcc58474bea2b2e440dcf8c413359821902bf3539f2ea3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.16-next.0":
-  version: 0.2.16-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.16-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.16-next.1":
+  version: 0.2.16-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
     "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.5-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     bitbucket: "npm:^2.12.0"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/2b096403c5b862a19c2a212c74f9c6524803c3da79c7efc1f83aa3ec04da6da406cd37ae07fc3b73f7711414e5298631a7162bf19065f423a0035c25c9458474
+  checksum: 10/576b7ea793a426868d1715f9fc6b9a0d0d6285b04d8593ef96911b1f869275ccb7d36e872af4e83978a509edea82ba5d42b3c99a64bcc7411801e803d0038a38
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.16-next.0":
-  version: 0.2.16-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.16-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.16-next.1":
+  version: 0.2.16-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/7ee6d440346201f902415a7e91491df31c8fc8dce0b73351b89155dd6457d70b8095f60e4f3a8b261495a9e02ee517e60f09acc03a9b31b6253a9bef7cb9eb15
+  checksum: 10/846339b81c596157e1159e7b1ce0ffeae151b7cbb5080f54c7c186e03145c0f1702b63fdf6faab467bc04bd46986d818d4bd7383832a307264b1e4651c378656
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.17-next.0":
-  version: 0.3.17-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.17-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.17-next.1":
+  version: 0.3.17-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.17-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.16-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.16-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.16-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.16-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/58361135ff61364f6b034b490c4e8a322c2b13da286dbdd40eee18f5c97e8e1f987bed5c92490595856484456a8fd3dce41c8ceae3c3e5bb1fbc6440ef9326ad
+  checksum: 10/902d151e797b70fe90903fdeccf2d46bf51783646b2ba4f82cd00012eada50078de261ded6948cccdf129f46d00c509f5d58af0dced2be5da7ac96d6fd4c889c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.16-next.0":
-  version: 0.2.16-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.16-next.0"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.16-next.1":
+  version: 0.2.16-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/ada28e4210b64f24e9326011ad4b079be07ddd40a83426102d853cc6244e82994a8b430f67cc61d213cb6dc795e29425d808b41b7a04f89e8bc1350998aeb8a4
+  checksum: 10/b1a4f285fd10b36bb5c8257f72d7c8ca56f745ec9f588418e2ffc5f75ca12da6c072fd964ba209c636a3396a24c73d259abca964dd0b0d5f3865f14412ceeeed
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.16-next.0":
-  version: 0.2.16-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.16-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.16-next.1":
+  version: 0.2.16-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/abad1ac0ab6dd106c2434f5995a3f256680ee9747a6d0afb89be759d31ddc54e995b70db96460c1ccb080243aa090349386d967216e8288ea39df567231c9832
+  checksum: 10/5f000ce61fdf0662b105a8fe812f8987fd477de8c828c984964a5345bb8e08652a4017fbd7c189acf09d2f6245ce9cef639ea57654573c486a1b9b9f61cbf20d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.46.0-next.1&npm=0.9.3-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.3-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.3-next.0":
-  version: 0.9.3-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.3-next.0"
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.46.0-next.2&npm=0.9.3-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.3-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.3-next.1":
+  version: 0.9.3-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.3-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     "@backstage/types": "npm:1.2.2"
     "@octokit/webhooks": "npm:^10.9.2"
     libsodium-wrappers: "npm:^0.7.11"
@@ -4802,78 +4922,78 @@ __metadata:
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/c8afa73ae0daa256e38a3663c60a02093bb627015896bb0e8818d4a780efea0b66db5aa5c23191ccb6bda176bd4397cf873dc685ad87230eba329be81d0637c3
+  checksum: 10/7775237c431255f3fde3a57b6ab92d52701c9f776b890c4bc39a0d83b4bb369661c00f1f156f1258fd789c4126cc19330f7d0f7ce8506eba04de452851c457a3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.10.1-next.0":
-  version: 0.10.1-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.10.1-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.11.0-next.1":
+  version: 0.11.0-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.11.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     "@gitbeaker/requester-utils": "npm:^41.2.0"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/549db60edc04d030885707cb9f7137bc3384f495e96c7171615c190b2940bd1534be8ad1ec68ccd8f8e70c4dfef4a05be7c04e32df9797d8ccb265a5d6bb7241
+  checksum: 10/4363923cf2492b02f9a6d87d7dc8633c95e6457641d22c53f5b95f4d06402d224ebc1a4fa0058a2505d8981bf2e4e54b84ec23c26ab3806a0dcc40b51f75be71
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.46.0-next.1&npm=0.1.17-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.17-next.0":
-  version: 0.1.17-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.17-next.0"
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.46.0-next.2&npm=0.1.17-next.1, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.17-next.1":
+  version: 0.1.17-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.17-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/plugin-notifications-common": "npm:0.2.0"
-    "@backstage/plugin-notifications-node": "npm:0.2.22-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/plugin-notifications-node": "npm:0.2.22-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/648d6e6742b828694e0d0dbc97b7dcb01c478969001b43e65bc640af96ffa76736bd09060aba436b6b5a543c5e895bdec680af4128eef5c004683333a6082ac5
+  checksum: 10/ca7f23042770e0a15928854d89215e19bdda41ea512a492d6cca85d9823579bd4ea91aa6445b31322bbfc53c1c33a841c8d49c725b00c38741db866b65dcca05
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.46.0-next.1&npm=3.1.0-next.0, @backstage/plugin-scaffolder-backend@npm:^3.1.0-next.0":
-  version: 3.1.0-next.0
-  resolution: "@backstage/plugin-scaffolder-backend@npm:3.1.0-next.0"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.46.0-next.2&npm=3.1.0-next.1, @backstage/plugin-scaffolder-backend@npm:^3.1.0-next.1":
+  version: 3.1.0-next.1
+  resolution: "@backstage/plugin-scaffolder-backend@npm:3.1.0-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.14.0-next.0"
-    "@backstage/backend-openapi-utils": "npm:0.6.4-next.0"
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-defaults": "npm:0.14.0-next.1"
+    "@backstage/backend-openapi-utils": "npm:0.6.4-next.1"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.10-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.10-next.1"
     "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.5-next.0"
-    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.15-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.18-next.0"
+    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.15-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.18-next.1"
     "@backstage/plugin-permission-common": "npm:0.9.3"
-    "@backstage/plugin-permission-node": "npm:0.10.7-next.0"
-    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.16-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.17-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.16-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.16-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.16-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.16-next.0"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.9.3-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.10.1-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.7-next.1"
+    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.16-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.17-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.2.16-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.16-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.16-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.16-next.1"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.9.3-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.11.0-next.1"
     "@backstage/plugin-scaffolder-common": "npm:1.7.4-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.2-next.1"
     "@backstage/types": "npm:1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/luxon": "npm:^3.0.0"
     concat-stream: "npm:^2.0.0"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
     globby: "npm:^11.0.0"
     isbinaryfile: "npm:^5.0.0"
-    isolated-vm: "npm:^5.0.1"
+    isolated-vm: "npm:^6.0.1"
     jsonschema: "npm:^1.5.0"
     knex: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
@@ -4892,7 +5012,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/e3c9041980a1031ac1de27c158effb5e3339708ca6e8cb04e4abf40b79aaf21fd16e5a7572a731bda0aa4d0f352732d45b477de114f9d80b6228d09e8709ef57
+  checksum: 10/bde7d2dfcc4659367cc2bfea3115b4a0a7eee676581bb2b51a07a9ef91cc19ca2ed76959c5ce35144a96f5602bc6f979738699bb70a454bfa09109e03d13912e
   languageName: node
   linkType: hard
 
@@ -4915,14 +5035,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:0.12.2-next.0":
-  version: 0.12.2-next.0
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.12.2-next.0"
+"@backstage/plugin-scaffolder-node@npm:0.12.2-next.1":
+  version: 0.12.2-next.1
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.12.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
     "@backstage/plugin-permission-common": "npm:0.9.3"
     "@backstage/plugin-scaffolder-common": "npm:1.7.4-next.0"
     "@backstage/types": "npm:1.2.2"
@@ -4939,20 +5059,20 @@ __metadata:
     winston-transport: "npm:^4.7.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/f050a2c809c2e9e1432fdd51c219d80fe8aa033a53af16fd85790391a7aee0d9b698d1f0ea187f69258e6a03bdf8c83a21d38924b70df5b993864caa6bbcd046
+  checksum: 10/b8639331b7dadbea92abbf7b104119cb3f30132efa248539992c703f178f300e2c97e7f15e9b81f03ddd8ccc1118bc5dfbf7f27f7dc59d40a0c7def8b2e1d919
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.19.4-next.0":
-  version: 1.19.4-next.0
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.19.4-next.0"
+"@backstage/plugin-scaffolder-react@npm:1.19.4-next.2":
+  version: 1.19.4-next.2
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.19.4-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4-next.0"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.4-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.21.4-next.2"
     "@backstage/plugin-permission-react": "npm:0.4.39-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.7.4-next.0"
     "@backstage/theme": "npm:0.7.1-next.0"
@@ -4962,10 +5082,10 @@ __metadata:
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
     "@react-hookz/web": "npm:^24.0.0"
-    "@rjsf/core": "npm:5.23.2"
-    "@rjsf/material-ui": "npm:5.23.2"
-    "@rjsf/utils": "npm:5.23.2"
-    "@rjsf/validator-ajv8": "npm:5.23.2"
+    "@rjsf/core": "npm:5.24.13"
+    "@rjsf/material-ui": "npm:5.24.13"
+    "@rjsf/utils": "npm:5.24.13"
+    "@rjsf/validator-ajv8": "npm:5.24.13"
     "@types/json-schema": "npm:^7.0.9"
     ajv: "npm:^8.0.1"
     ajv-errors: "npm:^3.0.0"
@@ -4979,7 +5099,7 @@ __metadata:
     luxon: "npm:^3.0.0"
     qs: "npm:^6.9.4"
     react-use: "npm:^17.2.4"
-    use-immer: "npm:^0.10.0"
+    use-immer: "npm:^0.11.0"
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
@@ -4991,27 +5111,27 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fe4d6bc7be288e598c28f8ea6d165d2250c04f56b492f6033dd8034be3875ee37d4134383a55bd09a9a744126c7645ccdef03c1008f88150fe6755d8af337a53
+  checksum: 10/8af8b24696abcca4ce0d45e9c468d189269fa99345684be7f937d5db49ba7775e7dcd2d1ba98b29963aa9c59367113bf83fa8faf826727178d7fe3d6e1076542
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.46.0-next.1&npm=1.34.4-next.0, @backstage/plugin-scaffolder@npm:^1.34.4-next.0":
-  version: 1.34.4-next.0
-  resolution: "@backstage/plugin-scaffolder@npm:1.34.4-next.0"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.46.0-next.2&npm=1.34.4-next.1, @backstage/plugin-scaffolder@npm:^1.34.4-next.1":
+  version: 1.34.4-next.1
+  resolution: "@backstage/plugin-scaffolder@npm:1.34.4-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4-next.0"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
-    "@backstage/integration": "npm:1.18.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
+    "@backstage/integration": "npm:1.18.3-next.1"
     "@backstage/integration-react": "npm:1.2.13-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-react": "npm:1.21.4-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.4-next.2"
     "@backstage/plugin-permission-react": "npm:0.4.39-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.7.4-next.0"
-    "@backstage/plugin-scaffolder-react": "npm:1.19.4-next.0"
+    "@backstage/plugin-scaffolder-react": "npm:1.19.4-next.2"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.6-next.0"
     "@backstage/types": "npm:1.2.2"
@@ -5022,10 +5142,10 @@ __metadata:
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
     "@react-hookz/web": "npm:^24.0.0"
-    "@rjsf/core": "npm:5.23.2"
-    "@rjsf/material-ui": "npm:5.23.2"
-    "@rjsf/utils": "npm:5.23.2"
-    "@rjsf/validator-ajv8": "npm:5.23.2"
+    "@rjsf/core": "npm:5.24.13"
+    "@rjsf/material-ui": "npm:5.24.13"
+    "@rjsf/utils": "npm:5.24.13"
+    "@rjsf/validator-ajv8": "npm:5.24.13"
     "@uiw/react-codemirror": "npm:^4.9.3"
     classnames: "npm:^2.2.6"
     git-url-parse: "npm:^15.0.0"
@@ -5052,33 +5172,33 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/421c3b2385aa56e0bae23ac92dddeec1c284969be4ff4e4e9210c74456ae6979e783f68379dcfe6cab1424a34af6c11513c8963fb51d8cf1bf6ee78bcd005bb6
+  checksum: 10/c36debd8e267a24cb7326ca002058331e6dd90593f2a4fbce4407cefb0cca63706d6ef3113241d43362ea6a3f3c96eef74bbe3095b7378791b9ca2ca1cab6396
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.46.0-next.1&npm=0.3.11-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.11-next.0":
-  version: 0.3.11-next.0
-  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.11-next.0"
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.46.0-next.2&npm=0.3.11-next.1, @backstage/plugin-search-backend-module-catalog@npm:^0.3.11-next.1":
+  version: 0.3.11-next.1
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.11-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
     "@backstage/plugin-permission-common": "npm:0.9.3"
-    "@backstage/plugin-search-backend-node": "npm:1.4.0-next.0"
+    "@backstage/plugin-search-backend-node": "npm:1.4.0-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21"
-  checksum: 10/7edd329479207d3313a56a0ae14a624cfb17c4ca1bd64231572675a3bbc3782d335dbfc434ab311b39242e2c29ea1539f368bc5a47891eb37b136a62beba7926
+  checksum: 10/02859ac095dde11a6d2695b4a471a483656346ffa5d15b5e32c5bee87d723d6d492079118d670489f3d147e3577473841105af6f8b433858ef9d17d93bdcfd9d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-node@npm:1.4.0-next.0":
-  version: 1.4.0-next.0
-  resolution: "@backstage/plugin-search-backend-node@npm:1.4.0-next.0"
+"@backstage/plugin-search-backend-node@npm:1.4.0-next.1":
+  version: 1.4.0-next.1
+  resolution: "@backstage/plugin-search-backend-node@npm:1.4.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-permission-common": "npm:0.9.3"
@@ -5088,7 +5208,7 @@ __metadata:
     lunr: "npm:^2.3.9"
     ndjson: "npm:^2.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/0451b655cbc6570eea6bf594b9aa91959ec762cb2b2866b4644e071fa39b710b69b215d7b9c4f186b25fafed66e41d1fd59d92d0de3abb3ada64a565ec05be15
+  checksum: 10/887f2e3bd4c303a2f8d265279fbc0bc27e5025e3900095fb0476196586d9f6585fc6efa80df20209a8d96b2cad6a6c86770e1939f92e67ae0fdc382335d4c944
   languageName: node
   linkType: hard
 
@@ -5110,27 +5230,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.46.0-next.1&npm=2.0.9-next.0, @backstage/plugin-search-backend@npm:^2.0.9-next.0":
-  version: 2.0.9-next.0
-  resolution: "@backstage/plugin-search-backend@npm:2.0.9-next.0"
+"@backstage/plugin-search-backend@backstage:^::backstage=1.46.0-next.2&npm=2.0.9-next.1, @backstage/plugin-search-backend@npm:^2.0.9-next.1":
+  version: 2.0.9-next.1
+  resolution: "@backstage/plugin-search-backend@npm:2.0.9-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.14.0-next.0"
-    "@backstage/backend-openapi-utils": "npm:0.6.4-next.0"
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-defaults": "npm:0.14.0-next.1"
+    "@backstage/backend-openapi-utils": "npm:0.6.4-next.1"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/plugin-permission-common": "npm:0.9.3"
-    "@backstage/plugin-permission-node": "npm:0.10.7-next.0"
-    "@backstage/plugin-search-backend-node": "npm:1.4.0-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.7-next.1"
+    "@backstage/plugin-search-backend-node": "npm:1.4.0-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21"
     "@backstage/types": "npm:1.2.2"
     dataloader: "npm:^2.0.0"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     lodash: "npm:^4.17.21"
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/34682ccd76a4faed5b2255babf2087c6a1fc5f22f8aa455a75befce194ebd790b60209875ee51614bad71e12ee112477307effee3df0723c5d75c77818169a66
+  checksum: 10/9fb41c1c19063ad5be6f69b97d9f366778da3c7c09fea16419092803edb40496d03e4b934d370b02a5230b1ee1e6728634452b5a22692b9c0454622dac94eb78
   languageName: node
   linkType: hard
 
@@ -5144,7 +5264,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.46.0-next.1&npm=1.10.1-next.0, @backstage/plugin-search-react@npm:1.10.1-next.0, @backstage/plugin-search-react@npm:^1.10.1-next.0":
+"@backstage/plugin-search-react@backstage:^::backstage=1.46.0-next.2&npm=1.10.1-next.0, @backstage/plugin-search-react@npm:1.10.1-next.0, @backstage/plugin-search-react@npm:^1.10.1-next.0":
   version: 1.10.1-next.0
   resolution: "@backstage/plugin-search-react@npm:1.10.1-next.0"
   dependencies:
@@ -5204,15 +5324,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.46.0-next.1&npm=1.5.1-next.0, @backstage/plugin-search@npm:^1.5.1-next.0":
-  version: 1.5.1-next.0
-  resolution: "@backstage/plugin-search@npm:1.5.1-next.0"
+"@backstage/plugin-search@backstage:^::backstage=1.46.0-next.2&npm=1.5.1-next.1, @backstage/plugin-search@npm:^1.5.1-next.1":
+  version: 1.5.1-next.1
+  resolution: "@backstage/plugin-search@npm:1.5.1-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.4-next.0"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.4-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.21.4-next.2"
     "@backstage/plugin-search-common": "npm:1.2.21"
     "@backstage/plugin-search-react": "npm:1.10.1-next.0"
     "@backstage/types": "npm:1.2.2"
@@ -5229,40 +5349,40 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6f7a846542d6c4c39d4bba82dda3fdafb19cd203ecb9566dff06d236163a223198f152dbb68399726aae086082192d07b8909132c1a9e433bad89697e3caaa93
+  checksum: 10/adaf9889b29e5b3e5fe38808f264bbb094bf5afe71fce287a643c6a2d1094dc6d64429af86a39ba3bc72950e07adeba74e10467497f496338ec19e86213b87ba
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.46.0-next.1&npm=0.3.11-next.0, @backstage/plugin-signals-backend@npm:^0.3.11-next.0":
-  version: 0.3.11-next.0
-  resolution: "@backstage/plugin-signals-backend@npm:0.3.11-next.0"
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.46.0-next.2&npm=0.3.11-next.1, @backstage/plugin-signals-backend@npm:^0.3.11-next.1":
+  version: 0.3.11-next.1
+  resolution: "@backstage/plugin-signals-backend@npm:0.3.11-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/plugin-events-node": "npm:0.4.18-next.0"
-    "@backstage/plugin-signals-node": "npm:0.1.27-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.18-next.1"
+    "@backstage/plugin-signals-node": "npm:0.1.27-next.1"
     "@backstage/types": "npm:1.2.2"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     uuid: "npm:^11.0.0"
     ws: "npm:^8.18.0"
-  checksum: 10/adc4adcabc9cfac9c33f215703e372de1b74489fd0868eb26c5dde63018812c3b11b3c315316ce376fa3239e2a1aed1b21e9c57b3313425ded0f0b6539538be2
+  checksum: 10/01197d46e3633d015459df3d4938f88731b6ea60033ddfc7ee373e7bb83d492bc8409d2fb15e23eb0ace2096f7d1614996eb8163e6adfb7304853a507efdf3fb
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-node@npm:0.1.27-next.0":
-  version: 0.1.27-next.0
-  resolution: "@backstage/plugin-signals-node@npm:0.1.27-next.0"
+"@backstage/plugin-signals-node@npm:0.1.27-next.1":
+  version: 0.1.27-next.1
+  resolution: "@backstage/plugin-signals-node@npm:0.1.27-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/plugin-auth-node": "npm:0.6.10-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.18-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.10-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.18-next.1"
     "@backstage/types": "npm:1.2.2"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     uuid: "npm:^11.0.0"
     ws: "npm:^8.18.0"
-  checksum: 10/3d49b682dd63c189226e8d6cab054f4a64a6759b071b4ebaa119743336335499adae124ac897ada76e999a10ad1a43336aa2564cb5b4cb194a473e46a8def29d
+  checksum: 10/00bd89fbe3179c09e5749558bdcb182f54c77ae15ef590e27654d530f8d35216e01ae285b01880158baa8afdf3240aaefa0d07a57dbf17c35af1e7e878d24281
   languageName: node
   linkType: hard
 
@@ -5285,7 +5405,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.46.0-next.1&npm=0.0.26-next.0, @backstage/plugin-signals@npm:^0.0.26-next.0":
+"@backstage/plugin-signals@backstage:^::backstage=1.46.0-next.2&npm=0.0.26-next.0, @backstage/plugin-signals@npm:^0.0.26-next.0":
   version: 0.0.26-next.0
   resolution: "@backstage/plugin-signals@npm:0.0.26-next.0"
   dependencies:
@@ -5309,27 +5429,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.46.0-next.1&npm=2.1.3-next.1, @backstage/plugin-techdocs-backend@npm:^2.1.3-next.1":
-  version: 2.1.3-next.1
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.1.3-next.1"
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.46.0-next.2&npm=2.1.3-next.2, @backstage/plugin-techdocs-backend@npm:^2.1.3-next.2":
+  version: 2.1.3-next.2
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.1.3-next.2"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.14.0-next.0"
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-defaults": "npm:0.14.0-next.1"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
-    "@backstage/plugin-catalog-node": "npm:1.20.1-next.0"
-    "@backstage/plugin-techdocs-node": "npm:1.13.10-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
+    "@backstage/plugin-catalog-node": "npm:1.20.1-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.13.10-next.1"
     "@backstage/types": "npm:1.2.2"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
     knex: "npm:^3.0.0"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/a85e9e9a2c28bc27c71d7a9cdf3d86c15078e69e757a96263090a1525f643911adbe7e76b93851aa2fbe85cf0469f2ce48d7ff289d471e803a95974770e155ea
+  checksum: 10/d0d9ee5d78834e9296b892eb30552e3cbbf2b80d0503b76e35d068a30537aedf6b78b27e54119f1081be15a515dbb3f50cb8e777ee1113e1abecbcf4e44b341b
   languageName: node
   linkType: hard
 
@@ -5340,7 +5460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.46.0-next.1&npm=1.1.31-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.31-next.1":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.46.0-next.2&npm=1.1.31-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.31-next.1":
   version: 1.1.31-next.1
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.31-next.1"
   dependencies:
@@ -5367,9 +5487,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.46.0-next.1&npm=1.13.10-next.0, @backstage/plugin-techdocs-node@npm:1.13.10-next.0, @backstage/plugin-techdocs-node@npm:^1.13.10-next.0":
-  version: 1.13.10-next.0
-  resolution: "@backstage/plugin-techdocs-node@npm:1.13.10-next.0"
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.46.0-next.2&npm=1.13.10-next.1, @backstage/plugin-techdocs-node@npm:1.13.10-next.1, @backstage/plugin-techdocs-node@npm:^1.13.10-next.1":
+  version: 1.13.10-next.1
+  resolution: "@backstage/plugin-techdocs-node@npm:1.13.10-next.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -5377,11 +5497,11 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-plugin-api": "npm:1.5.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.6.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.18.3-next.0"
+    "@backstage/integration": "npm:1.18.3-next.1"
     "@backstage/integration-aws-node": "npm:0.1.19"
     "@backstage/plugin-search-common": "npm:1.2.21"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
@@ -5390,7 +5510,7 @@ __metadata:
     "@trendyol-js/openstack-swift-sdk": "npm:^0.0.7"
     "@types/express": "npm:^4.17.6"
     dockerode: "npm:^4.0.0"
-    express: "npm:^4.17.1"
+    express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
     git-url-parse: "npm:^15.0.0"
     hpagent: "npm:^1.2.0"
@@ -5400,11 +5520,11 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/8d4d09827b47addb0844b0162953d12f9ae659530f45442a6d4379297b10f469348a79ab859ef54d2383c2957358b2936a2ef1ce96e562956765745c726d9c9f
+  checksum: 10/403605cc7e85e1bd5ff4e3345ed5385a96ed3689ec3645ef8ab922cf0271398fcf4091e0bd59c791ede9399a0af850a92079cd0ee73f74f4476250df456035f1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.46.0-next.1&npm=1.3.6-next.0, @backstage/plugin-techdocs-react@npm:1.3.6-next.0, @backstage/plugin-techdocs-react@npm:^1.3.6-next.0":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.46.0-next.2&npm=1.3.6-next.0, @backstage/plugin-techdocs-react@npm:1.3.6-next.0, @backstage/plugin-techdocs-react@npm:^1.3.6-next.0":
   version: 1.3.6-next.0
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.6-next.0"
   dependencies:
@@ -5462,21 +5582,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.46.0-next.1&npm=1.16.1-next.1, @backstage/plugin-techdocs@npm:^1.16.1-next.1":
-  version: 1.16.1-next.1
-  resolution: "@backstage/plugin-techdocs@npm:1.16.1-next.1"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.46.0-next.2&npm=1.16.1-next.2, @backstage/plugin-techdocs@npm:^1.16.1-next.2":
+  version: 1.16.1-next.2
+  resolution: "@backstage/plugin-techdocs@npm:1.16.1-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-components": "npm:0.18.4-next.1"
+    "@backstage/core-components": "npm:0.18.4-next.2"
     "@backstage/core-plugin-api": "npm:1.12.1-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.13.2-next.0"
-    "@backstage/integration": "npm:1.18.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2-next.1"
+    "@backstage/integration": "npm:1.18.3-next.1"
     "@backstage/integration-react": "npm:1.2.13-next.0"
     "@backstage/plugin-auth-react": "npm:0.1.22-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.4-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.21.4-next.2"
     "@backstage/plugin-search-common": "npm:1.2.21"
     "@backstage/plugin-search-react": "npm:1.10.1-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
@@ -5500,7 +5620,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b3c8e02b4ec72d1946d412e88f28daca7f3f5048212afe3cf7c53caff330c1c8f5da4981bd3fc6bc5c5374832ab116d42278bf8b4c62e8bb48337da460a15a77
+  checksum: 10/72a0fcb6f7de3bbbc6b91c536460082f509089b9f656f30b76945f7595a3e7dd6dd8dbb87bebe332e73474724f598c3cc3ba9fbdd41174504f2caaeb36205b3d
   languageName: node
   linkType: hard
 
@@ -5511,7 +5631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.46.0-next.1&npm=0.8.30-next.0, @backstage/plugin-user-settings@npm:^0.8.30-next.0":
+"@backstage/plugin-user-settings@backstage:^::backstage=1.46.0-next.2&npm=0.8.30-next.0, @backstage/plugin-user-settings@npm:^0.8.30-next.0":
   version: 0.8.30-next.0
   resolution: "@backstage/plugin-user-settings@npm:0.8.30-next.0"
   dependencies:
@@ -5579,7 +5699,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.46.0-next.1&npm=0.7.1-next.0, @backstage/theme@npm:0.7.1-next.0, @backstage/theme@npm:^0.7.1-next.0":
+"@backstage/theme@backstage:^::backstage=1.46.0-next.2&npm=0.7.1-next.0, @backstage/theme@npm:0.7.1-next.0, @backstage/theme@npm:^0.7.1-next.0":
   version: 0.7.1-next.0
   resolution: "@backstage/theme@npm:0.7.1-next.0"
   dependencies:
@@ -5646,7 +5766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.46.0-next.1&npm=0.10.0-next.1, @backstage/ui@npm:^0.10.0-next.1":
+"@backstage/ui@backstage:^::backstage=1.46.0-next.2&npm=0.10.0-next.1, @backstage/ui@npm:^0.10.0-next.1":
   version: 0.10.0-next.1
   resolution: "@backstage/ui@npm:0.10.0-next.1"
   dependencies:
@@ -6157,177 +6277,184 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/aix-ppc64@npm:0.25.1"
+"@esbuild/aix-ppc64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/aix-ppc64@npm:0.27.1"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/android-arm64@npm:0.25.1"
+"@esbuild/android-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/android-arm64@npm:0.27.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/android-arm@npm:0.25.1"
+"@esbuild/android-arm@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/android-arm@npm:0.27.1"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/android-x64@npm:0.25.1"
+"@esbuild/android-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/android-x64@npm:0.27.1"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/darwin-arm64@npm:0.25.1"
+"@esbuild/darwin-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/darwin-arm64@npm:0.27.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/darwin-x64@npm:0.25.1"
+"@esbuild/darwin-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/darwin-x64@npm:0.27.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/freebsd-arm64@npm:0.25.1"
+"@esbuild/freebsd-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.1"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/freebsd-x64@npm:0.25.1"
+"@esbuild/freebsd-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/freebsd-x64@npm:0.27.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/linux-arm64@npm:0.25.1"
+"@esbuild/linux-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-arm64@npm:0.27.1"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/linux-arm@npm:0.25.1"
+"@esbuild/linux-arm@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-arm@npm:0.27.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/linux-ia32@npm:0.25.1"
+"@esbuild/linux-ia32@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-ia32@npm:0.27.1"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/linux-loong64@npm:0.25.1"
+"@esbuild/linux-loong64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-loong64@npm:0.27.1"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/linux-mips64el@npm:0.25.1"
+"@esbuild/linux-mips64el@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-mips64el@npm:0.27.1"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/linux-ppc64@npm:0.25.1"
+"@esbuild/linux-ppc64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-ppc64@npm:0.27.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/linux-riscv64@npm:0.25.1"
+"@esbuild/linux-riscv64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-riscv64@npm:0.27.1"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/linux-s390x@npm:0.25.1"
+"@esbuild/linux-s390x@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-s390x@npm:0.27.1"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/linux-x64@npm:0.25.1"
+"@esbuild/linux-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/linux-x64@npm:0.27.1"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-arm64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/netbsd-arm64@npm:0.25.1"
+"@esbuild/netbsd-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.1"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/netbsd-x64@npm:0.25.1"
+"@esbuild/netbsd-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/netbsd-x64@npm:0.27.1"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-arm64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/openbsd-arm64@npm:0.25.1"
+"@esbuild/openbsd-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.1"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/openbsd-x64@npm:0.25.1"
+"@esbuild/openbsd-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/openbsd-x64@npm:0.27.1"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/sunos-x64@npm:0.25.1"
+"@esbuild/openharmony-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/sunos-x64@npm:0.27.1"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/win32-arm64@npm:0.25.1"
+"@esbuild/win32-arm64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/win32-arm64@npm:0.27.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/win32-ia32@npm:0.25.1"
+"@esbuild/win32-ia32@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/win32-ia32@npm:0.27.1"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.25.1":
-  version: 0.25.1
-  resolution: "@esbuild/win32-x64@npm:0.25.1"
+"@esbuild/win32-x64@npm:0.27.1":
+  version: 0.27.1
+  resolution: "@esbuild/win32-x64@npm:0.27.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -13344,38 +13471,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rjsf/core@npm:5.23.2":
-  version: 5.23.2
-  resolution: "@rjsf/core@npm:5.23.2"
+"@rjsf/core@npm:5.24.13":
+  version: 5.24.13
+  resolution: "@rjsf/core@npm:5.24.13"
   dependencies:
     lodash: "npm:^4.17.21"
     lodash-es: "npm:^4.17.21"
     markdown-to-jsx: "npm:^7.4.1"
-    nanoid: "npm:^3.3.7"
     prop-types: "npm:^15.8.1"
   peerDependencies:
-    "@rjsf/utils": ^5.23.x
+    "@rjsf/utils": ^5.24.x
     react: ^16.14.0 || >=17
-  checksum: 10/a49cbd41bb8b499ad2ed521417f53bf3fa65c09bedbf0e02ce0f00a5287a3ae4df774e74f89a8dcb8a24359d382a585ea4d20c3a6e109f4aaad2cd74b7db2b01
+  checksum: 10/80defb9ccbb563722dc0a613358122e86c775d10af04d1298e416e7069fa30cddf71823c82444fb1b5ab2f8e4706ff09f2606259fdd8ea59865373eb9493eb5e
   languageName: node
   linkType: hard
 
-"@rjsf/material-ui@npm:5.23.2":
-  version: 5.23.2
-  resolution: "@rjsf/material-ui@npm:5.23.2"
+"@rjsf/material-ui@npm:5.24.13":
+  version: 5.24.13
+  resolution: "@rjsf/material-ui@npm:5.24.13"
   peerDependencies:
     "@material-ui/core": ^4.12.3
     "@material-ui/icons": ^4.11.2
-    "@rjsf/core": ^5.23.x
-    "@rjsf/utils": ^5.23.x
+    "@rjsf/core": ^5.24.x
+    "@rjsf/utils": ^5.24.x
     react: ^16.14.0 || >=17
-  checksum: 10/0c9ab33d4a2251bc4a3868fd09e6267ccd23e96b226204e1e2b5d9667fec375f64ac9674f3f5c8b013bb6e0b745f31854cab92b859b0c9ff2527338760664d5f
+  checksum: 10/b52e35973e81670cf57d8d3bda10b2b1bc57dfb5b6ab7be6176e6d5c384d40b86171bb30e7712e0d5971428e1553a70de08935fa680ef6877b0e97ad4c192059
   languageName: node
   linkType: hard
 
-"@rjsf/utils@npm:5.23.2":
-  version: 5.23.2
-  resolution: "@rjsf/utils@npm:5.23.2"
+"@rjsf/utils@npm:5.24.13":
+  version: 5.24.13
+  resolution: "@rjsf/utils@npm:5.24.13"
   dependencies:
     json-schema-merge-allof: "npm:^0.8.1"
     jsonpointer: "npm:^5.0.1"
@@ -13384,21 +13510,21 @@ __metadata:
     react-is: "npm:^18.2.0"
   peerDependencies:
     react: ^16.14.0 || >=17
-  checksum: 10/739a65a40dede96dd1d202ad0c0df96ffe4c75cd3ebcf035da9589eecf2875100c9e28066e135ececa4c188abee436b9ccaa1536992ab5d8417bb6c9e43bd156
+  checksum: 10/4bd6788c4d12c147bd26c67568267ce34d15f618c1f38f964e6981d202bf78e2101ab0d286987659840455115bd8f183aa133308bf0f8468ca44153723e3c6d0
   languageName: node
   linkType: hard
 
-"@rjsf/validator-ajv8@npm:5.23.2":
-  version: 5.23.2
-  resolution: "@rjsf/validator-ajv8@npm:5.23.2"
+"@rjsf/validator-ajv8@npm:5.24.13":
+  version: 5.24.13
+  resolution: "@rjsf/validator-ajv8@npm:5.24.13"
   dependencies:
     ajv: "npm:^8.12.0"
     ajv-formats: "npm:^2.1.1"
     lodash: "npm:^4.17.21"
     lodash-es: "npm:^4.17.21"
   peerDependencies:
-    "@rjsf/utils": ^5.23.x
-  checksum: 10/568693ef0b93f21000b3b9352a65dd65001b4b85514fd94a1bf7562dc9ab8333f3a077c5335041fd7d250fac9a6c9cb77ea8539d8589a03afa55539898f896e6
+    "@rjsf/utils": ^5.24.x
+  checksum: 10/a684862ded27792c8f40cfcf26436fa91f0666c6b95aa7281bb6448221a85cffb6a178fd99d172758aae2c41c58033047d902743962b7f3a2b46204ebdb0009d
   languageName: node
   linkType: hard
 
@@ -17242,12 +17368,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-walk@npm:^8.3.4":
+  version: 8.3.4
+  resolution: "acorn-walk@npm:8.3.4"
+  dependencies:
+    acorn: "npm:^8.11.0"
+  checksum: 10/871386764e1451c637bb8ab9f76f4995d408057e9909be6fb5ad68537ae3375d85e6a6f170b98989f44ab3ff6c74ad120bc2779a3d577606e7a0cd2b4efcaf77
+  languageName: node
+  linkType: hard
+
 "acorn@npm:^8.1.0, acorn@npm:^8.14.0, acorn@npm:^8.4.1, acorn@npm:^8.8.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
   version: 8.14.1
   resolution: "acorn@npm:8.14.1"
   bin:
     acorn: bin/acorn
   checksum: 10/d1379bbee224e8d44c3c3946e6ba6973e999fbdd4e22e41c3455d7f9b6f72f7ce18d3dc218002e1e48eea789539cf1cb6d1430c81838c6744799c712fb557d92
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.11.0, acorn@npm:^8.14.1":
+  version: 8.15.0
+  resolution: "acorn@npm:8.15.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10/77f2de5051a631cf1729c090e5759148459cdb76b5f5c70f890503d629cf5052357b0ce783c0f976dd8a93c5150f59f6d18df1def3f502396a20f81282482fa4
   languageName: node
   linkType: hard
 
@@ -18629,6 +18773,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:~1.20.3":
+  version: 1.20.4
+  resolution: "body-parser@npm:1.20.4"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    content-type: "npm:~1.0.5"
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    destroy: "npm:~1.2.0"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.4.24"
+    on-finished: "npm:~2.4.1"
+    qs: "npm:~6.14.0"
+    raw-body: "npm:~2.5.3"
+    type-is: "npm:~1.6.18"
+    unpipe: "npm:~1.0.0"
+  checksum: 10/ff67e28d3f426707be8697a75fdf8d564dc50c341b41f054264d8ab6e2924e519c7ce8acc9d0de05328fdc41e1d9f3f200aec9c1cfb1867d6b676a410d97c689
+  languageName: node
+  linkType: hard
+
 "bonjour-service@npm:^1.2.1":
   version: 1.2.1
   resolution: "bonjour-service@npm:1.2.1"
@@ -18965,7 +19129,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.1.2":
+"bytes@npm:3.1.2, bytes@npm:~3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10/a10abf2ba70c784471d6b4f58778c0beeb2b5d405148e66affa91f23a9f13d07603d0a0354667310ae1d6dc141474ffd44e2a074be0f6e2254edb8fc21445388
@@ -19861,7 +20025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:0.5.4, content-disposition@npm:~0.5.2":
+"content-disposition@npm:0.5.4, content-disposition@npm:~0.5.2, content-disposition@npm:~0.5.4":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
   dependencies:
@@ -19908,6 +20072,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-signature@npm:~1.0.6":
+  version: 1.0.7
+  resolution: "cookie-signature@npm:1.0.7"
+  checksum: 10/1a62808cd30d15fb43b70e19829b64d04b0802d8ef00275b57d152de4ae6a3208ca05c197b6668d104c4d9de389e53ccc2d3bc6bcaaffd9602461417d8c40710
+  languageName: node
+  linkType: hard
+
 "cookie@npm:0.4.1":
   version: 0.4.1
   resolution: "cookie@npm:0.4.1"
@@ -19929,7 +20100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^0.7.0":
+"cookie@npm:^0.7.0, cookie@npm:~0.7.1":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10/24b286c556420d4ba4e9bc09120c9d3db7d28ace2bd0f8ccee82422ce42322f73c8312441271e5eefafbead725980e5996cc02766dbb89a90ac7f5636ede608f
@@ -21322,7 +21493,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"destroy@npm:1.2.0, destroy@npm:^1.0.4":
+"destroy@npm:1.2.0, destroy@npm:^1.0.4, destroy@npm:~1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
   checksum: 10/0acb300b7478a08b92d810ab229d5afe0d2f4399272045ab22affa0d99dbaf12637659411530a6fcd597a9bdac718fc94373a61a95b4651bbc7b83684a565e38
@@ -22048,35 +22219,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.25.0":
-  version: 0.25.1
-  resolution: "esbuild@npm:0.25.1"
+"esbuild@npm:^0.27.0":
+  version: 0.27.1
+  resolution: "esbuild@npm:0.27.1"
   dependencies:
-    "@esbuild/aix-ppc64": "npm:0.25.1"
-    "@esbuild/android-arm": "npm:0.25.1"
-    "@esbuild/android-arm64": "npm:0.25.1"
-    "@esbuild/android-x64": "npm:0.25.1"
-    "@esbuild/darwin-arm64": "npm:0.25.1"
-    "@esbuild/darwin-x64": "npm:0.25.1"
-    "@esbuild/freebsd-arm64": "npm:0.25.1"
-    "@esbuild/freebsd-x64": "npm:0.25.1"
-    "@esbuild/linux-arm": "npm:0.25.1"
-    "@esbuild/linux-arm64": "npm:0.25.1"
-    "@esbuild/linux-ia32": "npm:0.25.1"
-    "@esbuild/linux-loong64": "npm:0.25.1"
-    "@esbuild/linux-mips64el": "npm:0.25.1"
-    "@esbuild/linux-ppc64": "npm:0.25.1"
-    "@esbuild/linux-riscv64": "npm:0.25.1"
-    "@esbuild/linux-s390x": "npm:0.25.1"
-    "@esbuild/linux-x64": "npm:0.25.1"
-    "@esbuild/netbsd-arm64": "npm:0.25.1"
-    "@esbuild/netbsd-x64": "npm:0.25.1"
-    "@esbuild/openbsd-arm64": "npm:0.25.1"
-    "@esbuild/openbsd-x64": "npm:0.25.1"
-    "@esbuild/sunos-x64": "npm:0.25.1"
-    "@esbuild/win32-arm64": "npm:0.25.1"
-    "@esbuild/win32-ia32": "npm:0.25.1"
-    "@esbuild/win32-x64": "npm:0.25.1"
+    "@esbuild/aix-ppc64": "npm:0.27.1"
+    "@esbuild/android-arm": "npm:0.27.1"
+    "@esbuild/android-arm64": "npm:0.27.1"
+    "@esbuild/android-x64": "npm:0.27.1"
+    "@esbuild/darwin-arm64": "npm:0.27.1"
+    "@esbuild/darwin-x64": "npm:0.27.1"
+    "@esbuild/freebsd-arm64": "npm:0.27.1"
+    "@esbuild/freebsd-x64": "npm:0.27.1"
+    "@esbuild/linux-arm": "npm:0.27.1"
+    "@esbuild/linux-arm64": "npm:0.27.1"
+    "@esbuild/linux-ia32": "npm:0.27.1"
+    "@esbuild/linux-loong64": "npm:0.27.1"
+    "@esbuild/linux-mips64el": "npm:0.27.1"
+    "@esbuild/linux-ppc64": "npm:0.27.1"
+    "@esbuild/linux-riscv64": "npm:0.27.1"
+    "@esbuild/linux-s390x": "npm:0.27.1"
+    "@esbuild/linux-x64": "npm:0.27.1"
+    "@esbuild/netbsd-arm64": "npm:0.27.1"
+    "@esbuild/netbsd-x64": "npm:0.27.1"
+    "@esbuild/openbsd-arm64": "npm:0.27.1"
+    "@esbuild/openbsd-x64": "npm:0.27.1"
+    "@esbuild/openharmony-arm64": "npm:0.27.1"
+    "@esbuild/sunos-x64": "npm:0.27.1"
+    "@esbuild/win32-arm64": "npm:0.27.1"
+    "@esbuild/win32-ia32": "npm:0.27.1"
+    "@esbuild/win32-x64": "npm:0.27.1"
   dependenciesMeta:
     "@esbuild/aix-ppc64":
       optional: true
@@ -22120,6 +22292,8 @@ __metadata:
       optional: true
     "@esbuild/openbsd-x64":
       optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
     "@esbuild/sunos-x64":
       optional: true
     "@esbuild/win32-arm64":
@@ -22130,7 +22304,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 10/f1dcaa7c72133c4e130dc7a6c05158d48d7ccf6643efb12fd0c5a9727226a9249d3ea4a4ea34f879c4559819d9dd706a968fd34d5c180ae019ea0403246c5564
+  checksum: 10/534148f01e85ca93ec3a4ae8bef133680f5659e639915cd3a453d6ec9ead94c9a2e9bfd61380301471447e182beb62841cb72e0fa18251cdce3454a2511d7cf4
   languageName: node
   linkType: hard
 
@@ -22801,6 +22975,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express@npm:^4.22.0":
+  version: 4.22.1
+  resolution: "express@npm:4.22.1"
+  dependencies:
+    accepts: "npm:~1.3.8"
+    array-flatten: "npm:1.1.1"
+    body-parser: "npm:~1.20.3"
+    content-disposition: "npm:~0.5.4"
+    content-type: "npm:~1.0.4"
+    cookie: "npm:~0.7.1"
+    cookie-signature: "npm:~1.0.6"
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    finalhandler: "npm:~1.3.1"
+    fresh: "npm:~0.5.2"
+    http-errors: "npm:~2.0.0"
+    merge-descriptors: "npm:1.0.3"
+    methods: "npm:~1.1.2"
+    on-finished: "npm:~2.4.1"
+    parseurl: "npm:~1.3.3"
+    path-to-regexp: "npm:~0.1.12"
+    proxy-addr: "npm:~2.0.7"
+    qs: "npm:~6.14.0"
+    range-parser: "npm:~1.2.1"
+    safe-buffer: "npm:5.2.1"
+    send: "npm:~0.19.0"
+    serve-static: "npm:~1.16.2"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:~2.0.1"
+    type-is: "npm:~1.6.18"
+    utils-merge: "npm:1.0.1"
+    vary: "npm:~1.1.2"
+  checksum: 10/f33c1bd0c7d36e2a1f18de9cdc176469d32f68e20258d2941b8d296ab9a4fd9011872c246391bf87714f009fac5114c832ec5ac65cbee39421f1258801eb8470
+  languageName: node
+  linkType: hard
+
 "exsolve@npm:^1.0.1":
   version: 1.0.5
   resolution: "exsolve@npm:1.0.5"
@@ -23162,6 +23375,21 @@ __metadata:
     statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
   checksum: 10/4babe72969b7373b5842bc9f75c3a641a4d0f8eb53af6b89fa714d4460ce03fb92b28de751d12ba415e96e7e02870c436d67412120555e2b382640535697305b
+  languageName: node
+  linkType: hard
+
+"finalhandler@npm:~1.3.1":
+  version: 1.3.2
+  resolution: "finalhandler@npm:1.3.2"
+  dependencies:
+    debug: "npm:2.6.9"
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    on-finished: "npm:~2.4.1"
+    parseurl: "npm:~1.3.3"
+    statuses: "npm:~2.0.2"
+    unpipe: "npm:~1.0.0"
+  checksum: 10/6cb4f9f80eaeb5a0fac4fdbd27a65d39271f040a0034df16556d896bfd855fd42f09da886781b3102117ea8fceba97b903c1f8b08df1fb5740576d5e0f481eed
   languageName: node
   linkType: hard
 
@@ -24694,6 +24922,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "http-errors@npm:2.0.1"
+  dependencies:
+    depd: "npm:~2.0.0"
+    inherits: "npm:~2.0.4"
+    setprototypeof: "npm:~1.2.0"
+    statuses: "npm:~2.0.2"
+    toidentifier: "npm:~1.0.1"
+  checksum: 10/9fe31bc0edf36566c87048aed1d3d0cbe03552564adc3541626a0613f542d753fbcb13bdfcec0a3a530dbe1714bb566c89d46244616b66bddd26ac413b06a207
+  languageName: node
+  linkType: hard
+
 "http-parser-js@npm:>=0.5.1":
   version: 0.5.8
   resolution: "http-parser-js@npm:0.5.8"
@@ -24868,7 +25109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24":
+"iconv-lite@npm:0.4.24, iconv-lite@npm:^0.4.24, iconv-lite@npm:~0.4.24":
   version: 0.4.24
   resolution: "iconv-lite@npm:0.4.24"
   dependencies:
@@ -25833,13 +26074,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isolated-vm@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "isolated-vm@npm:5.0.1"
+"isolated-vm@npm:^6.0.1":
+  version: 6.0.2
+  resolution: "isolated-vm@npm:6.0.2"
   dependencies:
     node-gyp: "npm:latest"
-    prebuild-install: "npm:^7.1.1"
-  checksum: 10/55c69e9ba8ae6adaf7f76b9bfe2614d0edfcabc273c6346598ac4c0801016e9eb31e01b821cb1f59797362640c9ca7a9d003035aa8d2a7a311380b9afbf4fb23
+    prebuild-install: "npm:^7.1.3"
+  checksum: 10/74e97f13678023bf81141a6fb5c91bc179073a024e7f0a568af60d876b781b15b11e02d4012558e7d583e38a553ccccff70fd02645ed5d7bed2150dc3921fa64
   languageName: node
   linkType: hard
 
@@ -29286,6 +29527,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"napi-build-utils@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "napi-build-utils@npm:2.0.0"
+  checksum: 10/69adcdb828481737f1ec64440286013f6479d5b264e24d5439ba795f65293d0bb6d962035de07c65fae525ed7d2fcd0baab6891d8e3734ea792fec43918acf83
+  languageName: node
+  linkType: hard
+
 "native-duplexpair@npm:^1.0.0":
   version: 1.0.0
   resolution: "native-duplexpair@npm:1.0.0"
@@ -29463,6 +29711,13 @@ __metadata:
   version: 1.3.2
   resolution: "node-forge@npm:1.3.2"
   checksum: 10/dcc54aaffe0cf52367214a20c0032aa9b209d9095dd14526504f1972d1900a07e96046b3684cb0c8d0cc3d48744dd18e02b7b447ab28fac615ffb850beeabf18
+  languageName: node
+  linkType: hard
+
+"node-forge@npm:^1.3.2":
+  version: 1.3.3
+  resolution: "node-forge@npm:1.3.3"
+  checksum: 10/f41c31b9296771a4b8c955d58417471712f54f324603a35f8e6cbac19d5e6eaaf5fd5fd14584dfedecbf46a05438ded6eee60a5f2f0822fc5061aaa073cfc75d
   languageName: node
   linkType: hard
 
@@ -29858,7 +30113,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:2.4.1, on-finished@npm:^2.3.0, on-finished@npm:^2.4.1":
+"on-finished@npm:2.4.1, on-finished@npm:^2.3.0, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -30569,7 +30824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.12":
+"path-to-regexp@npm:0.1.12, path-to-regexp@npm:~0.1.12":
   version: 0.1.12
   resolution: "path-to-regexp@npm:0.1.12"
   checksum: 10/2e30f6a0144679c1f95c98e166b96e6acd1e72be9417830fefc8de7ac1992147eb9a4c7acaa59119fb1b3c34eec393b2129ef27e24b2054a3906fc4fb0d1398e
@@ -31482,6 +31737,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prebuild-install@npm:^7.1.3":
+  version: 7.1.3
+  resolution: "prebuild-install@npm:7.1.3"
+  dependencies:
+    detect-libc: "npm:^2.0.0"
+    expand-template: "npm:^2.0.3"
+    github-from-package: "npm:0.0.0"
+    minimist: "npm:^1.2.3"
+    mkdirp-classic: "npm:^0.5.3"
+    napi-build-utils: "npm:^2.0.0"
+    node-abi: "npm:^3.3.0"
+    pump: "npm:^3.0.0"
+    rc: "npm:^1.2.7"
+    simple-get: "npm:^4.0.0"
+    tar-fs: "npm:^2.0.0"
+    tunnel-agent: "npm:^0.6.0"
+  bin:
+    prebuild-install: bin.js
+  checksum: 10/1b7e4c00d2750b532a4fc2a83ffb0c5fefa1b6f2ad071896ead15eeadc3255f5babd816949991af083cf7429e375ae8c7d1c51f73658559da36f948a020a3a11
+  languageName: node
+  linkType: hard
+
 "prelude-ls@npm:^1.2.1":
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
@@ -31784,7 +32061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.11.2, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.14.0, qs@npm:^6.9.4":
+"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.11.2, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.14.0, qs@npm:^6.9.4, qs@npm:~6.14.0":
   version: 6.14.0
   resolution: "qs@npm:6.14.0"
   dependencies:
@@ -31964,6 +32241,18 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: 10/863b5171e140546a4d99f349b720abac4410338e23df5e409cfcc3752538c9caf947ce382c89129ba976f71894bd38b5806c774edac35ebf168d02aa1ac11a95
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:~2.5.3":
+  version: 2.5.3
+  resolution: "raw-body@npm:2.5.3"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.4.24"
+    unpipe: "npm:~1.0.0"
+  checksum: 10/f35759fe5a6548e7c529121ead1de4dd163f899749a5896c42e278479df2d9d7f98b5bb17312737c03617765e5a1433e586f717616e5cfbebc13b4738b820601
   languageName: node
   linkType: hard
 
@@ -33869,6 +34158,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:~0.19.0":
+  version: 0.19.1
+  resolution: "send@npm:0.19.1"
+  dependencies:
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    destroy: "npm:1.2.0"
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
+    mime: "npm:1.6.0"
+    ms: "npm:2.1.3"
+    on-finished: "npm:2.4.1"
+    range-parser: "npm:~1.2.1"
+    statuses: "npm:2.0.1"
+  checksum: 10/360bf50a839c7bbc181f67c3a0f3424a7ad8016dfebcd9eb90891f4b762b4377da14414c32250d67b53872e884171c27469110626f6c22765caa7c38c207ee1d
+  languageName: node
+  linkType: hard
+
 "seq-queue@npm:^0.0.5":
   version: 0.0.5
   resolution: "seq-queue@npm:0.0.5"
@@ -33909,7 +34219,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-static@npm:1.16.2":
+"serve-static@npm:1.16.2, serve-static@npm:~1.16.2":
   version: 1.16.2
   resolution: "serve-static@npm:1.16.2"
   dependencies:
@@ -33989,7 +34299,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setprototypeof@npm:1.2.0":
+"setprototypeof@npm:1.2.0, setprototypeof@npm:~1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10/fde1630422502fbbc19e6844346778f99d449986b2f9cdcceb8326730d2f3d9964dbcb03c02aaadaefffecd0f2c063315ebea8b3ad895914bf1afc1747fc172e
@@ -34514,6 +34824,13 @@ __metadata:
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: 10/c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
+  languageName: node
+  linkType: hard
+
+"statuses@npm:~2.0.1, statuses@npm:~2.0.2":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10/6927feb50c2a75b2a4caab2c565491f7a93ad3d8dbad7b1398d52359e9243a20e2ebe35e33726dee945125ef7a515e9097d8a1b910ba2bbd818265a2f6c39879
   languageName: node
   linkType: hard
 
@@ -35458,7 +35775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toidentifier@npm:1.0.1":
+"toidentifier@npm:1.0.1, toidentifier@npm:~1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10/952c29e2a85d7123239b5cfdd889a0dde47ab0497f0913d70588f19c53f7e0b5327c95f4651e413c74b785147f9637b17410ac8c846d5d4a20a5a33eb6dc3a45
@@ -35987,6 +36304,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript-json-schema@npm:^0.67.0":
+  version: 0.67.1
+  resolution: "typescript-json-schema@npm:0.67.1"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.9"
+    "@types/node": "npm:^18.11.9"
+    glob: "npm:^7.1.7"
+    path-equal: "npm:^1.2.5"
+    safe-stable-stringify: "npm:^2.2.0"
+    ts-node: "npm:^10.9.1"
+    typescript: "npm:~5.5.0"
+    vm2: "npm:^3.10.0"
+    yargs: "npm:^17.1.1"
+  bin:
+    typescript-json-schema: bin/typescript-json-schema
+  checksum: 10/b7c89c380ad3d8bd281fc5714ae140c8e8f9c491b8666ec3cb28bf16fa8f72c8f7b52c89a7ecef7dc52a233c4bc57d3c0f2c3c3f9d4b096c3432f45209696f0a
+  languageName: node
+  linkType: hard
+
 "typescript@npm:~5.4.0":
   version: 5.4.5
   resolution: "typescript@npm:5.4.5"
@@ -36406,13 +36742,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-immer@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "use-immer@npm:0.10.0"
+"use-immer@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "use-immer@npm:0.11.0"
   peerDependencies:
     immer: ">=8.0.0"
-    react: ^16.8.0 || ^17.0.1 || ^18.0.0
-  checksum: 10/372b0eea0a05e9435f5dc57a877ec619ea9a479fc82423f502b4a498d5697f8b06b85d089058db5a056bc8bbdb8e6f9ea8c9850b51a6b05d5c63ab0c8eeb2b7e
+    react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0
+  checksum: 10/09ddbddec5bd5a939dc462de4c9d1ce47989bc60daa712c5235664650b132e246b8e61b6bd3dc8179649445b7cf389065373c75f23829a676dbda6b5d2428928
   languageName: node
   linkType: hard
 
@@ -36707,6 +37043,18 @@ __metadata:
   version: 1.1.2
   resolution: "vm-browserify@npm:1.1.2"
   checksum: 10/ad5b17c9f7a9d9f1ed0e24c897782ab7a587c1fd40f370152482e1af154c7cf0b0bacc45c5ae76a44289881e083ae4ae127808fdff864aa9b562192aae8b5c3b
+  languageName: node
+  linkType: hard
+
+"vm2@npm:^3.10.0":
+  version: 3.10.0
+  resolution: "vm2@npm:3.10.0"
+  dependencies:
+    acorn: "npm:^8.14.1"
+    acorn-walk: "npm:^8.3.4"
+  bin:
+    vm2: bin/vm2
+  checksum: 10/ba8000037f2bed73aef6271a6a65a5db1c5d40046b920bc495a871fbeb3869908628e4e50feb1ec005bb43a17bd04fcf90638cff7db29ff2cb8070d879e61f18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.46.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.46.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.46.0-next.2-changelog.md)
- Upgrade Helper: [From 1.46.0-next.1 to 1.46.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.46.0-next.1&to=1.46.0-next.2)
 
Created by [Version Bump 20094806820](https://github.com/backstage/demo/actions/runs/20094806820)
 