### PR TITLE
v1.47.0-next.3 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: b3b00465cee9a55ea92b7555876084a6dbfb4b9dd2ce7617a0bca1c138dec6b33befabdff7f4035b2a2ad70d59a05dad3a8faf3a34d3bec21fa7949a497fdf48
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.47.0-next.2/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.47.0-next.3/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.47.0-next.2"
+  "version": "1.47.0-next.3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2385,7 +2385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.47.0-next.2&npm=1.7.4-next.0, @backstage/app-defaults@npm:^1.7.4-next.0":
+"@backstage/app-defaults@backstage:^::backstage=1.47.0-next.3&npm=1.7.4-next.0, @backstage/app-defaults@npm:^1.7.4-next.0":
   version: 1.7.4-next.0
   resolution: "@backstage/app-defaults@npm:1.7.4-next.0"
   dependencies:
@@ -2419,9 +2419,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.47.0-next.2&npm=0.14.1-next.1, @backstage/backend-defaults@npm:0.14.1-next.1, @backstage/backend-defaults@npm:^0.14.1-next.1":
-  version: 0.14.1-next.1
-  resolution: "@backstage/backend-defaults@npm:0.14.1-next.1"
+"@backstage/backend-defaults@backstage:^::backstage=1.47.0-next.3&npm=0.15.0-next.2, @backstage/backend-defaults@npm:0.15.0-next.2, @backstage/backend-defaults@npm:^0.15.0-next.2":
+  version: 0.15.0-next.2
+  resolution: "@backstage/backend-defaults@npm:0.15.0-next.2"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -2501,93 +2501,7 @@ __metadata:
       optional: true
     better-sqlite3:
       optional: true
-  checksum: 10/475532f7d318bcf282a025ddd3b4ede2f6070575d4a1fbb88bb3d2eb924d2775f4f87b186381fef1f8ba494abda34f878f8b1f7c6c269fc1e583b99be7fe60e3
-  languageName: node
-  linkType: hard
-
-"@backstage/backend-defaults@npm:0.14.1-next.0":
-  version: 0.14.1-next.0
-  resolution: "@backstage/backend-defaults@npm:0.14.1-next.0"
-  dependencies:
-    "@aws-sdk/abort-controller": "npm:^3.347.0"
-    "@aws-sdk/client-codecommit": "npm:^3.350.0"
-    "@aws-sdk/client-s3": "npm:^3.350.0"
-    "@aws-sdk/credential-providers": "npm:^3.350.0"
-    "@aws-sdk/types": "npm:^3.347.0"
-    "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-app-api": "npm:1.4.0"
-    "@backstage/backend-dev-utils": "npm:0.1.6"
-    "@backstage/backend-plugin-api": "npm:1.6.0"
-    "@backstage/cli-node": "npm:0.2.16"
-    "@backstage/config": "npm:1.3.6"
-    "@backstage/config-loader": "npm:1.10.7"
-    "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.0"
-    "@backstage/integration-aws-node": "npm:0.1.19"
-    "@backstage/plugin-auth-node": "npm:0.6.10"
-    "@backstage/plugin-events-node": "npm:0.4.18"
-    "@backstage/plugin-permission-node": "npm:0.10.7"
-    "@backstage/types": "npm:1.2.2"
-    "@google-cloud/storage": "npm:^7.0.0"
-    "@keyv/memcache": "npm:^2.0.1"
-    "@keyv/redis": "npm:^4.0.1"
-    "@keyv/valkey": "npm:^1.0.1"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    "@octokit/rest": "npm:^19.0.3"
-    "@opentelemetry/api": "npm:^1.9.0"
-    "@types/cors": "npm:^2.8.6"
-    "@types/express": "npm:^4.17.6"
-    archiver: "npm:^7.0.0"
-    base64-stream: "npm:^1.0.0"
-    compression: "npm:^1.7.4"
-    concat-stream: "npm:^2.0.0"
-    cookie: "npm:^0.7.0"
-    cors: "npm:^2.8.5"
-    cron: "npm:^3.0.0"
-    express: "npm:^4.22.0"
-    express-promise-router: "npm:^4.1.0"
-    express-rate-limit: "npm:^7.5.0"
-    fs-extra: "npm:^11.2.0"
-    git-url-parse: "npm:^15.0.0"
-    helmet: "npm:^6.0.0"
-    infinispan: "npm:^0.12.0"
-    is-glob: "npm:^4.0.3"
-    jose: "npm:^5.0.0"
-    keyv: "npm:^5.2.1"
-    knex: "npm:^3.0.0"
-    lodash: "npm:^4.17.21"
-    logform: "npm:^2.3.2"
-    luxon: "npm:^3.0.0"
-    minimatch: "npm:^9.0.0"
-    mysql2: "npm:^3.0.0"
-    node-fetch: "npm:^2.7.0"
-    node-forge: "npm:^1.3.2"
-    p-limit: "npm:^3.1.0"
-    path-to-regexp: "npm:^8.0.0"
-    pg: "npm:^8.11.3"
-    pg-connection-string: "npm:^2.3.0"
-    pg-format: "npm:^1.0.4"
-    rate-limit-redis: "npm:^4.2.0"
-    raw-body: "npm:^2.4.1"
-    selfsigned: "npm:^2.0.0"
-    tar: "npm:^6.1.12"
-    triple-beam: "npm:^1.4.1"
-    uuid: "npm:^11.0.0"
-    winston: "npm:^3.2.1"
-    winston-transport: "npm:^4.5.0"
-    yauzl: "npm:^3.0.0"
-    yn: "npm:^4.0.0"
-    zod: "npm:^3.22.4"
-    zod-to-json-schema: "npm:^3.20.4"
-  peerDependencies:
-    "@google-cloud/cloud-sql-connector": ^1.4.0
-    better-sqlite3: ^12.0.0
-  peerDependenciesMeta:
-    "@google-cloud/cloud-sql-connector":
-      optional: true
-    better-sqlite3:
-      optional: true
-  checksum: 10/9ef9de2b8c6da8f7083ac0eadfb4069b7e108ec699c537f6add97766b7c581321f65b02ea466567aa1fb092f373dd5c4b541d8361dc24d0a8249cd3a8461a731
+  checksum: 10/8d7ea35748fe42007acba99fd1fccd741c5d10e8cc496b60ddba823d6fd0a93e7ba0e65158e564a3f25f7a96b0c5dc6828856b3c99b18c1f7ae53c17ecfb45be
   languageName: node
   linkType: hard
 
