### PR TITLE
v1.47.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: b3b00465cee9a55ea92b7555876084a6dbfb4b9dd2ce7617a0bca1c138dec6b33befabdff7f4035b2a2ad70d59a05dad3a8faf3a34d3bec21fa7949a497fdf48
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.47.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.47.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.47.0-next.1"
+  "version": "1.47.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2385,15 +2385,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.47.0-next.1&npm=1.7.3, @backstage/app-defaults@npm:^1.7.3":
-  version: 1.7.3
-  resolution: "@backstage/app-defaults@npm:1.7.3"
+"@backstage/app-defaults@backstage:^::backstage=1.47.0-next.2&npm=1.7.4-next.0, @backstage/app-defaults@npm:^1.7.4-next.0":
+  version: 1.7.4-next.0
+  resolution: "@backstage/app-defaults@npm:1.7.4-next.0"
   dependencies:
-    "@backstage/core-app-api": "npm:^1.19.3"
-    "@backstage/core-components": "npm:^0.18.4"
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/plugin-permission-react": "npm:^0.4.39"
-    "@backstage/theme": "npm:^0.7.1"
+    "@backstage/core-app-api": "npm:1.19.3"
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/plugin-permission-react": "npm:0.4.39"
+    "@backstage/theme": "npm:0.7.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -2404,7 +2404,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/bb27c89f7b2f7558d34a5296161d742fa9c59e1ed7942a4b2cf4aa9476f13f93ecd15a1f2bd962fe4246982a639eb62a945560acf731d81021d0c2d2615af076
+  checksum: 10/7e7b9b623f2142020c7f826f9bf09b24e8e7cc31b1ec4b0bdb3834eb7a73ba3596ef92450f1f9b4500198f5bed7dfce965b7bf59f10bf22c9bc771a3ec5f9ab6
   languageName: node
   linkType: hard
 
@@ -2419,7 +2419,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.47.0-next.1&npm=0.14.1-next.1, @backstage/backend-defaults@npm:0.14.1-next.1, @backstage/backend-defaults@npm:^0.14.1-next.1":
+"@backstage/backend-defaults@backstage:^::backstage=1.47.0-next.2&npm=0.14.1-next.1, @backstage/backend-defaults@npm:0.14.1-next.1, @backstage/backend-defaults@npm:^0.14.1-next.1":
   version: 0.14.1-next.1
   resolution: "@backstage/backend-defaults@npm:0.14.1-next.1"
   dependencies:
@@ -2732,7 +2732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.47.0-next.1&npm=1.6.0, @backstage/backend-plugin-api@npm:1.6.0, @backstage/backend-plugin-api@npm:^1.6.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.47.0-next.2&npm=1.6.0, @backstage/backend-plugin-api@npm:1.6.0, @backstage/backend-plugin-api@npm:^1.6.0":
   version: 1.6.0
   resolution: "@backstage/backend-plugin-api@npm:1.6.0"
   dependencies:
@@ -2766,7 +2766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.47.0-next.1&npm=1.7.6, @backstage/catalog-model@npm:1.7.6, @backstage/catalog-model@npm:^1.7.6":
+"@backstage/catalog-model@backstage:^::backstage=1.47.0-next.2&npm=1.7.6, @backstage/catalog-model@npm:1.7.6, @backstage/catalog-model@npm:^1.7.6":
   version: 1.7.6
   resolution: "@backstage/catalog-model@npm:1.7.6"
   dependencies:
@@ -2806,7 +2806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.47.0-next.1&npm=0.35.2-next.1, @backstage/cli@npm:^0.35.2-next.1":
+"@backstage/cli@backstage:^::backstage=1.47.0-next.2&npm=0.35.2-next.1, @backstage/cli@npm:^0.35.2-next.1":
   version: 0.35.2-next.1
   resolution: "@backstage/cli@npm:0.35.2-next.1"
   dependencies:
@@ -2975,7 +2975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.47.0-next.1&npm=1.3.6, @backstage/config@npm:1.3.6, @backstage/config@npm:^1.3.6":
+"@backstage/config@backstage:^::backstage=1.47.0-next.2&npm=1.3.6, @backstage/config@npm:1.3.6, @backstage/config@npm:^1.3.6":
   version: 1.3.6
   resolution: "@backstage/config@npm:1.3.6"
   dependencies:
@@ -2986,7 +2986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.47.0-next.1&npm=1.19.3, @backstage/core-app-api@npm:1.19.3, @backstage/core-app-api@npm:^1.19.3":
+"@backstage/core-app-api@backstage:^::backstage=1.47.0-next.2&npm=1.19.3, @backstage/core-app-api@npm:1.19.3, @backstage/core-app-api@npm:^1.19.3":
   version: 1.19.3
   resolution: "@backstage/core-app-api@npm:1.19.3"
   dependencies:
@@ -3014,7 +3014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.47.0-next.1&npm=0.5.6-next.0, @backstage/core-compat-api@npm:0.5.6-next.0, @backstage/core-compat-api@npm:^0.5.6-next.0":
+"@backstage/core-compat-api@backstage:^::backstage=1.47.0-next.2&npm=0.5.6-next.0, @backstage/core-compat-api@npm:0.5.6-next.0, @backstage/core-compat-api@npm:^0.5.6-next.0":
   version: 0.5.6-next.0
   resolution: "@backstage/core-compat-api@npm:0.5.6-next.0"
   dependencies:
@@ -3060,7 +3060,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.47.0-next.1&npm=0.18.4, @backstage/core-components@npm:0.18.4, @backstage/core-components@npm:^0.18.3, @backstage/core-components@npm:^0.18.4":
+"@backstage/core-components@backstage:^::backstage=1.47.0-next.2&npm=0.18.5-next.0, @backstage/core-components@npm:0.18.5-next.0, @backstage/core-components@npm:^0.18.5-next.0":
+  version: 0.18.5-next.0
+  resolution: "@backstage/core-components@npm:0.18.5-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/theme": "npm:0.7.1"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.3.2"
+    linkifyjs: "npm:4.3.2"
+    lodash: "npm:^4.17.21"
+    parse5: "npm:^6.0.0"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-full-screen: "npm:^1.1.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    rehype-raw: "npm:^6.0.0"
+    rehype-sanitize: "npm:^5.0.0"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/8ca1b099d26558fe5ce5ed235fa3058997831cdf3dda65d6f4981691e66e52017e0d6173569e4ca0abeef7cc11314a38a40070c4f38a92dbef8aeb929942cb11
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.18.4, @backstage/core-components@npm:^0.18.3, @backstage/core-components@npm:^0.18.4":
   version: 0.18.4
   resolution: "@backstage/core-components@npm:0.18.4"
   dependencies:
