### PR TITLE
chore: remove deprecated inline styles

### DIFF
--- a/packages/app-migrated/public/index.html
+++ b/packages/app-migrated/public/index.html
@@ -41,11 +41,6 @@
       href="<%= publicPath %>/safari-pinned-tab.svg"
       color="#5bbad5"
     />
-    <style>
-      #root {
-        min-height: 100%;
-      }
-    </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -54,7 +49,7 @@
     />
     <title><%= config.getString('app.title') %></title>
   </head>
-  <body style="margin: 0">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/packages/app/public/index.html
+++ b/packages/app/public/index.html
@@ -41,11 +41,6 @@
       href="<%= publicPath %>/safari-pinned-tab.svg"
       color="#5bbad5"
     />
-    <style>
-      #root {
-        min-height: 100%;
-      }
-    </style>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -54,7 +49,7 @@
     />
     <title><%= config.getString('app.title') %></title>
   </head>
-  <body style="margin: 0">
+  <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--


### PR DESCRIPTION
Hey :wave:

Just a little bit of maintenance to remove some leftover styles from 4 years ago. Should be harmless, be could conflict with MUI/BUI, or make some layout issues harder to reproduce.

See [@backstage/create-app 0.4.10 changelog](https://github.com/backstage/backstage/blob/master/packages/create-app/CHANGELOG.md#patch-changes-221)

Cheers!