@@ -2732,7 +2646,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.47.0-next.2&npm=1.6.0, @backstage/backend-plugin-api@npm:1.6.0, @backstage/backend-plugin-api@npm:^1.6.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.47.0-next.3&npm=1.6.0, @backstage/backend-plugin-api@npm:1.6.0, @backstage/backend-plugin-api@npm:^1.6.0":
   version: 1.6.0
   resolution: "@backstage/backend-plugin-api@npm:1.6.0"
   dependencies:
@@ -2766,7 +2680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.47.0-next.2&npm=1.7.6, @backstage/catalog-model@npm:1.7.6, @backstage/catalog-model@npm:^1.7.6":
+"@backstage/catalog-model@backstage:^::backstage=1.47.0-next.3&npm=1.7.6, @backstage/catalog-model@npm:1.7.6, @backstage/catalog-model@npm:^1.7.6":
   version: 1.7.6
   resolution: "@backstage/catalog-model@npm:1.7.6"
   dependencies:
@@ -2806,7 +2720,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.47.0-next.2&npm=0.35.2-next.1, @backstage/cli@npm:^0.35.2-next.1":
+"@backstage/cli@backstage:^::backstage=1.47.0-next.3&npm=0.35.2-next.1, @backstage/cli@npm:^0.35.2-next.1":
   version: 0.35.2-next.1
   resolution: "@backstage/cli@npm:0.35.2-next.1"
   dependencies:
@@ -2975,7 +2889,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.47.0-next.2&npm=1.3.6, @backstage/config@npm:1.3.6, @backstage/config@npm:^1.3.6":
+"@backstage/config@backstage:^::backstage=1.47.0-next.3&npm=1.3.6, @backstage/config@npm:1.3.6, @backstage/config@npm:^1.3.6":
   version: 1.3.6
   resolution: "@backstage/config@npm:1.3.6"
   dependencies:
@@ -2986,7 +2900,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.47.0-next.2&npm=1.19.3, @backstage/core-app-api@npm:1.19.3, @backstage/core-app-api@npm:^1.19.3":
+"@backstage/core-app-api@backstage:^::backstage=1.47.0-next.3&npm=1.19.3, @backstage/core-app-api@npm:1.19.3, @backstage/core-app-api@npm:^1.19.3":
   version: 1.19.3
   resolution: "@backstage/core-app-api@npm:1.19.3"
   dependencies:
@@ -3014,7 +2928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.47.0-next.2&npm=0.5.6-next.0, @backstage/core-compat-api@npm:0.5.6-next.0, @backstage/core-compat-api@npm:^0.5.6-next.0":
+"@backstage/core-compat-api@backstage:^::backstage=1.47.0-next.3&npm=0.5.6-next.0, @backstage/core-compat-api@npm:0.5.6-next.0, @backstage/core-compat-api@npm:^0.5.6-next.0":
   version: 0.5.6-next.0
   resolution: "@backstage/core-compat-api@npm:0.5.6-next.0"
   dependencies:
@@ -3060,7 +2974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.47.0-next.2&npm=0.18.5-next.0, @backstage/core-components@npm:0.18.5-next.0, @backstage/core-components@npm:^0.18.5-next.0":
+"@backstage/core-components@backstage:^::backstage=1.47.0-next.3&npm=0.18.5-next.0, @backstage/core-components@npm:0.18.5-next.0, @backstage/core-components@npm:^0.18.5-next.0":
   version: 0.18.5-next.0
   resolution: "@backstage/core-components@npm:0.18.5-next.0"
   dependencies:
@@ -3173,7 +3087,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.47.0-next.2&npm=1.12.1, @backstage/core-plugin-api@npm:1.12.1, @backstage/core-plugin-api@npm:^1.12.1":
+"@backstage/core-plugin-api@backstage:^::backstage=1.47.0-next.3&npm=1.12.1, @backstage/core-plugin-api@npm:1.12.1, @backstage/core-plugin-api@npm:^1.12.1":
   version: 1.12.1
   resolution: "@backstage/core-plugin-api@npm:1.12.1"
   dependencies:
@@ -3196,7 +3110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.47.0-next.2&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.47.0-next.3&npm=0.1.1, @backstage/e2e-test-utils@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/e2e-test-utils@npm:0.1.1"
   dependencies:
@@ -3283,7 +3197,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.47.0-next.2&npm=0.3.5-next.1, @backstage/frontend-defaults@npm:^0.3.5-next.1":
+"@backstage/frontend-defaults@backstage:^::backstage=1.47.0-next.3&npm=0.3.5-next.1, @backstage/frontend-defaults@npm:^0.3.5-next.1":
   version: 0.3.5-next.1
   resolution: "@backstage/frontend-defaults@npm:0.3.5-next.1"
   dependencies:
@@ -3352,7 +3266,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.47.0-next.2&npm=0.13.2, @backstage/frontend-plugin-api@npm:0.13.2, @backstage/frontend-plugin-api@npm:^0.13.2":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.47.0-next.3&npm=0.13.2, @backstage/frontend-plugin-api@npm:0.13.2, @backstage/frontend-plugin-api@npm:^0.13.2":
   version: 0.13.2
   resolution: "@backstage/frontend-plugin-api@npm:0.13.2"
   dependencies:
@@ -3438,7 +3352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.47.0-next.2&npm=1.2.14-next.0, @backstage/integration-react@npm:1.2.14-next.0, @backstage/integration-react@npm:^1.2.14-next.0":
+"@backstage/integration-react@backstage:^::backstage=1.47.0-next.3&npm=1.2.14-next.0, @backstage/integration-react@npm:1.2.14-next.0, @backstage/integration-react@npm:^1.2.14-next.0":
   version: 1.2.14-next.0
   resolution: "@backstage/integration-react@npm:1.2.14-next.0"
   dependencies:
@@ -3516,16 +3430,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.47.0-next.2&npm=0.13.3-next.1, @backstage/plugin-api-docs@npm:^0.13.3-next.1":
-  version: 0.13.3-next.1
-  resolution: "@backstage/plugin-api-docs@npm:0.13.3-next.1"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.47.0-next.3&npm=0.13.3-next.2, @backstage/plugin-api-docs@npm:^0.13.3-next.2":
+  version: 0.13.3-next.2
+  resolution: "@backstage/plugin-api-docs@npm:0.13.3-next.2"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/core-components": "npm:0.18.5-next.0"
     "@backstage/core-plugin-api": "npm:1.12.1"
     "@backstage/frontend-plugin-api": "npm:0.13.2"
-    "@backstage/plugin-catalog": "npm:1.32.2-next.1"
+    "@backstage/plugin-catalog": "npm:1.32.2-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.7"
     "@backstage/plugin-catalog-react": "npm:1.21.5-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.39"
@@ -3546,11 +3460,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b8f1da186210386c03cf9583811acfed568bcfda6cfa584739016148835f147356835b32f1e12c13a892387c69714ca1028d4b33a3fbf768317e125787639f9a
+  checksum: 10/f4098d8ebd6aeac6615d7a04931a8a069695bd34b3a760081830de3f93d57d9cfb1492a20a87b633aac5c8af4a14e817d429e872981d838b06c852390a3c1c46
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.47.0-next.2&npm=0.5.9, @backstage/plugin-app-backend@npm:^0.5.9":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.47.0-next.3&npm=0.5.9, @backstage/plugin-app-backend@npm:^0.5.9":
   version: 0.5.9
   resolution: "@backstage/plugin-app-backend@npm:0.5.9"
   dependencies:
@@ -3677,7 +3591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.47.0-next.2&npm=0.4.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.4.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.47.0-next.3&npm=0.4.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.4.0":
   version: 0.4.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.4.0"
   dependencies:
@@ -3689,7 +3603,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.47.0-next.2&npm=0.2.15, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.15":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.47.0-next.3&npm=0.2.15, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.15":
   version: 0.2.15
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.15"
   dependencies:
@@ -3702,17 +3616,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.47.0-next.2&npm=0.25.7, @backstage/plugin-auth-backend@npm:^0.25.7":
-  version: 0.25.7
-  resolution: "@backstage/plugin-auth-backend@npm:0.25.7"
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.47.0-next.3&npm=0.26.0-next.0, @backstage/plugin-auth-backend@npm:^0.26.0-next.0":
+  version: 0.26.0-next.0
+  resolution: "@backstage/plugin-auth-backend@npm:0.26.0-next.0"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.6.0"
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-auth-node": "npm:^0.6.10"
-    "@backstage/plugin-catalog-node": "npm:^1.20.1"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/backend-plugin-api": "npm:1.6.0"
+    "@backstage/catalog-model": "npm:1.7.6"
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/plugin-auth-node": "npm:0.6.10"
+    "@backstage/plugin-catalog-node": "npm:1.20.1"
+    "@backstage/types": "npm:1.2.2"
     "@google-cloud/firestore": "npm:^7.0.0"
     connect-session-knex: "npm:^4.0.0"
     cookie-parser: "npm:^1.4.5"
@@ -3727,7 +3641,7 @@ __metadata:
     minimatch: "npm:^9.0.0"
     passport: "npm:^0.7.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/9a43230a6132fad04fb6b0f8e68c4d8bdc545fa4baeb008ae53565f3d655f91a6f3cd4efd278d4b8df8e2dd2255d18fb29446b3c83c1900a85209462ef2d6557
+  checksum: 10/a1c321ce393d8617d477dbb110cf7714d8528c1a97f119aafcd9372b445edcde01b25d53bdc1a64b10236990fb606521e5f7628422c3eb3a1f0d3ba05255d732
   languageName: node
   linkType: hard
 
@@ -3785,9 +3699,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.47.0-next.2&npm=0.12.1-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.12.1-next.0":
-  version: 0.12.1-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.12.1-next.0"
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.47.0-next.3&npm=0.12.1-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.12.1-next.1":
+  version: 0.12.1-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.12.1-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.6.0"
     "@backstage/catalog-model": "npm:1.7.6"
@@ -3804,11 +3718,11 @@ __metadata:
     lodash: "npm:^4.17.21"
     minimatch: "npm:^9.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/54c6aea80107d6bdfa070e0ad2b16f8a76c432615ef747d439d55ccd0a96e2d4f6890701fc31472683a91b47d32e58a302e0a19b1bf1be3022406087141a243b
+  checksum: 10/6399037f7dbca8f01ab10fe31b03a074c26d6c3517cc7def15037ef6c4a9df3f7403dd1f3c9301f764550f6b09b1d648d89384e057fcca7a2ec9d7d52056c307
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.47.0-next.2&npm=0.1.18-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.18-next.0":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.47.0-next.3&npm=0.1.18-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.18-next.0":
   version: 0.1.18-next.0
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.18-next.0"
   dependencies:
@@ -3819,7 +3733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.47.0-next.2&npm=0.2.16-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.16-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.16-next.0":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.47.0-next.3&npm=0.2.16-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.16-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.16-next.0":
   version: 0.2.16-next.0
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.16-next.0"
   dependencies:
@@ -3832,7 +3746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.47.0-next.2&npm=3.3.1-next.1, @backstage/plugin-catalog-backend@npm:^3.3.1-next.1":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.47.0-next.3&npm=3.3.1-next.1, @backstage/plugin-catalog-backend@npm:^3.3.1-next.1":
   version: 3.3.1-next.1
   resolution: "@backstage/plugin-catalog-backend@npm:3.3.1-next.1"
   dependencies:
@@ -3910,7 +3824,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.47.0-next.2&npm=1.1.7, @backstage/plugin-catalog-common@npm:1.1.7, @backstage/plugin-catalog-common@npm:^1.1.7":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.47.0-next.3&npm=1.1.7, @backstage/plugin-catalog-common@npm:1.1.7, @backstage/plugin-catalog-common@npm:^1.1.7":
   version: 1.1.7
   resolution: "@backstage/plugin-catalog-common@npm:1.1.7"
   dependencies:
@@ -3921,7 +3835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.47.0-next.2&npm=0.5.5-next.1, @backstage/plugin-catalog-graph@npm:^0.5.5-next.1":
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.47.0-next.3&npm=0.5.5-next.1, @backstage/plugin-catalog-graph@npm:^0.5.5-next.1":
   version: 0.5.5-next.1
   resolution: "@backstage/plugin-catalog-graph@npm:0.5.5-next.1"
   dependencies:
@@ -3952,7 +3866,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.47.0-next.2&npm=1.20.1, @backstage/plugin-catalog-node@npm:1.20.1, @backstage/plugin-catalog-node@npm:^1.20.1":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.47.0-next.3&npm=1.20.1, @backstage/plugin-catalog-node@npm:1.20.1, @backstage/plugin-catalog-node@npm:^1.20.1":
   version: 1.20.1
   resolution: "@backstage/plugin-catalog-node@npm:1.20.1"
   dependencies:
@@ -3970,7 +3884,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.47.0-next.2&npm=1.21.5-next.1, @backstage/plugin-catalog-react@npm:1.21.5-next.1, @backstage/plugin-catalog-react@npm:^1.21.5-next.1":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.47.0-next.3&npm=1.21.5-next.1, @backstage/plugin-catalog-react@npm:1.21.5-next.1, @backstage/plugin-catalog-react@npm:^1.21.5-next.1":
   version: 1.21.5-next.1
   resolution: "@backstage/plugin-catalog-react@npm:1.21.5-next.1"
   dependencies:
@@ -4093,9 +4007,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.47.0-next.2&npm=1.32.2-next.1, @backstage/plugin-catalog@npm:1.32.2-next.1, @backstage/plugin-catalog@npm:^1.32.2-next.1":
-  version: 1.32.2-next.1
-  resolution: "@backstage/plugin-catalog@npm:1.32.2-next.1"
+"@backstage/plugin-catalog@backstage:^::backstage=1.47.0-next.3&npm=1.32.2-next.2, @backstage/plugin-catalog@npm:1.32.2-next.2, @backstage/plugin-catalog@npm:^1.32.2-next.2":
+  version: 1.32.2-next.2
+  resolution: "@backstage/plugin-catalog@npm:1.32.2-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
@@ -4135,11 +4049,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9234f8c4e55e1eb07d6da99fd99f6ea36f94a1153e5379051230d410980ff60d15aec0d669990529ad14f6f11483af4fac62457a7e1e6e0721a28af959683f22
+  checksum: 10/35c9b5b69294e2605cc0683830a27062fa0aab5c37195d0be2c085299c3a40d6dcf971f462986d7542ced7c386968ebc5c6f6e2675c9267a1c22bf875ec70fa1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.47.0-next.2&npm=0.4.8-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.8-next.0":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.47.0-next.3&npm=0.4.8-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.8-next.0":
   version: 0.4.8-next.0
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.8-next.0"
   dependencies:
@@ -4156,7 +4070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.47.0-next.2&npm=0.5.10-next.0, @backstage/plugin-events-backend@npm:^0.5.10-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.47.0-next.3&npm=0.5.10-next.0, @backstage/plugin-events-backend@npm:^0.5.10-next.0":
   version: 0.5.10-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.5.10-next.0"
   dependencies:
@@ -4214,9 +4128,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.47.0-next.2&npm=0.8.16-next.1, @backstage/plugin-home@npm:^0.8.16-next.1":
-  version: 0.8.16-next.1
-  resolution: "@backstage/plugin-home@npm:0.8.16-next.1"
+"@backstage/plugin-home@backstage:^::backstage=1.47.0-next.3&npm=0.9.0-next.2, @backstage/plugin-home@npm:^0.9.0-next.2":
+  version: 0.9.0-next.2
+  resolution: "@backstage/plugin-home@npm:0.9.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
@@ -4249,11 +4163,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/52997af78f6ab0e6d62f659e0ff03b3117a7add2a2a9a8574625c0fb609d5d60397b82d0a8e0ec2240cfd5db91a2b048d14063f586a16d71197991936ec91c4a
+  checksum: 10/3940e892f13e38fe94be6e1ebd3dc97e4b7127e5182100c624d3539b6f5c0c29f00435376f235b35ffd4f6c2d5c41cc75827ca0548f841cbe3a1a16ef69fcb1c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.47.0-next.2&npm=0.21.0, @backstage/plugin-kubernetes-backend@npm:^0.21.0":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.47.0-next.3&npm=0.21.0, @backstage/plugin-kubernetes-backend@npm:^0.21.0":
   version: 0.21.0
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.0"
   dependencies:
@@ -4356,7 +4270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.47.0-next.2&npm=0.12.15-next.1, @backstage/plugin-kubernetes@npm:^0.12.15-next.1":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.47.0-next.3&npm=0.12.15-next.1, @backstage/plugin-kubernetes@npm:^0.12.15-next.1":
   version: 0.12.15-next.1
   resolution: "@backstage/plugin-kubernetes@npm:0.12.15-next.1"
   dependencies:
@@ -4381,7 +4295,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.47.0-next.2&npm=0.6.1, @backstage/plugin-notifications-backend@npm:^0.6.1":
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.47.0-next.3&npm=0.6.1, @backstage/plugin-notifications-backend@npm:^0.6.1":
   version: 0.6.1
   resolution: "@backstage/plugin-notifications-backend@npm:0.6.1"
   dependencies:
@@ -4414,7 +4328,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.47.0-next.2&npm=0.2.22, @backstage/plugin-notifications-node@npm:0.2.22, @backstage/plugin-notifications-node@npm:^0.2.22":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.47.0-next.3&npm=0.2.22, @backstage/plugin-notifications-node@npm:0.2.22, @backstage/plugin-notifications-node@npm:^0.2.22":
   version: 0.2.22
   resolution: "@backstage/plugin-notifications-node@npm:0.2.22"
   dependencies:
@@ -4429,7 +4343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.47.0-next.2&npm=0.5.13-next.0, @backstage/plugin-notifications@npm:^0.5.13-next.0":
+"@backstage/plugin-notifications@backstage:^::backstage=1.47.0-next.3&npm=0.5.13-next.0, @backstage/plugin-notifications@npm:^0.5.13-next.0":
   version: 0.5.13-next.0
   resolution: "@backstage/plugin-notifications@npm:0.5.13-next.0"
   dependencies:
@@ -4459,7 +4373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.47.0-next.2&npm=0.6.48-next.1, @backstage/plugin-org@npm:^0.6.48-next.1":
+"@backstage/plugin-org@backstage:^::backstage=1.47.0-next.3&npm=0.6.48-next.1, @backstage/plugin-org@npm:^0.6.48-next.1":
   version: 0.6.48-next.1
   resolution: "@backstage/plugin-org@npm:0.6.48-next.1"
   dependencies:
@@ -4542,7 +4456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.47.0-next.2&npm=0.6.9, @backstage/plugin-proxy-backend@npm:^0.6.9":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.47.0-next.3&npm=0.6.9, @backstage/plugin-proxy-backend@npm:^0.6.9":
   version: 0.6.9
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.9"
   dependencies:
@@ -4658,9 +4572,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.47.0-next.2&npm=0.9.4-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.4-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.4-next.0":
-  version: 0.9.4-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.4-next.0"
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.47.0-next.3&npm=0.9.4-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.4-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.4-next.1":
+  version: 0.9.4-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.4-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.6.0"
     "@backstage/catalog-model": "npm:1.7.6"
@@ -4676,7 +4590,7 @@ __metadata:
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/fa72be15fb0ddb8ec878b6471fbf6fdddfd08efc8edaf9932f0bda934ded85de6af6558dcaea6aeb1afb548a4f30775077415c4b284381652db8e5c9961452d1
+  checksum: 10/0fc2049d9b92c6824316877544ada53f6d0cb4d07bfceb20ec2b005416531b2fdc48858d479a1809896abfe46584be271493186f1fb6f1730d015b3ca27b6c81
   languageName: node
   linkType: hard
 
@@ -4698,7 +4612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.47.0-next.2&npm=0.1.18-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.18-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.47.0-next.3&npm=0.1.18-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.18-next.0":
   version: 0.1.18-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.18-next.0"
   dependencies:
@@ -4711,11 +4625,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.47.0-next.2&npm=3.1.1-next.1, @backstage/plugin-scaffolder-backend@npm:^3.1.1-next.1":
-  version: 3.1.1-next.1
-  resolution: "@backstage/plugin-scaffolder-backend@npm:3.1.1-next.1"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.47.0-next.3&npm=3.1.1-next.2, @backstage/plugin-scaffolder-backend@npm:^3.1.1-next.2":
+  version: 3.1.1-next.2
+  resolution: "@backstage/plugin-scaffolder-backend@npm:3.1.1-next.2"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.14.1-next.1"
+    "@backstage/backend-defaults": "npm:0.15.0-next.2"
     "@backstage/backend-openapi-utils": "npm:0.6.5-next.0"
     "@backstage/backend-plugin-api": "npm:1.6.0"
     "@backstage/catalog-model": "npm:1.7.6"
@@ -4735,7 +4649,7 @@ __metadata:
     "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.17-next.0"
     "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.17-next.0"
     "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.17-next.0"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.9.4-next.0"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.9.4-next.1"
     "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.11.1-next.0"
     "@backstage/plugin-scaffolder-common": "npm:1.7.5-next.0"
     "@backstage/plugin-scaffolder-node": "npm:0.12.3-next.0"
@@ -4766,7 +4680,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.20.4"
-  checksum: 10/7522c77ab6c3cedbb59f497a004641631d7a1a72d0b45e708d4196dcef0e6d512bf2432e50a2c11a354568e906593a411bdcb9cde13608fb43834e45161c1766
+  checksum: 10/a9a949cffff8286cbdb2ef88040c2524a9baba583a66baf2483082ac2b81de12ed9269b52e8730477b791c1119686462ab1e15c537045f690fb36a7191dc549d
   languageName: node
   linkType: hard
 
@@ -4869,9 +4783,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.47.0-next.2&npm=1.35.1-next.1, @backstage/plugin-scaffolder@npm:^1.35.1-next.1":
-  version: 1.35.1-next.1
-  resolution: "@backstage/plugin-scaffolder@npm:1.35.1-next.1"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.47.0-next.3&npm=1.35.1-next.2, @backstage/plugin-scaffolder@npm:^1.35.1-next.2":
+  version: 1.35.1-next.2
+  resolution: "@backstage/plugin-scaffolder@npm:1.35.1-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
@@ -4926,11 +4840,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d0a9467cc8eafe97a204666e7c1eb49d919aab70d91ec8369b80867e373b437720c674dc0b2b24ef00cacb347d0569d24c2b591c1af532b30c5f0bf65d571f0a
+  checksum: 10/6de768620ed197d0bedbe3a68eabce06f6ff73114f13c4f8f331f4fd614b14b8e7856bccf5bebf9f03ac41f25a253766f29002cdab1445a456b4f9990bfd393e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.47.0-next.2&npm=0.3.11, @backstage/plugin-search-backend-module-catalog@npm:^0.3.11":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.47.0-next.3&npm=0.3.11, @backstage/plugin-search-backend-module-catalog@npm:^0.3.11":
   version: 0.3.11
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.11"
   dependencies:
@@ -4966,11 +4880,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.47.0-next.2&npm=2.0.10-next.0, @backstage/plugin-search-backend@npm:^2.0.10-next.0":
-  version: 2.0.10-next.0
-  resolution: "@backstage/plugin-search-backend@npm:2.0.10-next.0"
+"@backstage/plugin-search-backend@backstage:^::backstage=1.47.0-next.3&npm=2.0.10-next.1, @backstage/plugin-search-backend@npm:^2.0.10-next.1":
+  version: 2.0.10-next.1
+  resolution: "@backstage/plugin-search-backend@npm:2.0.10-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.14.1-next.0"
+    "@backstage/backend-defaults": "npm:0.15.0-next.2"
     "@backstage/backend-openapi-utils": "npm:0.6.5-next.0"
     "@backstage/backend-plugin-api": "npm:1.6.0"
     "@backstage/config": "npm:1.3.6"
@@ -4986,7 +4900,7 @@ __metadata:
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.22.4"
-  checksum: 10/fb6bd6b3725ab99bb8843493011970b7e6bfd1efdd6938a778bc0980e2b53336d0f1bd1f4722881acb4d4110d2a3d6d8399cb49e6ffd7ac636dca9563e059c2f
+  checksum: 10/a234b9bbc6675659d94d8fcf88173d44504dfd6ae996281dcfd938073c3c565e6da6ffe6800b164b9f5af0b31412049cea5810753324685b459c25a6b0916b69
   languageName: node
   linkType: hard
 
@@ -5000,7 +4914,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.47.0-next.2&npm=1.10.2-next.0, @backstage/plugin-search-react@npm:1.10.2-next.0, @backstage/plugin-search-react@npm:^1.10.2-next.0":
+"@backstage/plugin-search-react@backstage:^::backstage=1.47.0-next.3&npm=1.10.2-next.0, @backstage/plugin-search-react@npm:1.10.2-next.0, @backstage/plugin-search-react@npm:^1.10.2-next.0":
   version: 1.10.2-next.0
   resolution: "@backstage/plugin-search-react@npm:1.10.2-next.0"
   dependencies:
@@ -5060,7 +4974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.47.0-next.2&npm=1.5.2-next.1, @backstage/plugin-search@npm:^1.5.2-next.1":
+"@backstage/plugin-search@backstage:^::backstage=1.47.0-next.3&npm=1.5.2-next.1, @backstage/plugin-search@npm:^1.5.2-next.1":
   version: 1.5.2-next.1
   resolution: "@backstage/plugin-search@npm:1.5.2-next.1"
   dependencies:
@@ -5089,7 +5003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.47.0-next.2&npm=0.3.11, @backstage/plugin-signals-backend@npm:^0.3.11":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.47.0-next.3&npm=0.3.11, @backstage/plugin-signals-backend@npm:^0.3.11":
   version: 0.3.11
   resolution: "@backstage/plugin-signals-backend@npm:0.3.11"
   dependencies:
@@ -5141,7 +5055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.47.0-next.2&npm=0.0.27-next.0, @backstage/plugin-signals@npm:^0.0.27-next.0":
+"@backstage/plugin-signals@backstage:^::backstage=1.47.0-next.3&npm=0.0.27-next.0, @backstage/plugin-signals@npm:^0.0.27-next.0":
   version: 0.0.27-next.0
   resolution: "@backstage/plugin-signals@npm:0.0.27-next.0"
   dependencies:
@@ -5165,11 +5079,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.47.0-next.2&npm=2.1.4-next.1, @backstage/plugin-techdocs-backend@npm:^2.1.4-next.1":
-  version: 2.1.4-next.1
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.1.4-next.1"
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.47.0-next.3&npm=2.1.4-next.2, @backstage/plugin-techdocs-backend@npm:^2.1.4-next.2":
+  version: 2.1.4-next.2
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.1.4-next.2"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.14.1-next.1"
+    "@backstage/backend-defaults": "npm:0.15.0-next.2"
     "@backstage/backend-plugin-api": "npm:1.6.0"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
@@ -5185,7 +5099,7 @@ __metadata:
     knex: "npm:^3.0.0"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/09c6c35c46ac9646627f335c14368c7711b00f100d832298f79b8baeb3c184fdf2e43fa29c1300f4bede4db1b8990f3a3e6e779e26a1c0a307bbf1750c4bfcc3