@@ -3115,7 +3173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.47.0-next.1&npm=1.12.1, @backstage/core-plugin-api@npm:1.12.1, @backstage/core-plugin-api@npm:^1.12.0, @backstage/core-plugin-api@npm:^1.12.1":
+"@backstage/core-plugin-api@backstage:^::backstage=1.47.0-next.2&npm=1.12.1, @backstage/core-plugin-api@npm:1.12.1, @backstage/core-plugin-api@npm:^1.12.0, @backstage/core-plugin-api@npm:^1.12.1":
   version: 1.12.1
   resolution: "@backstage/core-plugin-api@npm:1.12.1"
   dependencies:
@@ -3138,7 +3196,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.47.0-next.1&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.47.0-next.2&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -3225,7 +3283,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.47.0-next.1&npm=0.3.5-next.0, @backstage/frontend-defaults@npm:0.3.5-next.0, @backstage/frontend-defaults@npm:^0.3.5-next.0":
+"@backstage/frontend-defaults@backstage:^::backstage=1.47.0-next.2&npm=0.3.5-next.1, @backstage/frontend-defaults@npm:^0.3.5-next.1":
+  version: 0.3.5-next.1
+  resolution: "@backstage/frontend-defaults@npm:0.3.5-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-app-api": "npm:0.13.4-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.13.2"
+    "@backstage/plugin-app": "npm:0.3.4-next.1"
+    "@react-hookz/web": "npm:^24.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/946f45b5e8b3c3e6ad326aa1fcaede59038d8bbafa90805a50c85b44f1447bf43cae7806b0bac2e4901a9c69f87171eb6133b54a111c2582d4f839087e704937
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-defaults@npm:0.3.5-next.0":
   version: 0.3.5-next.0
   resolution: "@backstage/frontend-defaults@npm:0.3.5-next.0"
   dependencies:
@@ -3271,7 +3352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.47.0-next.1&npm=0.13.2, @backstage/frontend-plugin-api@npm:0.13.2, @backstage/frontend-plugin-api@npm:^0.13.1, @backstage/frontend-plugin-api@npm:^0.13.2":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.47.0-next.2&npm=0.13.2, @backstage/frontend-plugin-api@npm:0.13.2, @backstage/frontend-plugin-api@npm:^0.13.1, @backstage/frontend-plugin-api@npm:^0.13.2":
   version: 0.13.2
   resolution: "@backstage/frontend-plugin-api@npm:0.13.2"
   dependencies:
@@ -3357,7 +3438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.47.0-next.1&npm=1.2.14-next.0, @backstage/integration-react@npm:1.2.14-next.0, @backstage/integration-react@npm:^1.2.14-next.0":
+"@backstage/integration-react@backstage:^::backstage=1.47.0-next.2&npm=1.2.14-next.0, @backstage/integration-react@npm:1.2.14-next.0, @backstage/integration-react@npm:^1.2.14-next.0":
   version: 1.2.14-next.0
   resolution: "@backstage/integration-react@npm:1.2.14-next.0"
   dependencies:
@@ -3435,18 +3516,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.47.0-next.1&npm=0.13.3-next.0, @backstage/plugin-api-docs@npm:^0.13.3-next.0":
-  version: 0.13.3-next.0
-  resolution: "@backstage/plugin-api-docs@npm:0.13.3-next.0"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.47.0-next.2&npm=0.13.3-next.1, @backstage/plugin-api-docs@npm:^0.13.3-next.1":
+  version: 0.13.3-next.1
+  resolution: "@backstage/plugin-api-docs@npm:0.13.3-next.1"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
-    "@backstage/plugin-catalog": "npm:1.32.2-next.0"
+    "@backstage/plugin-catalog": "npm:1.32.2-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.39"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -3465,11 +3546,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/757aa1da3b65b70df5893b66a23ec0feb714f86de45f1b41ea3c24fc9e8d07f2b89f4ee87b9b70918c938dcf89e7578e6caecda4f18785205122491813d896ca
+  checksum: 10/b8f1da186210386c03cf9583811acfed568bcfda6cfa584739016148835f147356835b32f1e12c13a892387c69714ca1028d4b33a3fbf768317e125787639f9a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.47.0-next.1&npm=0.5.9, @backstage/plugin-app-backend@npm:^0.5.9":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.47.0-next.2&npm=0.5.9, @backstage/plugin-app-backend@npm:^0.5.9":
   version: 0.5.9
   resolution: "@backstage/plugin-app-backend@npm:0.5.9"
   dependencies:
@@ -3536,6 +3617,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-app@npm:0.3.4-next.1":
+  version: 0.3.4-next.1
+  resolution: "@backstage/plugin-app@npm:0.3.4-next.1"
+  dependencies:
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/frontend-plugin-api": "npm:0.13.2"
+    "@backstage/integration-react": "npm:1.2.14-next.0"
+    "@backstage/plugin-permission-react": "npm:0.4.39"
+    "@backstage/theme": "npm:0.7.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.9.13"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    react-use: "npm:^17.2.4"
+    zod: "npm:^3.22.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/cc235180203fa1843c7d3f18c88ff55b80cd7c6b7c74492edda72afe17f1cad330a68d757fed06eb9be0a8fee043518e5d914aa79810813df0719d1df6aae4f1
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-app@npm:^0.3.3":
   version: 0.3.3
   resolution: "@backstage/plugin-app@npm:0.3.3"
@@ -3566,7 +3677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.47.0-next.1&npm=0.4.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.4.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.47.0-next.2&npm=0.4.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.4.0":
   version: 0.4.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.4.0"
   dependencies:
@@ -3578,7 +3689,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.47.0-next.1&npm=0.2.15, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.15":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.47.0-next.2&npm=0.2.15, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.15":
   version: 0.2.15
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.15"
   dependencies:
@@ -3591,7 +3702,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.47.0-next.1&npm=0.25.7, @backstage/plugin-auth-backend@npm:^0.25.7":
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.47.0-next.2&npm=0.25.7, @backstage/plugin-auth-backend@npm:^0.25.7":
   version: 0.25.7
   resolution: "@backstage/plugin-auth-backend@npm:0.25.7"
   dependencies:
@@ -3643,13 +3754,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-react@npm:0.1.22":
-  version: 0.1.22
-  resolution: "@backstage/plugin-auth-react@npm:0.1.22"
+"@backstage/plugin-auth-react@npm:0.1.23-next.0":
+  version: 0.1.23-next.0
+  resolution: "@backstage/plugin-auth-react@npm:0.1.23-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.18.4"
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/errors": "npm:1.2.7"
     "@material-ui/core": "npm:^4.9.13"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
@@ -3660,7 +3771,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2b9d595abd6d652d92f8a04e25eed0b499d08e2161f71fab8b541f30b5f727905ae13523fd7be963428909732f6ab2acd675eb717392b1f469c1001226e59021
+  checksum: 10/926dd536b0823f08d85db0c21aecd3a73f05ed97f3f1603839eb7ecb730b3541977ce3034b93a9a45a17250ff7e68dfa2eedbeccc3aa770263bf602807fac19d
   languageName: node
   linkType: hard
 
