### PR TITLE
Docs demo: Youtube iframe error 153

### DIFF
--- a/docs/examples/iframe.md
+++ b/docs/examples/iframe.md
@@ -12,14 +12,12 @@ To be able to use iframes with TechDocs you'll need to follow this guide: [How t
 
 Here is an example:
 
-<iframe width="672" height="378" src="https://www.youtube.com/embed/85TQEpNCaU0" title="YouTube video player" frameborder="0" allow="picture-in-picture" allowfullscreen></iframe>
+<iframe width="672" height="378" src="https://www.youtube.com/embed/85TQEpNCaU0" title="YouTube video player" frameborder="0" allow="picture-in-picture" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
 
 ## Markdown
 
 Here is the Markdown:
 
 ```markdown
-<iframe width="672" height="378" frameborder="0"
-src="https://www.youtube.com/embed/85TQEpNCaU0" title="YouTube video player" 
-allow="picture-in-picture" allowfullscreen></iframe>
+<iframe width="672" height="378" src="https://www.youtube.com/embed/85TQEpNCaU0" title="YouTube video player" frameborder="0" allow="picture-in-picture" allowfullscreen referrerpolicy="strict-origin-when-cross-origin"></iframe>
 ```


### PR DESCRIPTION
Hey :wave:

Due to the lack of `referrerpolicy="strict-origin-when-cross-origin"`, the Youtube iframe in the Techdocs demo is showing "Error 153".

<img width="1011" height="610" alt="image" src="https://github.com/user-attachments/assets/91841703-a9cf-4fb9-9b5f-8507d00f361e" />

Tested quickly with devtool, and seem to do the trick.