+  checksum: 10/a2abcd0c9479d31fe73fb27555c00fbbb60d077c6490e1bb23991bce37b2814d67817cb07970951f42c355e6d2fb766a20eb559f1e03329c27f7e31e4498795a
   languageName: node
   linkType: hard
 
@@ -5196,7 +5110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.47.0-next.2&npm=1.1.32-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.32-next.1":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.47.0-next.3&npm=1.1.32-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.32-next.1":
   version: 1.1.32-next.1
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.32-next.1"
   dependencies:
@@ -5223,7 +5137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.47.0-next.2&npm=1.13.11-next.0, @backstage/plugin-techdocs-node@npm:1.13.11-next.0, @backstage/plugin-techdocs-node@npm:^1.13.11-next.0":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.47.0-next.3&npm=1.13.11-next.0, @backstage/plugin-techdocs-node@npm:1.13.11-next.0, @backstage/plugin-techdocs-node@npm:^1.13.11-next.0":
   version: 1.13.11-next.0
   resolution: "@backstage/plugin-techdocs-node@npm:1.13.11-next.0"
   dependencies:
@@ -5260,7 +5174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.47.0-next.2&npm=1.3.7-next.0, @backstage/plugin-techdocs-react@npm:1.3.7-next.0, @backstage/plugin-techdocs-react@npm:^1.3.7-next.0":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.47.0-next.3&npm=1.3.7-next.0, @backstage/plugin-techdocs-react@npm:1.3.7-next.0, @backstage/plugin-techdocs-react@npm:^1.3.7-next.0":
   version: 1.3.7-next.0
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.7-next.0"
   dependencies:
@@ -5289,7 +5203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.47.0-next.2&npm=1.16.2-next.1, @backstage/plugin-techdocs@npm:^1.16.2-next.1":
+"@backstage/plugin-techdocs@backstage:^::backstage=1.47.0-next.3&npm=1.16.2-next.1, @backstage/plugin-techdocs@npm:^1.16.2-next.1":
   version: 1.16.2-next.1
   resolution: "@backstage/plugin-techdocs@npm:1.16.2-next.1"
   dependencies:
@@ -5338,7 +5252,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.47.0-next.2&npm=0.8.31-next.1, @backstage/plugin-user-settings@npm:^0.8.31-next.1":
+"@backstage/plugin-user-settings@backstage:^::backstage=1.47.0-next.3&npm=0.8.31-next.1, @backstage/plugin-user-settings@npm:^0.8.31-next.1":
   version: 0.8.31-next.1
   resolution: "@backstage/plugin-user-settings@npm:0.8.31-next.1"
   dependencies:
@@ -5406,7 +5320,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.47.0-next.2&npm=0.7.1, @backstage/theme@npm:0.7.1, @backstage/theme@npm:^0.7.1":
+"@backstage/theme@backstage:^::backstage=1.47.0-next.3&npm=0.7.1, @backstage/theme@npm:0.7.1, @backstage/theme@npm:^0.7.1":
   version: 0.7.1
   resolution: "@backstage/theme@npm:0.7.1"
   dependencies:
@@ -5433,10 +5347,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.47.0-next.2&npm=0.11.0-next.0, @backstage/ui@npm:^0.11.0-next.0":
-  version: 0.11.0-next.0
-  resolution: "@backstage/ui@npm:0.11.0-next.0"
+"@backstage/ui@backstage:^::backstage=1.47.0-next.3&npm=0.11.0-next.1, @backstage/ui@npm:^0.11.0-next.1":
+  version: 0.11.0-next.1
+  resolution: "@backstage/ui@npm:0.11.0-next.1"
   dependencies:
+    "@backstage/version-bridge": "npm:1.0.11"
     "@remixicon/react": "npm:^4.6.0"
     "@tanstack/react-table": "npm:^8.21.3"
     clsx: "npm:^2.1.1"
@@ -5449,7 +5364,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/80696a4df68b5507dd60a2ef423d8bb71f7024e164b1eeb913e9feb18e8aebb53e2b95678bad8a38fa597bc3112e2738e3ec28685163ab5714dbb6a23d7dfb5e
+  checksum: 10/409b79f0ab0d1847872ade2bdb6e58e22c4fa36101b83de1f8f6669f7a6312daee644f84861dc71c4284e6022e9199bf1bbde46ba2ee4129c6cf4cbe1369cc84
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.47.0-next.3 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.47.0-next.3](https://github.com/backstage/backstage/blob/master/docs/releases/v1.47.0-next.3-changelog.md)
- Upgrade Helper: [From 1.47.0-next.2 to 1.47.0-next.3](https://backstage.github.io/upgrade-helper/?from=1.47.0-next.2&to=1.47.0-next.3)
 
Created by [Version Bump 20995001577](https://github.com/backstage/demo/actions/runs/20995001577)
 