@@ -3674,7 +3785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.47.0-next.1&npm=0.12.1-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.12.1-next.0":
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.47.0-next.2&npm=0.12.1-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.12.1-next.0":
   version: 0.12.1-next.0
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.12.1-next.0"
   dependencies:
@@ -3697,7 +3808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.47.0-next.1&npm=0.1.18-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.18-next.0":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.47.0-next.2&npm=0.1.18-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.18-next.0":
   version: 0.1.18-next.0
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.18-next.0"
   dependencies:
@@ -3708,7 +3819,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.47.0-next.1&npm=0.2.16-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.16-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.16-next.0":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.47.0-next.2&npm=0.2.16-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.16-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.16-next.0":
   version: 0.2.16-next.0
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.16-next.0"
   dependencies:
@@ -3721,7 +3832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.47.0-next.1&npm=3.3.1-next.1, @backstage/plugin-catalog-backend@npm:^3.3.1-next.1":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.47.0-next.2&npm=3.3.1-next.1, @backstage/plugin-catalog-backend@npm:^3.3.1-next.1":
   version: 3.3.1-next.1
   resolution: "@backstage/plugin-catalog-backend@npm:3.3.1-next.1"
   dependencies:
@@ -3799,7 +3910,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.47.0-next.1&npm=1.1.7, @backstage/plugin-catalog-common@npm:1.1.7, @backstage/plugin-catalog-common@npm:^1.1.7":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.47.0-next.2&npm=1.1.7, @backstage/plugin-catalog-common@npm:1.1.7, @backstage/plugin-catalog-common@npm:^1.1.7":
   version: 1.1.7
   resolution: "@backstage/plugin-catalog-common@npm:1.1.7"
   dependencies:
@@ -3810,16 +3921,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.47.0-next.1&npm=0.5.5-next.0, @backstage/plugin-catalog-graph@npm:^0.5.5-next.0":
-  version: 0.5.5-next.0
-  resolution: "@backstage/plugin-catalog-graph@npm:0.5.5-next.0"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.47.0-next.2&npm=0.5.5-next.1, @backstage/plugin-catalog-graph@npm:^0.5.5-next.1":
+  version: 0.5.5-next.1
+  resolution: "@backstage/plugin-catalog-graph@npm:0.5.5-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -3837,11 +3948,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/df0bb0fb0ef20aaa2b325fc64abfb8c0bb99a08fcd78e4823ddec207f23dfff396216e4fcc8a386f53393ee78aa2419e48fd1ee71f3219a29bf13697cc8872cd
+  checksum: 10/66795ffa3dad1496fee0c85824fb5623453de4782260e7d056cc379aa08e8be42f8634e783048ae65cdbff23f1178fe91b5e725185bf719b9de02d309b2ff6f5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.47.0-next.1&npm=1.20.1, @backstage/plugin-catalog-node@npm:1.20.1, @backstage/plugin-catalog-node@npm:^1.20.1":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.47.0-next.2&npm=1.20.1, @backstage/plugin-catalog-node@npm:1.20.1, @backstage/plugin-catalog-node@npm:^1.20.1":
   version: 1.20.1
   resolution: "@backstage/plugin-catalog-node@npm:1.20.1"
   dependencies:
@@ -3859,7 +3970,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.47.0-next.1&npm=1.21.5-next.0, @backstage/plugin-catalog-react@npm:1.21.5-next.0, @backstage/plugin-catalog-react@npm:^1.21.5-next.0":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.47.0-next.2&npm=1.21.5-next.1, @backstage/plugin-catalog-react@npm:1.21.5-next.1, @backstage/plugin-catalog-react@npm:^1.21.5-next.1":
+  version: 1.21.5-next.1
+  resolution: "@backstage/plugin-catalog-react@npm:1.21.5-next.1"
+  dependencies:
+    "@backstage/catalog-client": "npm:1.12.1"
+    "@backstage/catalog-model": "npm:1.7.6"
+    "@backstage/core-compat-api": "npm:0.5.6-next.0"
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-plugin-api": "npm:0.13.2"
+    "@backstage/frontend-test-utils": "npm:0.4.3-next.0"
+    "@backstage/integration-react": "npm:1.2.14-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.7"
+    "@backstage/plugin-permission-common": "npm:0.9.3"
+    "@backstage/plugin-permission-react": "npm:0.4.39"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    classnames: "npm:^2.2.6"
+    lodash: "npm:^4.17.21"
+    material-ui-popup-state: "npm:^5.3.6"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.2.4"
+    yaml: "npm:^2.0.0"
+    zen-observable: "npm:^0.10.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/faee18ef3a3fef50a5ef358ac45c1432165eaf6a7e03779311572ca18c920c6ae6e35a897aaaeaf9d7c7ea9a01bac5e7100107cf425ba9a0cea2081814e4153b
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-react@npm:1.21.5-next.0":
   version: 1.21.5-next.0
   resolution: "@backstage/plugin-catalog-react@npm:1.21.5-next.0"
   dependencies:
@@ -3941,26 +4093,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.47.0-next.1&npm=1.32.2-next.0, @backstage/plugin-catalog@npm:1.32.2-next.0, @backstage/plugin-catalog@npm:^1.32.2-next.0":
-  version: 1.32.2-next.0
-  resolution: "@backstage/plugin-catalog@npm:1.32.2-next.0"
+"@backstage/plugin-catalog@backstage:^::backstage=1.47.0-next.2&npm=1.32.2-next.1, @backstage/plugin-catalog@npm:1.32.2-next.1, @backstage/plugin-catalog@npm:^1.32.2-next.1":
+  version: 1.32.2-next.1
+  resolution: "@backstage/plugin-catalog@npm:1.32.2-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/core-compat-api": "npm:0.5.6-next.0"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
     "@backstage/integration-react": "npm:1.2.14-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.39"
     "@backstage/plugin-scaffolder-common": "npm:1.7.5-next.0"
     "@backstage/plugin-search-common": "npm:1.2.21"
-    "@backstage/plugin-search-react": "npm:1.10.1"
+    "@backstage/plugin-search-react": "npm:1.10.2-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.6"
+    "@backstage/plugin-techdocs-react": "npm:1.3.7-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -3983,11 +4135,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/42716710d75f4a9e0cd43023e5ed7432012e44947b30fba47133b02324beb0bf06a7551f9e3260a91a12a79f290e69ae9616f0ea87b59de2fba4c0cd6c6d1402
+  checksum: 10/9234f8c4e55e1eb07d6da99fd99f6ea36f94a1153e5379051230d410980ff60d15aec0d669990529ad14f6f11483af4fac62457a7e1e6e0721a28af959683f22
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.47.0-next.1&npm=0.4.8-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.8-next.0":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.47.0-next.2&npm=0.4.8-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.8-next.0":
   version: 0.4.8-next.0
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.8-next.0"
   dependencies:
@@ -4004,7 +4156,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.47.0-next.1&npm=0.5.10-next.0, @backstage/plugin-events-backend@npm:^0.5.10-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.47.0-next.2&npm=0.5.10-next.0, @backstage/plugin-events-backend@npm:^0.5.10-next.0":
   version: 0.5.10-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.5.10-next.0"
   dependencies:
@@ -4040,13 +4192,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@npm:0.1.33":
-  version: 0.1.33
-  resolution: "@backstage/plugin-home-react@npm:0.1.33"
+"@backstage/plugin-home-react@npm:0.1.34-next.0":
+  version: 0.1.34-next.0
+  resolution: "@backstage/plugin-home-react@npm:0.1.34-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.18.4"
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/frontend-plugin-api": "npm:^0.13.2"
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/frontend-plugin-api": "npm:0.13.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@rjsf/utils": "npm:5.24.13"
@@ -4058,23 +4210,23 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/09244c685056859168ac52bd37d20fe53ced38974c46be0b670ba9ce782c81d8defb182a3041200c89ad6a53e1515575c66ca1e2cc4a6a1542a98993dec19e79
+  checksum: 10/cd5a198ac8347f88bcfa75e48003706a5ad9b3c40dfbae7c0b0d877f63f1918104d5d953a583a35999f5b5a4b90e7972cf95a534d58905caef3dff28b02badd4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.47.0-next.1&npm=0.8.16-next.0, @backstage/plugin-home@npm:^0.8.16-next.0":
-  version: 0.8.16-next.0
-  resolution: "@backstage/plugin-home@npm:0.8.16-next.0"
+"@backstage/plugin-home@backstage:^::backstage=1.47.0-next.2&npm=0.8.16-next.1, @backstage/plugin-home@npm:^0.8.16-next.1":
+  version: 0.8.16-next.1
+  resolution: "@backstage/plugin-home@npm:0.8.16-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/core-app-api": "npm:1.19.3"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
-    "@backstage/plugin-home-react": "npm:0.1.33"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
+    "@backstage/plugin-home-react": "npm:0.1.34-next.0"
     "@backstage/theme": "npm:0.7.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4097,11 +4249,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/01ca3256c10db2ac18b198fa1b79910cfb233fef8f57317ee2a9e1a16cb6c04fd64d031915de049b38eb24adc2df7902debe1259a9d7241e021ccc6b407bc581
+  checksum: 10/52997af78f6ab0e6d62f659e0ff03b3117a7add2a2a9a8574625c0fb609d5d60397b82d0a8e0ec2240cfd5db91a2b048d14063f586a16d71197991936ec91c4a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.47.0-next.1&npm=0.21.0, @backstage/plugin-kubernetes-backend@npm:^0.21.0":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.47.0-next.2&npm=0.21.0, @backstage/plugin-kubernetes-backend@npm:^0.21.0":
   version: 0.21.0
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.0"
   dependencies:
@@ -4167,16 +4319,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-react@npm:0.5.14":
-  version: 0.5.14
-  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.14"
+"@backstage/plugin-kubernetes-react@npm:0.5.15-next.0":
+  version: 0.5.15-next.0
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.15-next.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/core-components": "npm:^0.18.4"
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-kubernetes-common": "npm:^0.9.9"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/catalog-model": "npm:1.7.6"
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.9"
+    "@backstage/types": "npm:1.2.2"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
     "@kubernetes/client-node": "npm:1.4.0"
@@ -4200,21 +4352,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/16492111cabb573b2400def1c1ef6d40e4c75560b3c8b453ced9df8cd6b8d9625ea55a237ce85aa0ebc3ad8933f4d9f8d8f8b30c2e35bbf7d7044b6034700913
+  checksum: 10/8570a3ff0781c8adf22e7d4189b28193d5123a36a5414d2e308e833920283204601c6183ec645230db9ce5bbdfc5ce6018e4b2cc4dccea868e2512cdcb47699d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.47.0-next.1&npm=0.12.15-next.0, @backstage/plugin-kubernetes@npm:^0.12.15-next.0":
-  version: 0.12.15-next.0
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.15-next.0"
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.47.0-next.2&npm=0.12.15-next.1, @backstage/plugin-kubernetes@npm:^0.12.15-next.1":
+  version: 0.12.15-next.1
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.15-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/plugin-kubernetes-common": "npm:0.9.9"
-    "@backstage/plugin-kubernetes-react": "npm:0.5.14"
+    "@backstage/plugin-kubernetes-react": "npm:0.5.15-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.39"
     "@material-ui/core": "npm:^4.12.2"
   peerDependencies:
@@ -4225,11 +4377,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9f192e129d6e82e127c6c08d7c2f11e7a2b951f768841ea1ac96148f4203cc2068b35be50b0777fe83d839aa9e8e1a66a676b1e0f90c40173f527a0863dc4bd9
+  checksum: 10/801dfb7a3e3416d09d3f70574b3f1b6e415b4e2f3e57ff9eb81020d4235f02d5b770e260cd289a36cafe0c6c6395403c155a3254cf87e080397f63db81904814
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.47.0-next.1&npm=0.6.1, @backstage/plugin-notifications-backend@npm:^0.6.1":
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.47.0-next.2&npm=0.6.1, @backstage/plugin-notifications-backend@npm:^0.6.1":
   version: 0.6.1
   resolution: "@backstage/plugin-notifications-backend@npm:0.6.1"
   dependencies:
@@ -4262,7 +4414,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.47.0-next.1&npm=0.2.22, @backstage/plugin-notifications-node@npm:0.2.22, @backstage/plugin-notifications-node@npm:^0.2.22":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.47.0-next.2&npm=0.2.22, @backstage/plugin-notifications-node@npm:0.2.22, @backstage/plugin-notifications-node@npm:^0.2.22":
   version: 0.2.22
   resolution: "@backstage/plugin-notifications-node@npm:0.2.22"
   dependencies:
@@ -4277,17 +4429,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.47.0-next.1&npm=0.5.12, @backstage/plugin-notifications@npm:^0.5.12":
-  version: 0.5.12
-  resolution: "@backstage/plugin-notifications@npm:0.5.12"
+"@backstage/plugin-notifications@backstage:^::backstage=1.47.0-next.2&npm=0.5.13-next.0, @backstage/plugin-notifications@npm:^0.5.13-next.0":
+  version: 0.5.13-next.0
+  resolution: "@backstage/plugin-notifications@npm:0.5.13-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.18.4"
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/frontend-plugin-api": "npm:^0.13.2"
-    "@backstage/plugin-notifications-common": "npm:^0.2.0"
-    "@backstage/plugin-signals-react": "npm:^0.0.18"
-    "@backstage/theme": "npm:^0.7.1"
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-plugin-api": "npm:0.13.2"
+    "@backstage/plugin-notifications-common": "npm:0.2.0"
+    "@backstage/plugin-signals-react": "npm:0.0.18"
+    "@backstage/theme": "npm:0.7.1"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
     lodash: "npm:^4.17.21"
@@ -4303,20 +4455,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/25f7a28482b1d6370f306ea731c484f341da55bcbff425a55e0bfcc18ff4062fbabba91cc5f7c0782f5d26914b3faef4f66b1d32e0243c27462fd533a3549703
+  checksum: 10/77a35eb2f64296a47bc39f6bc39796e1c0a4b9f47a5c42bd03ae84f9a61f9231c9cdd9e4389b42c0ce3b889a2a1acb5bae239d9c326b435d052d7223a40d8114
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.47.0-next.1&npm=0.6.48-next.0, @backstage/plugin-org@npm:^0.6.48-next.0":
-  version: 0.6.48-next.0
-  resolution: "@backstage/plugin-org@npm:0.6.48-next.0"
+"@backstage/plugin-org@backstage:^::backstage=1.47.0-next.2&npm=0.6.48-next.1, @backstage/plugin-org@npm:^0.6.48-next.1":
+  version: 0.6.48-next.1
+  resolution: "@backstage/plugin-org@npm:0.6.48-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -4333,7 +4485,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5550d89913ce137d0f1869e58ef240a081f88b7d3b8ff3a907a5b6c1edf21a6831878fadc95cd6ee4c60026978ea2896b76c12fd1caefd235b079a148c387307
+  checksum: 10/fe01f2d4ddd65ef43e96675542466a9889499ac31922b1e408bab26fc4133af59c9333e4a4c47c649071a110084440e9c84b764ead7f2d605f74a1902fbcc18a
   languageName: node
   linkType: hard
 
@@ -4390,7 +4542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.47.0-next.1&npm=0.6.9, @backstage/plugin-proxy-backend@npm:^0.6.9":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.47.0-next.2&npm=0.6.9, @backstage/plugin-proxy-backend@npm:^0.6.9":
   version: 0.6.9
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.9"
   dependencies:
@@ -4506,7 +4658,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.47.0-next.1&npm=0.9.4-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.4-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.4-next.0":
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.47.0-next.2&npm=0.9.4-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.4-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.4-next.0":
   version: 0.9.4-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.4-next.0"
   dependencies:
@@ -4546,7 +4698,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.47.0-next.1&npm=0.1.18-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.18-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.47.0-next.2&npm=0.1.18-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.18-next.0":
   version: 0.1.18-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.18-next.0"
   dependencies:
@@ -4559,7 +4711,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.47.0-next.1&npm=3.1.1-next.1, @backstage/plugin-scaffolder-backend@npm:^3.1.1-next.1":
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.47.0-next.2&npm=3.1.1-next.1, @backstage/plugin-scaffolder-backend@npm:^3.1.1-next.1":
   version: 3.1.1-next.1
   resolution: "@backstage/plugin-scaffolder-backend@npm:3.1.1-next.1"
   dependencies:
@@ -4665,16 +4817,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.19.5-next.0":
-  version: 1.19.5-next.0
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.19.5-next.0"
+"@backstage/plugin-scaffolder-react@npm:1.19.5-next.1":
+  version: 1.19.5-next.1
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.19.5-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.39"
     "@backstage/plugin-scaffolder-common": "npm:1.7.5-next.0"
     "@backstage/theme": "npm:0.7.1"
@@ -4713,29 +4865,29 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/320eafad8a45ff5cf9f73275f93883f3a144305f56e37249a7fd6f0783eff4a23cc8c0a0794724e57546a2c8db932108b32630fc7809257c341d33af7473a9f9
+  checksum: 10/d5392ddfb20fe77798d5f82f8a48522490ccde4d84d713bf9b7a95508381ff32cf221046b05a6bbdd5b09f0089905e7cd849f9c88e3f4ad2f9b53c98e9af16c5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.47.0-next.1&npm=1.35.1-next.0, @backstage/plugin-scaffolder@npm:^1.35.1-next.0":
-  version: 1.35.1-next.0
-  resolution: "@backstage/plugin-scaffolder@npm:1.35.1-next.0"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.47.0-next.2&npm=1.35.1-next.1, @backstage/plugin-scaffolder@npm:^1.35.1-next.1":
+  version: 1.35.1-next.1
+  resolution: "@backstage/plugin-scaffolder@npm:1.35.1-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
     "@backstage/integration": "npm:1.19.2-next.0"
     "@backstage/integration-react": "npm:1.2.14-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.39"
     "@backstage/plugin-scaffolder-common": "npm:1.7.5-next.0"
-    "@backstage/plugin-scaffolder-react": "npm:1.19.5-next.0"
+    "@backstage/plugin-scaffolder-react": "npm:1.19.5-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.6"
+    "@backstage/plugin-techdocs-react": "npm:1.3.7-next.0"
     "@backstage/types": "npm:1.2.2"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
@@ -4774,11 +4926,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c5cedd058e4c31debf05a42ee242cd1cf7358303388d07d04858c718363ce777180e3c405ee0c8c577b43c72598a0840ea885040cd713b70dafbad67e87c9c95
+  checksum: 10/d0a9467cc8eafe97a204666e7c1eb49d919aab70d91ec8369b80867e373b437720c674dc0b2b24ef00cacb347d0569d24c2b591c1af532b30c5f0bf65d571f0a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.47.0-next.1&npm=0.3.11, @backstage/plugin-search-backend-module-catalog@npm:^0.3.11":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.47.0-next.2&npm=0.3.11, @backstage/plugin-search-backend-module-catalog@npm:^0.3.11":
   version: 0.3.11
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.11"
   dependencies:
@@ -4814,7 +4966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.47.0-next.1&npm=2.0.10-next.0, @backstage/plugin-search-backend@npm:^2.0.10-next.0":
+"@backstage/plugin-search-backend@backstage:^::backstage=1.47.0-next.2&npm=2.0.10-next.0, @backstage/plugin-search-backend@npm:^2.0.10-next.0":
   version: 2.0.10-next.0
   resolution: "@backstage/plugin-search-backend@npm:2.0.10-next.0"
   dependencies:
@@ -4848,7 +5000,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.47.0-next.1&npm=1.10.1, @backstage/plugin-search-react@npm:1.10.1, @backstage/plugin-search-react@npm:^1.10.1":
+"@backstage/plugin-search-react@backstage:^::backstage=1.47.0-next.2&npm=1.10.2-next.0, @backstage/plugin-search-react@npm:1.10.2-next.0, @backstage/plugin-search-react@npm:^1.10.2-next.0":
+  version: 1.10.2-next.0
+  resolution: "@backstage/plugin-search-react@npm:1.10.2-next.0"
+  dependencies:
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/frontend-plugin-api": "npm:0.13.2"
+    "@backstage/plugin-search-common": "npm:1.2.21"
+    "@backstage/theme": "npm:0.7.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    lodash: "npm:^4.17.21"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.3.2"
+    uuid: "npm:^11.0.2"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/7ccfd9c0412d1ef339e159e6dd4e095dd050906b7b0809c83d6643100089e0c1fb7c378b235c9589d4126c37197855ce8ba308db79f2e178e4578ba7af1d5e33
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-react@npm:^1.10.1":
   version: 1.10.1
   resolution: "@backstage/plugin-search-react@npm:1.10.1"
   dependencies:
@@ -4878,17 +5060,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.47.0-next.1&npm=1.5.2-next.0, @backstage/plugin-search@npm:^1.5.2-next.0":
-  version: 1.5.2-next.0
-  resolution: "@backstage/plugin-search@npm:1.5.2-next.0"
+"@backstage/plugin-search@backstage:^::backstage=1.47.0-next.2&npm=1.5.2-next.1, @backstage/plugin-search@npm:^1.5.2-next.1":
+  version: 1.5.2-next.1
+  resolution: "@backstage/plugin-search@npm:1.5.2-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21"
-    "@backstage/plugin-search-react": "npm:1.10.1"
+    "@backstage/plugin-search-react": "npm:1.10.2-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -4903,11 +5085,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/347bf2a1c5d0b11835ec3e5be044090b984394987bba1f49664e5cfe04c0facb7778ff54a44a0d5398fc3cf84d4f60bc1fa397be03b2f04fbc3a0881a159038f
+  checksum: 10/dea36c6a29d52efd9e2faec79a4baccf89522cef825d09fcf627f550c7114a5cd4a0450a29b21c842eccdf018a0a9e8ef0d5e39a0e85f8bbcb486c19ae03b817
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.47.0-next.1&npm=0.3.11, @backstage/plugin-signals-backend@npm:^0.3.11":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.47.0-next.2&npm=0.3.11, @backstage/plugin-signals-backend@npm:^0.3.11":
   version: 0.3.11
   resolution: "@backstage/plugin-signals-backend@npm:0.3.11"
   dependencies:
@@ -4940,7 +5122,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-react@npm:0.0.18, @backstage/plugin-signals-react@npm:^0.0.18":
+"@backstage/plugin-signals-react@npm:0.0.18":
   version: 0.0.18
   resolution: "@backstage/plugin-signals-react@npm:0.0.18"
   dependencies:
@@ -4959,16 +5141,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.47.0-next.1&npm=0.0.26, @backstage/plugin-signals@npm:^0.0.26":
-  version: 0.0.26
-  resolution: "@backstage/plugin-signals@npm:0.0.26"
+"@backstage/plugin-signals@backstage:^::backstage=1.47.0-next.2&npm=0.0.27-next.0, @backstage/plugin-signals@npm:^0.0.27-next.0":
+  version: 0.0.27-next.0
+  resolution: "@backstage/plugin-signals@npm:0.0.27-next.0"
   dependencies:
-    "@backstage/core-components": "npm:^0.18.4"
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/frontend-plugin-api": "npm:^0.13.2"
-    "@backstage/plugin-signals-react": "npm:^0.0.18"
-    "@backstage/theme": "npm:^0.7.1"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/frontend-plugin-api": "npm:0.13.2"
+    "@backstage/plugin-signals-react": "npm:0.0.18"
+    "@backstage/theme": "npm:0.7.1"
+    "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.4"
     uuid: "npm:^11.0.0"
   peerDependencies:
@@ -4979,11 +5161,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/41f2280d0fe1497eb20e8ca5686acac382713e02d9c691275e31d23fd43fa354ab21725819b43d1e94aed3456264ad2adfde0e1931ebe9437a96b8c2168b5155
+  checksum: 10/f04cb55f114b01351b10b2b991752fd082761c9e7fbe76280f0d9555515a3eafdcea77918a690cafc6a4d4b9f1b3cc47e0b4a923463424d3199ffe864a9801c3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.47.0-next.1&npm=2.1.4-next.1, @backstage/plugin-techdocs-backend@npm:^2.1.4-next.1":
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.47.0-next.2&npm=2.1.4-next.1, @backstage/plugin-techdocs-backend@npm:^2.1.4-next.1":
   version: 2.1.4-next.1
   resolution: "@backstage/plugin-techdocs-backend@npm:2.1.4-next.1"
   dependencies:
@@ -5007,23 +5189,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-common@npm:0.1.1, @backstage/plugin-techdocs-common@npm:^0.1.1":
+"@backstage/plugin-techdocs-common@npm:0.1.1":
   version: 0.1.1
   resolution: "@backstage/plugin-techdocs-common@npm:0.1.1"
   checksum: 10/e0c197facff4c393c6d43677345cf86ed2b5c9cdf2c273a2a5ee6beb00deb837691288bfea91f32fffe757fdd89ebd2d5b5864e55b24d9af72fcc0a320f355fc
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.47.0-next.1&npm=1.1.32-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.32-next.0":
-  version: 1.1.32-next.0
-  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.32-next.0"
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.47.0-next.2&npm=1.1.32-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.32-next.1":
+  version: 1.1.32-next.1
+  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.32-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
     "@backstage/integration": "npm:1.19.2-next.0"
     "@backstage/integration-react": "npm:1.2.14-next.0"
-    "@backstage/plugin-techdocs-react": "npm:1.3.6"
+    "@backstage/plugin-techdocs-react": "npm:1.3.7-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@react-hookz/web": "npm:^24.0.0"
@@ -5037,11 +5219,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e89f971cd1efc4b06281873f9c157f67cc40f01d3f1f8d10d949665e2c2e228b5466d511c719cd1f2796456b2be65d62f2a6f276c1faa1fe52b7fc7791dcf7d0
+  checksum: 10/de572c74defe88857b1e134116078e1bbb882908771b08a68082f1ad010b54770e3bd16521c45f5e190080babd43aca2bd9c3b626760e8b4aa74358e4951f1f1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.47.0-next.1&npm=1.13.11-next.0, @backstage/plugin-techdocs-node@npm:1.13.11-next.0, @backstage/plugin-techdocs-node@npm:^1.13.11-next.0":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.47.0-next.2&npm=1.13.11-next.0, @backstage/plugin-techdocs-node@npm:1.13.11-next.0, @backstage/plugin-techdocs-node@npm:^1.13.11-next.0":
   version: 1.13.11-next.0
   resolution: "@backstage/plugin-techdocs-node@npm:1.13.11-next.0"
   dependencies:
@@ -5078,17 +5260,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.47.0-next.1&npm=1.3.6, @backstage/plugin-techdocs-react@npm:1.3.6, @backstage/plugin-techdocs-react@npm:^1.3.6":
-  version: 1.3.6
-  resolution: "@backstage/plugin-techdocs-react@npm:1.3.6"
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.47.0-next.2&npm=1.3.7-next.0, @backstage/plugin-techdocs-react@npm:1.3.7-next.0, @backstage/plugin-techdocs-react@npm:^1.3.7-next.0":
+  version: 1.3.7-next.0
+  resolution: "@backstage/plugin-techdocs-react@npm:1.3.7-next.0"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/core-components": "npm:^0.18.4"
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/frontend-plugin-api": "npm:^0.13.2"
-    "@backstage/plugin-techdocs-common": "npm:^0.1.1"
-    "@backstage/version-bridge": "npm:^1.0.11"
+    "@backstage/catalog-model": "npm:1.7.6"
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/core-components": "npm:0.18.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.1"
+    "@backstage/frontend-plugin-api": "npm:0.13.2"
+    "@backstage/plugin-techdocs-common": "npm:0.1.1"
+    "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/styles": "npm:^4.11.0"
     jss: "npm:~10.10.0"
@@ -5103,29 +5285,29 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/13b70b294220b7ac8c4d29a40ad2ccfdedd34ae28144cf77656fe1e2f9bb8ff47e8656a1f9f25dbde8aeb7bda26555a3bf5615157461fa772e50ac288edccdb3
+  checksum: 10/04864007f5b89e92e11df96786d8d78794ead57e4ca96139e27d68c5c25de0979ce1c41be4939a2b535a0f0d5020483c2d3e164406a3f2b8c60cb5a5041564ca
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.47.0-next.1&npm=1.16.2-next.0, @backstage/plugin-techdocs@npm:^1.16.2-next.0":
-  version: 1.16.2-next.0
-  resolution: "@backstage/plugin-techdocs@npm:1.16.2-next.0"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.47.0-next.2&npm=1.16.2-next.1, @backstage/plugin-techdocs@npm:^1.16.2-next.1":
+  version: 1.16.2-next.1
+  resolution: "@backstage/plugin-techdocs@npm:1.16.2-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
     "@backstage/integration": "npm:1.19.2-next.0"
     "@backstage/integration-react": "npm:1.2.14-next.0"
-    "@backstage/plugin-auth-react": "npm:0.1.22"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-auth-react": "npm:0.1.23-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/plugin-search-common": "npm:1.2.21"
-    "@backstage/plugin-search-react": "npm:1.10.1"
+    "@backstage/plugin-search-react": "npm:1.10.2-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.6"
+    "@backstage/plugin-techdocs-react": "npm:1.3.7-next.0"
     "@backstage/theme": "npm:0.7.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5145,7 +5327,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/71203f68eeabb6c562814feae5bb8cd1cd764f4ec54008e053c3f8b6d108e8be0c9d18236f26c6780366ed70b9859fdc657c9db1fa3f67b5a1e07a199d9d6adc
+  checksum: 10/c7ba94ef0501ebd870080dfa7e101df81db9ea3fabfb1bb2d2f0a849bdd7bc22ecd0c11e6c8471598781f91baf0f994489f1ee1d5bc3a679fd20d690186672de
   languageName: node
   linkType: hard
 
@@ -5156,17 +5338,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.47.0-next.1&npm=0.8.31-next.0, @backstage/plugin-user-settings@npm:^0.8.31-next.0":
-  version: 0.8.31-next.0
-  resolution: "@backstage/plugin-user-settings@npm:0.8.31-next.0"
+"@backstage/plugin-user-settings@backstage:^::backstage=1.47.0-next.2&npm=0.8.31-next.1, @backstage/plugin-user-settings@npm:^0.8.31-next.1":
+  version: 0.8.31-next.1
+  resolution: "@backstage/plugin-user-settings@npm:0.8.31-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/core-app-api": "npm:1.19.3"
-    "@backstage/core-components": "npm:0.18.4"
+    "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
-    "@backstage/plugin-catalog-react": "npm:1.21.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.18"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
     "@backstage/theme": "npm:0.7.1"
@@ -5184,7 +5366,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2fdfc9c74b7d278fe49cd061473f5529ac0069e42f0895f5bf536fff93089925d4f72ce082dd25238ba21730b3dc2b4fef765fe1bf7e6a28ba3d118544c766ab
+  checksum: 10/d889cec4dd0a6ca640bc23a579ac3082a620546b3cc95d16cb90d79d26cc95bdf72385a053a0b014e13732539a580ffbd2f35597e1efb1568151f839e25bd082
   languageName: node
   linkType: hard
 
@@ -5224,7 +5406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.47.0-next.1&npm=0.7.1, @backstage/theme@npm:0.7.1, @backstage/theme@npm:^0.7.1":
+"@backstage/theme@backstage:^::backstage=1.47.0-next.2&npm=0.7.1, @backstage/theme@npm:0.7.1, @backstage/theme@npm:^0.7.1":
   version: 0.7.1
   resolution: "@backstage/theme@npm:0.7.1"
   dependencies:
@@ -5251,7 +5433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.47.0-next.1&npm=0.11.0-next.0, @backstage/ui@npm:^0.11.0-next.0":
+"@backstage/ui@backstage:^::backstage=1.47.0-next.2&npm=0.11.0-next.0, @backstage/ui@npm:^0.11.0-next.0":
   version: 0.11.0-next.0
   resolution: "@backstage/ui@npm:0.11.0-next.0"
   dependencies:
@@ -15588,6 +15770,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/parse5@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "@types/parse5@npm:6.0.3"
+  checksum: 10/834d40c9b1a8a99a9574b0b3f6629cf48adcff2eda01a35d701f1de5dcf46ce24223684647890aba9f985d6c801b233f878168683de0ae425940403c383fba8f
+  languageName: node
+  linkType: hard
+
 "@types/passport@npm:^1.0.3":
   version: 1.0.16
   resolution: "@types/passport@npm:1.0.16"
@@ -23015,10 +23204,76 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-from-parse5@npm:^7.0.0":
+  version: 7.1.2
+  resolution: "hast-util-from-parse5@npm:7.1.2"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    "@types/unist": "npm:^2.0.0"
+    hastscript: "npm:^7.0.0"
+    property-information: "npm:^6.0.0"
+    vfile: "npm:^5.0.0"
+    vfile-location: "npm:^4.0.0"
+    web-namespaces: "npm:^2.0.0"
+  checksum: 10/7a90a16430a1482ed1be5c2f8b182e8b12aee8834781245b101700b5a04cea8b569cf40ef08214e1eb333249432e861b17e6fe46d0447b5281827c8798e86f1a
+  languageName: node
+  linkType: hard
+
 "hast-util-parse-selector@npm:^2.0.0":
   version: 2.2.5
   resolution: "hast-util-parse-selector@npm:2.2.5"
   checksum: 10/22ee4afbd11754562144cb3c4f3ec52524dafba4d90ee52512902d17cf11066d83b38f7bdf6ca571bbc2541f07ba30db0d234657b6ecb8ca4631587466459605
+  languageName: node
+  linkType: hard
+
+"hast-util-parse-selector@npm:^3.0.0":
+  version: 3.1.1
+  resolution: "hast-util-parse-selector@npm:3.1.1"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+  checksum: 10/511d373465f60dd65e924f88bf0954085f4fb6e3a2b062a4b5ac43b93cbfd36a8dce6234b5d1e3e63499d936375687e83fc5da55628b22bd6b581b5ee167d1c4
+  languageName: node
+  linkType: hard
+
+"hast-util-raw@npm:^7.2.0":
+  version: 7.2.3
+  resolution: "hast-util-raw@npm:7.2.3"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    "@types/parse5": "npm:^6.0.0"
+    hast-util-from-parse5: "npm:^7.0.0"
+    hast-util-to-parse5: "npm:^7.0.0"
+    html-void-elements: "npm:^2.0.0"
+    parse5: "npm:^6.0.0"
+    unist-util-position: "npm:^4.0.0"
+    unist-util-visit: "npm:^4.0.0"
+    vfile: "npm:^5.0.0"
+    web-namespaces: "npm:^2.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10/fe39d4b9e68de7131ec61e9abe887cc0579dc7491f738735150c6021565fc998e37c9d096e97fc35c769e986e04b721d4724835ee82fcc22076d778acf6c4832
+  languageName: node
+  linkType: hard
+
+"hast-util-sanitize@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "hast-util-sanitize@npm:4.1.0"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+  checksum: 10/8258ba32be9e57e871f894d3c6b3187dd98e0682bf1382cd1306c20045cd5dc209589919817dc079803d9a259b420d9cd88771535088c9fe0eea122028c348eb
+  languageName: node
+  linkType: hard
+
+"hast-util-to-parse5@npm:^7.0.0":
+  version: 7.1.0
+  resolution: "hast-util-to-parse5@npm:7.1.0"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    property-information: "npm:^6.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+    web-namespaces: "npm:^2.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10/695539881431f9713ca4a0be7d06bf3e57ae4d9f930eccba371534c50cff11855d345f8ec30099d04482637ad82e3c70d480269bfa4c109f37993536e8ea690d
   languageName: node
   linkType: hard
 
@@ -23039,6 +23294,19 @@ __metadata:
     property-information: "npm:^5.0.0"
     space-separated-tokens: "npm:^1.0.0"
   checksum: 10/78f91b71e50506f7499c8275d67645f9f4f130e6f12b038853261d1fa7393432da4113baf3508c41b79d933f255089d6d593beea9d4cda89dfd34d0a498cf378
+  languageName: node
+  linkType: hard
+
+"hastscript@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "hastscript@npm:7.2.0"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    comma-separated-tokens: "npm:^2.0.0"
+    hast-util-parse-selector: "npm:^3.0.0"
+    property-information: "npm:^6.0.0"
+    space-separated-tokens: "npm:^2.0.0"
+  checksum: 10/98740e0b69b4765a23d0174fb93eb1c1bdcae6a9f1c9e1b07de6aca2d578427a42e1d45ee98eda26463ac58ff73a8ce45af19c4eb8b5f6f768a9c8543964d28f
   languageName: node
   linkType: hard
 
@@ -23189,6 +23457,13 @@ __metadata:
   bin:
     html-minifier-terser: cli.js
   checksum: 10/a244fa944e002b57c66cc829a3f2dfdb9514b1833c2d838ada624964bf8c0afaf61d36c371758c7e44dedae95cea740a84d8d1067b916ed204f35175184d0e27
+  languageName: node
+  linkType: hard
+
+"html-void-elements@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "html-void-elements@npm:2.0.1"
+  checksum: 10/06d41f13b9d5d6e0f39861c4bec9a9196fa4906d56cd5cf6cf54ad2e52a85bf960cca2bf9600026bde16c8331db171bedba5e5a35e2e43630c8f1d497b2fb658
   languageName: node
   linkType: hard
 
@@ -28804,6 +29079,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "parse5@npm:6.0.1"
+  checksum: 10/dfb110581f62bd1425725a7c784ae022a24669bd0efc24b58c71fc731c4d868193e2ebd85b74cde2dbb965e4dcf07059b1e651adbec1b3b5267531bd132fdb75
+  languageName: node
+  linkType: hard
+
 "parse5@npm:^7.0.0, parse5@npm:^7.1.2":
   version: 7.3.0
   resolution: "parse5@npm:7.3.0"
@@ -31237,6 +31519,28 @@ __metadata:
   version: 2.0.1
   resolution: "regression@npm:2.0.1"
   checksum: 10/d8c902e29d2485dea72e89c39f21cf6e56ca89e556f0547ce73d5098e18817e32dcfa95e8999dfbcebd03c9e4a4d614ee90adaea8cd5204882926566b310b09f
+  languageName: node
+  linkType: hard
+
+"rehype-raw@npm:^6.0.0":
+  version: 6.1.1
+  resolution: "rehype-raw@npm:6.1.1"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    hast-util-raw: "npm:^7.2.0"
+    unified: "npm:^10.0.0"
+  checksum: 10/3599d22c45264bea52c93eec2136f50f119282c0bd4e9604aeb2421fe20db84f9c4536caebf64f29158d8c2403b6fd3b3da634211393fdda9cdd500149d00ae4
+  languageName: node
+  linkType: hard
+
+"rehype-sanitize@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "rehype-sanitize@npm:5.0.1"
+  dependencies:
+    "@types/hast": "npm:^2.0.0"
+    hast-util-sanitize: "npm:^4.0.0"
+    unified: "npm:^10.0.0"
+  checksum: 10/b9d9efc0b3c894fe5da84558147148c355c933794c3411dc7c02278b28ea251d241020cd26836e5cc5c979e0e058b45ca51a0eb87824ffdb7241efecd65b6d29
   languageName: node
   linkType: hard
 
@@ -34940,6 +35244,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vfile-location@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "vfile-location@npm:4.1.0"
+  dependencies:
+    "@types/unist": "npm:^2.0.0"
+    vfile: "npm:^5.0.0"
+  checksum: 10/c894e8e5224170d1f85288f4a1d1ebcee0780823ea2b49d881648ab360ebf01b37ecb09b1c4439a75f9a51f31a9f9742cd045e987763e367c352a1ef7c50d446
+  languageName: node
+  linkType: hard
+
 "vfile-message@npm:^3.0.0":
   version: 3.1.4
   resolution: "vfile-message@npm:3.1.4"
@@ -35057,6 +35371,13 @@ __metadata:
   dependencies:
     defaults: "npm:^1.0.3"
   checksum: 10/182ebac8ca0b96845fae6ef44afd4619df6987fe5cf552fdee8396d3daa1fb9b8ec5c6c69855acb7b3c1231571393bd1f0a4cdc4028d421575348f64bb0a8817
+  languageName: node
+  linkType: hard
+
+"web-namespaces@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "web-namespaces@npm:2.0.1"
+  checksum: 10/b6d9f02f1a43d0ef0848a812d89c83801d5bbad57d8bb61f02eb6d7eb794c3736f6cc2e1191664bb26136594c8218ac609f4069722c6f56d9fc2d808fa9271c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.47.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.47.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.47.0-next.2-changelog.md)
- Upgrade Helper: [From 1.47.0-next.1 to 1.47.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.47.0-next.1&to=1.47.0-next.2)
 
Created by [Version Bump 20777813182](https://github.com/backstage/demo/actions/runs/20777813182)
 