### PR TITLE
v1.48.0-next.1 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: b3b00465cee9a55ea92b7555876084a6dbfb4b9dd2ce7617a0bca1c138dec6b33befabdff7f4035b2a2ad70d59a05dad3a8faf3a34d3bec21fa7949a497fdf48
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.48.0-next.0/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.48.0-next.1/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.48.0-next.0"
+  "version": "1.48.0-next.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2385,15 +2385,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/app-defaults@backstage:^::backstage=1.48.0-next.0&npm=1.7.5-next.0, @backstage/app-defaults@npm:^1.7.5-next.0":
-  version: 1.7.5-next.0
-  resolution: "@backstage/app-defaults@npm:1.7.5-next.0"
+"@backstage/app-defaults@backstage:^::backstage=1.48.0-next.1&npm=1.7.5-next.1, @backstage/app-defaults@npm:^1.7.5-next.1":
+  version: 1.7.5-next.1
+  resolution: "@backstage/app-defaults@npm:1.7.5-next.1"
   dependencies:
-    "@backstage/core-app-api": "npm:1.19.4-next.0"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-app-api": "npm:1.19.5-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.40-next.0"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -2404,7 +2404,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6a0514ac48945f54baeb1da3491c7504ba97bd6c9c1f895c87c00446dc1d609ab87055580fa8382b91a01dae98a66755a1236b9f0f1b36f19358ed86ca1eb3f6
+  checksum: 10/74ef41517e7af6d99c49683dd7d448c5e2551cdeb2a627c4ea3d841177fa2c420bb6e337db5e9659c4a72d9002aa60880d8f2bc59c9726e93149f3ef2c7d35f6
   languageName: node
   linkType: hard
 
@@ -2430,28 +2430,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.48.0-next.0&npm=0.15.1-next.0, @backstage/backend-defaults@npm:0.15.1-next.0, @backstage/backend-defaults@npm:^0.15.1-next.0":
-  version: 0.15.1-next.0
-  resolution: "@backstage/backend-defaults@npm:0.15.1-next.0"
+"@backstage/backend-defaults@backstage:^::backstage=1.48.0-next.1&npm=0.15.2-next.1, @backstage/backend-defaults@npm:0.15.2-next.1, @backstage/backend-defaults@npm:^0.15.2-next.1":
+  version: 0.15.2-next.1
+  resolution: "@backstage/backend-defaults@npm:0.15.2-next.1"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@aws-sdk/types": "npm:^3.347.0"
+    "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
     "@backstage/backend-app-api": "npm:1.5.0-next.0"
     "@backstage/backend-dev-utils": "npm:0.1.7-next.0"
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
-    "@backstage/cli-node": "npm:0.2.17-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
+    "@backstage/cli-node": "npm:0.2.18-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/config-loader": "npm:1.10.8-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
     "@backstage/integration-aws-node": "npm:0.1.20-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.12-next.0"
+    "@backstage/plugin-auth-node": "npm:0.6.13-next.0"
     "@backstage/plugin-events-node": "npm:0.4.19-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.9-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.10-next.0"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/storage": "npm:^7.0.0"
     "@keyv/memcache": "npm:^2.0.1"
@@ -2512,7 +2513,7 @@ __metadata:
       optional: true
     better-sqlite3:
       optional: true
-  checksum: 10/667c345e1819036e9acb0edd3ff3c130c4a6802e474d64d2411c2355782179131ffe407d8a55821bbe5e67f6fda51e6a6890b938358ffad8040e15fea1bb5179
+  checksum: 10/f9ce920338b462ed146b9019a86aec324256d77f16a2dfab761fe76a01c25ab19ec8b77624b48f932d31847d6797c42c46b61f3df7887043392fa06ee3464798
   languageName: node
   linkType: hard
 
@@ -2664,7 +2665,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.48.0-next.0&npm=1.7.0-next.0, @backstage/backend-plugin-api@npm:1.7.0-next.0, @backstage/backend-plugin-api@npm:^1.7.0-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.48.0-next.1&npm=1.7.0-next.1, @backstage/backend-plugin-api@npm:1.7.0-next.1, @backstage/backend-plugin-api@npm:^1.7.0-next.1":
+  version: 1.7.0-next.1
+  resolution: "@backstage/backend-plugin-api@npm:1.7.0-next.1"
+  dependencies:
+    "@backstage/cli-common": "npm:0.1.18-next.0"
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/plugin-auth-node": "npm:0.6.13-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.10-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/json-schema": "npm:^7.0.6"
+    "@types/luxon": "npm:^3.0.0"
+    json-schema: "npm:^0.4.0"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+    zod: "npm:^3.25.76"
+  checksum: 10/05b6e753bb27938e7f47dbcf4bbb2c25173e581a7bb98b357709f1a792c2cc1cdbee231d9b3d6df27039dea1901e6dc29dc057c53671e2cb7d1d2759e1cfae41
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-plugin-api@npm:1.7.0-next.0":
   version: 1.7.0-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.7.0-next.0"
   dependencies:
@@ -2720,7 +2743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.48.0-next.0&npm=1.7.6, @backstage/catalog-model@npm:1.7.6, @backstage/catalog-model@npm:^1.7.6":
+"@backstage/catalog-model@backstage:^::backstage=1.48.0-next.1&npm=1.7.6, @backstage/catalog-model@npm:1.7.6, @backstage/catalog-model@npm:^1.7.6":
   version: 1.7.6
   resolution: "@backstage/catalog-model@npm:1.7.6"
   dependencies:
@@ -2756,9 +2779,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-node@npm:0.2.17-next.0":
-  version: 0.2.17-next.0
-  resolution: "@backstage/cli-node@npm:0.2.17-next.0"
+"@backstage/cli-node@npm:0.2.18-next.1":
+  version: 0.2.18-next.1
+  resolution: "@backstage/cli-node@npm:0.2.18-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.1.18-next.0"
     "@backstage/errors": "npm:1.2.7"
@@ -2768,7 +2791,7 @@ __metadata:
     fs-extra: "npm:^11.2.0"
     semver: "npm:^7.5.3"
     zod: "npm:^3.25.76"
-  checksum: 10/3f5351a898cb8b5c97d119f7892de902f7b7899641ba978cd651791ec4670d4ef780a09a7918e9eb0ef5fa68af9c623d16ce35cdeeb990d54bf08663cf626978
+  checksum: 10/487859fa87032d8ece63fd403231af6f75a48423f5c63a6c59254d69a1297babe96b882fdb8defcb1ac2cfa05c451ebf5faf4cd47c1baef66aa5d599ce3f4e32
   languageName: node
   linkType: hard
 
@@ -2788,18 +2811,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.48.0-next.0&npm=0.35.3-next.0, @backstage/cli@npm:^0.35.3-next.0":
-  version: 0.35.3-next.0
-  resolution: "@backstage/cli@npm:0.35.3-next.0"
+"@backstage/cli@backstage:^::backstage=1.48.0-next.1&npm=0.35.4-next.1, @backstage/cli@npm:^0.35.4-next.1":
+  version: 0.35.4-next.1
+  resolution: "@backstage/cli@npm:0.35.4-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/cli-common": "npm:0.1.18-next.0"
-    "@backstage/cli-node": "npm:0.2.17-next.0"
+    "@backstage/cli-node": "npm:0.2.18-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/config-loader": "npm:1.10.8-next.0"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/eslint-plugin": "npm:0.2.1-next.0"
-    "@backstage/integration": "npm:1.19.3-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
     "@backstage/release-manifests": "npm:0.0.13"
     "@backstage/types": "npm:1.2.2"
     "@manypkg/get-packages": "npm:^1.1.3"
@@ -2930,7 +2953,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/1e499fc06c47272a724e55aad3d1a336d05d03708b4194b2645f99a6fa9c841081e76333f3a524f60860f27ad7bef5a4fdcb3c72cdf3e6f9ec5630967f1ae2a8
+  checksum: 10/60bf9f2665011f62dfbe07b97a8bcd1bd26cf9c15ee8c0e6e16ff3b250b60d68275c79a29cc92346cef6c4ad398f0adeb45abef6490b6156a116a82e4630759b
   languageName: node
   linkType: hard
 
@@ -2980,7 +3003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.48.0-next.0&npm=1.3.6, @backstage/config@npm:1.3.6, @backstage/config@npm:^1.3.6":
+"@backstage/config@backstage:^::backstage=1.48.0-next.1&npm=1.3.6, @backstage/config@npm:1.3.6, @backstage/config@npm:^1.3.6":
   version: 1.3.6
   resolution: "@backstage/config@npm:1.3.6"
   dependencies:
@@ -2991,12 +3014,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.48.0-next.0&npm=1.19.4-next.0, @backstage/core-app-api@npm:1.19.4-next.0, @backstage/core-app-api@npm:^1.19.4-next.0":
-  version: 1.19.4-next.0
-  resolution: "@backstage/core-app-api@npm:1.19.4-next.0"
+"@backstage/core-app-api@backstage:^::backstage=1.48.0-next.1&npm=1.19.5-next.0, @backstage/core-app-api@npm:1.19.5-next.0, @backstage/core-app-api@npm:^1.19.5-next.0":
+  version: 1.19.5-next.0
+  resolution: "@backstage/core-app-api@npm:1.19.5-next.0"
   dependencies:
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     "@types/prop-types": "npm:^15.7.3"
@@ -3015,7 +3038,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a6a741c980126d762c074c9f389bb60ae92e1c167a16791856851e04e96d36f5965cc46e29208c6684e1359e85e388b8ec4f354d0857cfc2a9f512de0cc1f1d0
+  checksum: 10/7792a443e1138df45fcff888807a59bf70aa13a1e1786cfaac8f61490bb775bf7737005a6984ac2b554b040227bb17ed9b7795a11b0def366fdf1991cb0fa018
   languageName: node
   linkType: hard
 
@@ -3047,14 +3070,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.48.0-next.0&npm=0.5.7-next.0, @backstage/core-compat-api@npm:0.5.7-next.0, @backstage/core-compat-api@npm:^0.5.7-next.0":
-  version: 0.5.7-next.0
-  resolution: "@backstage/core-compat-api@npm:0.5.7-next.0"
+"@backstage/core-compat-api@backstage:^::backstage=1.48.0-next.1&npm=0.5.8-next.1, @backstage/core-compat-api@npm:0.5.8-next.1, @backstage/core-compat-api@npm:^0.5.8-next.1":
+  version: 0.5.8-next.1
+  resolution: "@backstage/core-compat-api@npm:0.5.8-next.1"
   dependencies:
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
     "@backstage/plugin-app-react": "npm:0.1.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     lodash: "npm:^4.17.21"
@@ -3067,7 +3090,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b1f6a5429475abe23b95d60c9f25c185b98cabccde1a6e18656e6791ff86483f47850318c344439b423e2b23e0430995e42d2f248ff2be409c3263fe0f298a10
+  checksum: 10/d0727a9e7940f9b630a550ea1aa4b882dd8b32b86e3a4360ff7320c678c1206a97dc1eace01a8fa38c7c5c36e87777f13d3e54d1f340b0db4283a531d472c77a
   languageName: node
   linkType: hard
 
@@ -3094,7 +3117,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.48.0-next.0&npm=0.18.6-next.0, @backstage/core-components@npm:0.18.6-next.0, @backstage/core-components@npm:^0.18.6-next.0":
+"@backstage/core-components@backstage:^::backstage=1.48.0-next.1&npm=0.18.7-next.1, @backstage/core-components@npm:0.18.7-next.1, @backstage/core-components@npm:^0.18.7-next.1":
+  version: 0.18.7-next.1
+  resolution: "@backstage/core-components@npm:0.18.7-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/theme": "npm:0.7.2-next.0"
+    "@backstage/version-bridge": "npm:1.0.11"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.3.2"
+    linkifyjs: "npm:4.3.2"
+    lodash: "npm:^4.17.21"
+    parse5: "npm:^6.0.0"
+    pluralize: "npm:^8.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-full-screen: "npm:^1.1.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    rehype-raw: "npm:^6.0.0"
+    rehype-sanitize: "npm:^5.0.0"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/8be777d8f9598409985e184d7b17ad08d312030b98a23df2c7601d0279b85d6c01764f4a4c3566a5490568c5c88cbbf1f795741674ddc1ce053389856da34350
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.18.6-next.0":
   version: 0.18.6-next.0
   resolution: "@backstage/core-components@npm:0.18.6-next.0"
   dependencies:
@@ -3210,7 +3291,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.48.0-next.0&npm=1.12.2-next.0, @backstage/core-plugin-api@npm:1.12.2-next.0, @backstage/core-plugin-api@npm:^1.12.2-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.48.0-next.1&npm=1.12.3-next.0, @backstage/core-plugin-api@npm:1.12.3-next.0, @backstage/core-plugin-api@npm:^1.12.3-next.0":
+  version: 1.12.3-next.0
+  resolution: "@backstage/core-plugin-api@npm:1.12.3-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    history: "npm:^5.0.0"
+    zod: "npm:^3.25.76"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/0a4e0da7542453b7492a0ea0483ec3807394e389c00e846274bfbf7443b13b9f457b02286b531b4e22fd91b0ab01f53280033bd427e0db9266ccfd480db0c666
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:1.12.2-next.0":
   version: 1.12.2-next.0
   resolution: "@backstage/core-plugin-api@npm:1.12.2-next.0"
   dependencies:
@@ -3256,7 +3360,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.48.0-next.0&npm=0.1.2-next.0, @backstage/e2e-test-utils@npm:^0.1.2-next.0":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.48.0-next.1&npm=0.1.2-next.0, @backstage/e2e-test-utils@npm:^0.1.2-next.0":
   version: 0.1.2-next.0
   resolution: "@backstage/e2e-test-utils@npm:0.1.2-next.0"
   dependencies:
@@ -3291,16 +3395,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-app-api@npm:0.14.1-next.0":
-  version: 0.14.1-next.0
-  resolution: "@backstage/frontend-app-api@npm:0.14.1-next.0"
+"@backstage/frontend-app-api@npm:0.15.0-next.1":
+  version: 0.15.0-next.1
+  resolution: "@backstage/frontend-app-api@npm:0.15.0-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-app-api": "npm:1.19.4-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-app-api": "npm:1.19.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-defaults": "npm:0.3.6-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
+    "@backstage/frontend-defaults": "npm:0.4.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     lodash: "npm:^4.17.21"
@@ -3313,7 +3417,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/32c237d50509ea2f8afd708619769c442ce0eeef7ccb9a24e95337d01360bb1d867e2be425a581f4b219c3bcaa7d6f2098dfb5d03f9889b4feaf4893b61dd961
+  checksum: 10/0164918ec2a2c34d781767fd2ed752e5194c126845d7530e439918cd6a785326e24788f173abd9163a6a1f633d05a69a9e5821559a282ce49bff41b25cc9e5d2
   languageName: node
   linkType: hard
 
@@ -3343,16 +3447,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.48.0-next.0&npm=0.3.6-next.0, @backstage/frontend-defaults@npm:0.3.6-next.0, @backstage/frontend-defaults@npm:^0.3.6-next.0":
-  version: 0.3.6-next.0
-  resolution: "@backstage/frontend-defaults@npm:0.3.6-next.0"
+"@backstage/frontend-defaults@backstage:^::backstage=1.48.0-next.1&npm=0.4.0-next.1, @backstage/frontend-defaults@npm:0.4.0-next.1, @backstage/frontend-defaults@npm:^0.4.0-next.1":
+  version: 0.4.0-next.1
+  resolution: "@backstage/frontend-defaults@npm:0.4.0-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-components": "npm:0.18.6-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-app-api": "npm:0.14.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/plugin-app": "npm:0.4.0-next.0"
+    "@backstage/frontend-app-api": "npm:0.15.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/plugin-app": "npm:0.4.0-next.1"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -3362,7 +3466,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1c954bd06ce09c249cc82d19d8a485f93b8743753545d4342edbe6627a0ec09fa7a9af791c0d615b7449ebf05c2e4b267aea0d487594fd8a544611c2d2ee8228
+  checksum: 10/aeaaac2ab0bbae09afaf037a8ab241804185af586712290796f309bbb260b3ca89c6b9a1a5b4f68ec49610cb30ca2c02b8fe1143dfa1cdf07b3781a7045772a1
   languageName: node
   linkType: hard
 
@@ -3389,7 +3493,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.48.0-next.0&npm=0.14.0-next.0, @backstage/frontend-plugin-api@npm:0.14.0-next.0, @backstage/frontend-plugin-api@npm:^0.14.0-next.0":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.48.0-next.1&npm=0.14.0-next.1, @backstage/frontend-plugin-api@npm:0.14.0-next.1, @backstage/frontend-plugin-api@npm:^0.14.0-next.1":
+  version: 0.14.0-next.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.14.0-next.1"
+  dependencies:
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.11"
+    zod: "npm:^3.25.76"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/7ea37c234898885df5c34d0688a47fa31f6fa22f403b1d09d9069cdf0915643f422a88e0a9ef8e3d0b5990d936ca2cb72b2bfc57ac230a9644d6c256192f5afb
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:0.14.0-next.0":
   version: 0.14.0-next.0
   resolution: "@backstage/frontend-plugin-api@npm:0.14.0-next.0"
   dependencies:
@@ -3431,16 +3556,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-test-utils@npm:0.4.5-next.0":
-  version: 0.4.5-next.0
-  resolution: "@backstage/frontend-test-utils@npm:0.4.5-next.0"
+"@backstage/frontend-test-utils@npm:0.4.6-next.1":
+  version: 0.4.6-next.1
+  resolution: "@backstage/frontend-test-utils@npm:0.4.6-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.6"
-    "@backstage/frontend-app-api": "npm:0.14.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/plugin-app": "npm:0.4.0-next.0"
+    "@backstage/frontend-app-api": "npm:0.15.0-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/plugin-app": "npm:0.4.0-next.1"
     "@backstage/plugin-app-react": "npm:0.1.1-next.0"
-    "@backstage/test-utils": "npm:1.7.15-next.0"
+    "@backstage/test-utils": "npm:1.7.15-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     zod: "npm:^3.25.76"
@@ -3453,7 +3578,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/63ac200119c6e33d7997c6e455b4bb9fcf193f16b63fcdaaf94308764de28078a1141c66c0ae8bf521723ce4a9df2d527652ef3e80711fcdb82bb450c2b16f7c
+  checksum: 10/c3eee5c5891a373e097721e77f9b91c67e9714271180f978697620a82603169e5fe764b7df84ac43b7a57003b7d8c7ae6d554bb96bca8f7a07f4b324f7ea4b4e
   languageName: node
   linkType: hard
 
@@ -3512,13 +3637,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.48.0-next.0&npm=1.2.15-next.0, @backstage/integration-react@npm:1.2.15-next.0, @backstage/integration-react@npm:^1.2.15-next.0":
-  version: 1.2.15-next.0
-  resolution: "@backstage/integration-react@npm:1.2.15-next.0"
+"@backstage/integration-react@backstage:^::backstage=1.48.0-next.1&npm=1.2.15-next.1, @backstage/integration-react@npm:1.2.15-next.1, @backstage/integration-react@npm:^1.2.15-next.1":
+  version: 1.2.15-next.1
+  resolution: "@backstage/integration-react@npm:1.2.15-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/integration": "npm:1.19.3-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
   peerDependencies:
@@ -3529,7 +3654,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ac9724887ea5eed1d5b345851ee6a2ab9704e2cee23d00ab491aec0f31f92bc13133a5364f7a43a99b7f677f0e48ff4a04c7a56ed762b1b2990c0eb5cb8f23f9
+  checksum: 10/ae6340a1eb9214cf71d172fc3af36f422f9b20a072ea42451a467ce805ced999023925824616d44f1c859cfa44e9cb20a8ae6a62d73e1c4b9019cf4181832ef9
   languageName: node
   linkType: hard
 
@@ -3572,6 +3697,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration@npm:1.20.0-next.1":
+  version: 1.20.0-next.1
+  resolution: "@backstage/integration@npm:1.20.0-next.1"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+  checksum: 10/ae07bf8b71ec393ebcaab95a5a8a0de7172ab10812900c0b6ebed646be2e993ddf1def763f2dbb2441bbae36206db98ef25dcf0b35f9f9b72c03b76fe0759b67
+  languageName: node
+  linkType: hard
+
 "@backstage/integration@npm:^1.19.0, @backstage/integration@npm:^1.19.2":
   version: 1.19.2
   resolution: "@backstage/integration@npm:1.19.2"
@@ -3590,18 +3733,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.48.0-next.0&npm=0.13.4-next.0, @backstage/plugin-api-docs@npm:^0.13.4-next.0":
-  version: 0.13.4-next.0
-  resolution: "@backstage/plugin-api-docs@npm:0.13.4-next.0"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.48.0-next.1&npm=0.13.4-next.1, @backstage/plugin-api-docs@npm:^0.13.4-next.1":
+  version: 0.13.4-next.1
+  resolution: "@backstage/plugin-api-docs@npm:0.13.4-next.1"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/plugin-catalog": "npm:1.32.3-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/plugin-catalog": "npm:1.33.0-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.8-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.40-next.0"
     "@graphiql/react": "npm:^0.23.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -3620,11 +3763,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/0a53327998f29c245815dadb254d29a80dd163781ac31aac076064df71f1116af03683510a1da5127b5bbedbf2aedd73370be4e5061f283144bbd74bd24a9ae3
+  checksum: 10/5673d679ee2ce144fc39aed40861dfe1be66fdf60824878ded6ea73d65a0cdb2c45a3b3306269bfb29308e7ef3880f4a0f076176d94cfc774e5b22493dc428e7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.48.0-next.0&npm=0.5.11-next.0, @backstage/plugin-app-backend@npm:^0.5.11-next.0":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.48.0-next.1&npm=0.5.11-next.0, @backstage/plugin-app-backend@npm:^0.5.11-next.0":
   version: 0.5.11-next.0
   resolution: "@backstage/plugin-app-backend@npm:0.5.11-next.0"
   dependencies:
@@ -3661,7 +3804,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-react@backstage:^::backstage=1.48.0-next.0&npm=0.1.1-next.0, @backstage/plugin-app-react@npm:0.1.1-next.0, @backstage/plugin-app-react@npm:^0.1.1-next.0":
+"@backstage/plugin-app-react@backstage:^::backstage=1.48.0-next.1&npm=0.1.1-next.0, @backstage/plugin-app-react@npm:0.1.1-next.0, @backstage/plugin-app-react@npm:^0.1.1-next.0":
   version: 0.1.1-next.0
   resolution: "@backstage/plugin-app-react@npm:0.1.1-next.0"
   dependencies:
@@ -3699,17 +3842,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@npm:0.4.0-next.0":
-  version: 0.4.0-next.0
-  resolution: "@backstage/plugin-app@npm:0.4.0-next.0"
+"@backstage/plugin-app@npm:0.4.0-next.1":
+  version: 0.4.0-next.1
+  resolution: "@backstage/plugin-app@npm:0.4.0-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/integration-react": "npm:1.2.15-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/integration-react": "npm:1.2.15-next.1"
     "@backstage/plugin-app-react": "npm:0.1.1-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.40-next.0"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.9.13"
@@ -3726,7 +3869,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5d91d67e408df2c254a62858a7bf71a56bdaa58c29df22bb14397a734654ecbd9b5e2d309063b46b67b324720fb4310bd73481fc350301c28a5ce98bf27e7843
+  checksum: 10/c3ceabd9ae42feb66c1313823b959103f39cd26377fb607da9f427b148c664261693e51365f1cd3fa8e5ab6796fd156a5abe74726a4cde502b20fd32fcb62d17
   languageName: node
   linkType: hard
 
@@ -3761,7 +3904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.48.0-next.0&npm=0.5.0-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.0-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.48.0-next.1&npm=0.5.0-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.0-next.0":
   version: 0.5.0-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.5.0-next.0"
   dependencies:
@@ -3773,7 +3916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.48.0-next.0&npm=0.2.16-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.16-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.48.0-next.1&npm=0.2.16-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.16-next.0":
   version: 0.2.16-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.16-next.0"
   dependencies:
@@ -3786,7 +3929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.48.0-next.0&npm=0.26.1-next.0, @backstage/plugin-auth-backend@npm:^0.26.1-next.0":
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.48.0-next.1&npm=0.26.1-next.0, @backstage/plugin-auth-backend@npm:^0.26.1-next.0":
   version: 0.26.1-next.0
   resolution: "@backstage/plugin-auth-backend@npm:0.26.1-next.0"
   dependencies:
@@ -3838,6 +3981,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-node@npm:0.6.13-next.0":
+  version: 0.6.13-next.0
+  resolution: "@backstage/plugin-auth-node@npm:0.6.13-next.0"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
+    "@backstage/catalog-client": "npm:1.12.1"
+    "@backstage/catalog-model": "npm:1.7.6"
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.22.0"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76"
+    zod-to-json-schema: "npm:^3.25.1"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10/c6ea3b67d51aeb335db3d14719a2066cd1cd44e5e16b18fea9d89e620bb77829823ba0231925e251b78f4b91ad210f35c912202c27ecab91144733c742725d86
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-node@npm:^0.6.10, @backstage/plugin-auth-node@npm:^0.6.11":
   version: 0.6.11
   resolution: "@backstage/plugin-auth-node@npm:0.6.11"
@@ -3882,24 +4048,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-bitbucket-cloud-common@npm:0.3.7-next.0":
-  version: 0.3.7-next.0
-  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.3.7-next.0"
+"@backstage/plugin-bitbucket-cloud-common@npm:0.3.7-next.1":
+  version: 0.3.7-next.1
+  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.3.7-next.1"
   dependencies:
-    "@backstage/integration": "npm:1.19.3-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
     cross-fetch: "npm:^4.0.0"
-  checksum: 10/6a3b004db137beff04197cf647555f8b45ebe71889746eeb7c5f07bc7817abe0d285b695821f3fc7eb4be28afc5e145f123e6b6c814f8beff446a540b2c79a15
+  checksum: 10/4e83fa36f10539b8cfe009de949d82b1c9c51c4245b5122ab930a2e77d161f06515cb483813545bcb274c7996efd90ef49a6f519276866db2550ba7930c7f513
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.48.0-next.0&npm=0.12.2-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.12.2-next.0":
-  version: 0.12.2-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.12.2-next.0"
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.48.0-next.1&npm=0.12.2-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.12.2-next.1":
+  version: 0.12.2-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.12.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/integration": "npm:1.19.3-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.8-next.0"
     "@backstage/plugin-catalog-node": "npm:1.21.0-next.0"
     "@backstage/plugin-events-node": "npm:0.4.19-next.0"
@@ -3911,11 +4077,11 @@ __metadata:
     lodash: "npm:^4.17.21"
     minimatch: "npm:^9.0.0"
     uuid: "npm:^11.0.0"
-  checksum: 10/832038313617e33cd15e7db82b654e0dbdbaa9591891aa3fa3a4905af8498cbba6ffe11ebb437cc43190c79fc6ae3f1a2532159aef82929b9524e695e80d3eb1
+  checksum: 10/5bf8bb2724a41decacae07956a1b7cbc9354d041a726d3411836f8915a6ca76aad2ffe73c582ee73c0e629731b0ce211abf594c116934ac0b4f419a8886116e5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.48.0-next.0&npm=0.1.19-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.19-next.0":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.48.0-next.1&npm=0.1.19-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.19-next.0":
   version: 0.1.19-next.0
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.19-next.0"
   dependencies:
@@ -3926,7 +4092,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.48.0-next.0&npm=0.2.17-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.17-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.17-next.0":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.48.0-next.1&npm=0.2.17-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.17-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.17-next.0":
   version: 0.2.17-next.0
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.17-next.0"
   dependencies:
@@ -3939,7 +4105,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.48.0-next.0&npm=3.4.0-next.0, @backstage/plugin-catalog-backend@npm:3.4.0-next.0, @backstage/plugin-catalog-backend@npm:^3.4.0-next.0":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.48.0-next.1&npm=3.4.0-next.1, @backstage/plugin-catalog-backend@npm:^3.4.0-next.1":
+  version: 3.4.0-next.1
+  resolution: "@backstage/plugin-catalog-backend@npm:3.4.0-next.1"
+  dependencies:
+    "@backstage/backend-openapi-utils": "npm:0.6.6-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
+    "@backstage/catalog-client": "npm:1.12.1"
+    "@backstage/catalog-model": "npm:1.7.6"
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.1.8-next.0"
+    "@backstage/plugin-catalog-node": "npm:1.21.0-next.0"
+    "@backstage/plugin-events-node": "npm:0.4.19-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.10-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@opentelemetry/api": "npm:^1.9.0"
+    codeowners-utils: "npm:^1.0.2"
+    core-js: "npm:^3.6.5"
+    express: "npm:^4.22.0"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    fs-extra: "npm:^11.2.0"
+    git-url-parse: "npm:^15.0.0"
+    glob: "npm:^7.1.6"
+    knex: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    minimatch: "npm:^9.0.0"
+    p-limit: "npm:^3.0.2"
+    prom-client: "npm:^15.0.0"
+    uuid: "npm:^11.0.0"
+    yaml: "npm:^2.0.0"
+    yn: "npm:^4.0.0"
+    zod: "npm:^3.25.76"
+  checksum: 10/69dd4f0ce7c1713ec5f3e52b1bef302f6ccf0b4bc32b58838cfdd1aa7141227d6b8a248962e87f67387a521ad033bc7d504b7676c206d9b95864fd357138d7a4
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend@npm:3.4.0-next.0":
   version: 3.4.0-next.0
   resolution: "@backstage/plugin-catalog-backend@npm:3.4.0-next.0"
   dependencies:
@@ -3978,7 +4183,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.48.0-next.0&npm=1.1.8-next.0, @backstage/plugin-catalog-common@npm:1.1.8-next.0, @backstage/plugin-catalog-common@npm:^1.1.8-next.0":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.48.0-next.1&npm=1.1.8-next.0, @backstage/plugin-catalog-common@npm:1.1.8-next.0, @backstage/plugin-catalog-common@npm:^1.1.8-next.0":
   version: 1.1.8-next.0
   resolution: "@backstage/plugin-catalog-common@npm:1.1.8-next.0"
   dependencies:
@@ -4000,16 +4205,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.48.0-next.0&npm=0.5.7-next.0, @backstage/plugin-catalog-graph@npm:^0.5.7-next.0":
-  version: 0.5.7-next.0
-  resolution: "@backstage/plugin-catalog-graph@npm:0.5.7-next.0"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.48.0-next.1&npm=0.5.7-next.1, @backstage/plugin-catalog-graph@npm:^0.5.7-next.1":
+  version: 0.5.7-next.1
+  resolution: "@backstage/plugin-catalog-graph@npm:0.5.7-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4027,11 +4232,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/34456164098731e7eb5a749432e3a3ef464ac5c2ee8e7730cbbd9b381314faf660b225ac1f09f9b5b7d3bbc62635acbb4829fc9a2993d4f10773311b5c8f7c84
+  checksum: 10/01ab5922ed3de13e1894d48658a408fbd0d603516f1d8354bd8cb7c9aa1e94dd382078ee1c270a4d11ae1204447d88142c17ab76c9c451896427cb81f82a486e
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.48.0-next.0&npm=1.21.0-next.0, @backstage/plugin-catalog-node@npm:1.21.0-next.0, @backstage/plugin-catalog-node@npm:^1.21.0-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.48.0-next.1&npm=1.21.0-next.0, @backstage/plugin-catalog-node@npm:1.21.0-next.0, @backstage/plugin-catalog-node@npm:^1.21.0-next.0":
   version: 1.21.0-next.0
   resolution: "@backstage/plugin-catalog-node@npm:1.21.0-next.0"
   dependencies:
@@ -4067,23 +4272,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.48.0-next.0&npm=1.21.6-next.0, @backstage/plugin-catalog-react@npm:1.21.6-next.0, @backstage/plugin-catalog-react@npm:^1.21.6-next.0":
-  version: 1.21.6-next.0
-  resolution: "@backstage/plugin-catalog-react@npm:1.21.6-next.0"
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.48.0-next.1&npm=1.22.0-next.1, @backstage/plugin-catalog-react@npm:1.22.0-next.1, @backstage/plugin-catalog-react@npm:^1.22.0-next.1":
+  version: 1.22.0-next.1
+  resolution: "@backstage/plugin-catalog-react@npm:1.22.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-compat-api": "npm:0.5.7-next.0"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-compat-api": "npm:0.5.8-next.1"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/frontend-test-utils": "npm:0.4.5-next.0"
-    "@backstage/integration-react": "npm:1.2.15-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/frontend-test-utils": "npm:0.4.6-next.1"
+    "@backstage/integration-react": "npm:1.2.15-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.8-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.5-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.40-next.0"
     "@backstage/types": "npm:1.2.2"
+    "@backstage/ui": "npm:0.12.0-next.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4104,7 +4310,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a77e6aa918f0e1acbd59d0d428d9009a501a4df6a5c3d2148eaec458ace589b82447b2a80a50864de7c875c380ec4174097a4ed1994955b8e06c779b461590f9
+  checksum: 10/e0a718c458d479109ad892c809958812cecf3fa90a15467d632d6672258c4c04933492966ebb8dcedfbda0eab45626b8a7297fda131cc13af1703d743b3c83e0
   languageName: node
   linkType: hard
 
@@ -4149,27 +4355,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.48.0-next.0&npm=1.32.3-next.0, @backstage/plugin-catalog@npm:1.32.3-next.0, @backstage/plugin-catalog@npm:^1.32.3-next.0":
-  version: 1.32.3-next.0
-  resolution: "@backstage/plugin-catalog@npm:1.32.3-next.0"
+"@backstage/plugin-catalog@backstage:^::backstage=1.48.0-next.1&npm=1.33.0-next.1, @backstage/plugin-catalog@npm:1.33.0-next.1, @backstage/plugin-catalog@npm:^1.33.0-next.1":
+  version: 1.33.0-next.1
+  resolution: "@backstage/plugin-catalog@npm:1.33.0-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-compat-api": "npm:0.5.7-next.0"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-compat-api": "npm:0.5.8-next.1"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/integration-react": "npm:1.2.15-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/integration-react": "npm:1.2.15-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.8-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.40-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.7.6-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.7.6-next.1"
     "@backstage/plugin-search-common": "npm:1.2.22-next.0"
-    "@backstage/plugin-search-react": "npm:1.10.3-next.0"
+    "@backstage/plugin-search-react": "npm:1.10.3-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.8-next.0"
     "@backstage/types": "npm:1.2.2"
+    "@backstage/ui": "npm:0.12.0-next.1"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4191,28 +4398,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e75b22c1d132cf1189203315be69745d190c7f50a04dbf5ff8e0a58e4b8af73333acedbeada46a32c622f5f6b616942f92c80038a049bbfb3641183dcc5888bb
+  checksum: 10/8b37266e30162965203fae972a4a41b4324c52491b49d81d86856dfe66f4fabe0f14f6f300148107ce0fb0031de5a53b3aa91b5a0a580a97bfc18596778a1772
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.48.0-next.0&npm=0.4.9-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.9-next.0":
-  version: 0.4.9-next.0
-  resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.9-next.0"
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.48.0-next.1&npm=0.4.9-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.9-next.1":
+  version: 0.4.9-next.1
+  resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.9-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/integration": "npm:1.19.3-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
     "@backstage/plugin-events-node": "npm:0.4.19-next.0"
     "@backstage/types": "npm:1.2.2"
     "@octokit/auth-callback": "npm:^5.0.0"
     "@octokit/webhooks-methods": "npm:^3.0.0"
     lodash: "npm:^4.17.21"
     octokit: "npm:^3.0.0"
-  checksum: 10/ba0f8ffa5166c54b8503ec5f9b5be43e71f5c8eb2429f5255772daec8cf74d1807dda0c34b8b7d7791beaa8fe096b270687bc7dbd221603310b3a93e9c11dbe5
+  checksum: 10/ec94878479508f8238685fe8f0436edc649198f386d7a4c0c2c91603b580c7fa1b78f381015ee38ad4c895d573e7e4a3fe5fbb10bebce9be2bc7c659ab37a88f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.48.0-next.0&npm=0.5.11-next.0, @backstage/plugin-events-backend@npm:^0.5.11-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.48.0-next.1&npm=0.5.11-next.0, @backstage/plugin-events-backend@npm:^0.5.11-next.0":
   version: 0.5.11-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.5.11-next.0"
   dependencies:
@@ -4287,20 +4494,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.48.0-next.0&npm=0.9.1-next.0, @backstage/plugin-home@npm:^0.9.1-next.0":
-  version: 0.9.1-next.0
-  resolution: "@backstage/plugin-home@npm:0.9.1-next.0"
+"@backstage/plugin-home@backstage:^::backstage=1.48.0-next.1&npm=0.9.2-next.1, @backstage/plugin-home@npm:^0.9.2-next.1":
+  version: 0.9.2-next.1
+  resolution: "@backstage/plugin-home@npm:0.9.2-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-app-api": "npm:1.19.4-next.0"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/core-app-api": "npm:1.19.5-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/plugin-home-react": "npm:0.1.35-next.0"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -4322,28 +4529,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fb5baf513e81e0568beaea80eab4dc6ee3c21320fc239e56c7c82d2ab89b5f58443284efb476f76377c9feada36d26ec7c10a3e2f1071576b69135f62e3ae92d
+  checksum: 10/5082241d2b34e032d60f4c35acfd2e5ac052054f8ae9e933ecce9de94b0dfcd81116167c37d944c530673bffa653e2b5e2ba3b2c15602bad9fb179182fffd99b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.48.0-next.0&npm=0.21.1-next.0, @backstage/plugin-kubernetes-backend@npm:^0.21.1-next.0":
-  version: 0.21.1-next.0
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.1-next.0"
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.48.0-next.1&npm=0.21.1-next.1, @backstage/plugin-kubernetes-backend@npm:^0.21.1-next.1":
+  version: 0.21.1-next.1
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.1-next.1"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@azure/identity": "npm:^4.0.0"
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
     "@backstage/integration-aws-node": "npm:0.1.20-next.0"
     "@backstage/plugin-catalog-node": "npm:1.21.0-next.0"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.10-next.0"
-    "@backstage/plugin-kubernetes-node": "npm:0.4.1-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.5-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.9-next.0"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.10-next.1"
+    "@backstage/plugin-kubernetes-node": "npm:0.4.1-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.10-next.0"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/container": "npm:^5.0.0"
     "@jest-mock/express": "npm:^2.0.1"
@@ -4357,50 +4564,50 @@ __metadata:
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     node-fetch: "npm:^2.7.0"
-  checksum: 10/8110551d492eb539683f0480bee3d311a37c592cda41968ab47917a69b29c6c38513bb6979a040b4d60133a3af30189549ad81e491319619f74ba5f3687e8ec3
+  checksum: 10/009b714ea08e941017ff4aab739d1d4c8eadf87fe79fbb70c75a2c355ef8d044f54129793be2827ede1d7db234a14353de36e110ee334685c60cea9396825698
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-common@npm:0.9.10-next.0":
-  version: 0.9.10-next.0
-  resolution: "@backstage/plugin-kubernetes-common@npm:0.9.10-next.0"
+"@backstage/plugin-kubernetes-common@npm:0.9.10-next.1":
+  version: 0.9.10-next.1
+  resolution: "@backstage/plugin-kubernetes-common@npm:0.9.10-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/plugin-permission-common": "npm:0.9.5-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
     "@backstage/types": "npm:1.2.2"
     "@kubernetes/client-node": "npm:1.4.0"
     kubernetes-models: "npm:^4.3.1"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-  checksum: 10/a14964159f573c7391cb14f73524f1316401742b1c7dc4ea36a25bf1669cb8d1e4504a2e934834bfc60c8a4f31c46a5b4cb8da897ddb4dac33560c6a9941a041
+  checksum: 10/3d749f043cc11628319babac5e888781c21a7ff9d0909b43f695aad5daec4677de46e590f2fbd06ed7c462abfd0481b95df175cd048f7e552fbc8b14314e583c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-node@npm:0.4.1-next.0":
-  version: 0.4.1-next.0
-  resolution: "@backstage/plugin-kubernetes-node@npm:0.4.1-next.0"
+"@backstage/plugin-kubernetes-node@npm:0.4.1-next.1":
+  version: 0.4.1-next.1
+  resolution: "@backstage/plugin-kubernetes-node@npm:0.4.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.10-next.0"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.10-next.1"
     "@backstage/types": "npm:1.2.2"
     "@kubernetes/client-node": "npm:1.4.0"
     "@types/express": "npm:^4.17.6"
     node-fetch: "npm:^2.7.0"
     winston: "npm:^3.2.1"
-  checksum: 10/398d0533e4db0389d5e7522e41dd76c4744ff823efa969dd3dd28f67647bce8d03fe7c781ae7d2d52a06307fb0f0cd605b14fff8052ae399ef3552d8caac32ba
+  checksum: 10/60899cb9e18040b2880098153fcdfc187a05c625871704a6e3cdd12458886e022873f26554d01a6de909c25b44c194acebbe2a03b64e2ef480fe6e6d30989ed4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-react@npm:0.5.16-next.0":
-  version: 0.5.16-next.0
-  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.16-next.0"
+"@backstage/plugin-kubernetes-react@npm:0.5.16-next.1":
+  version: 0.5.16-next.1
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.16-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.10-next.0"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.10-next.1"
     "@backstage/types": "npm:1.2.2"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
@@ -4425,21 +4632,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3998a305d7b71cadf1a9bcc52f4fdb1494b1400bf6f374264367d814115a8e9926e6d9d91d30ff3697417906bc492aa6b48b315db0f189ffd1971ff2f40122ad
+  checksum: 10/786b37ad906a159f2f2977c28e8e936ed545c471e15b72d42243fd48a97c18a7414400d99ac21fc4d5fb403d7c15ed215c146bb0da9c9c3209448b3c9f65f5ed
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.48.0-next.0&npm=0.12.16-next.0, @backstage/plugin-kubernetes@npm:^0.12.16-next.0":
-  version: 0.12.16-next.0
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.16-next.0"
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.48.0-next.1&npm=0.12.16-next.1, @backstage/plugin-kubernetes@npm:^0.12.16-next.1":
+  version: 0.12.16-next.1
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.16-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.10-next.0"
-    "@backstage/plugin-kubernetes-react": "npm:0.5.16-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.10-next.1"
+    "@backstage/plugin-kubernetes-react": "npm:0.5.16-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.40-next.0"
     "@material-ui/core": "npm:^4.12.2"
   peerDependencies:
@@ -4450,15 +4657,15 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/40477533b0fe50dd7ef47b109825c2d1cf1c31c8db946757b1e00efc931fa6303add5843a41425797cd9e581903e12703f984535af6c7e727b075de27d7d679a
+  checksum: 10/1f10b79392f4c5451dab68bcbdceb4c1dc09199f66007d2d90437a5eb08b7eba01061e2974fbbbb86730a2a68dbd5ee1d2576464571e55c0fef0dd200a9b8839
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.48.0-next.0&npm=0.6.2-next.0, @backstage/plugin-notifications-backend@npm:^0.6.2-next.0":
-  version: 0.6.2-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.6.2-next.0"
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.48.0-next.1&npm=0.6.2-next.1, @backstage/plugin-notifications-backend@npm:^0.6.2-next.1":
+  version: 0.6.2-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.6.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
@@ -4472,7 +4679,7 @@ __metadata:
     knex: "npm:^3.0.0"
     p-throttle: "npm:^4.1.1"
     uuid: "npm:^11.0.0"
-  checksum: 10/48b16d82a6756236c5eddc627ac983f831facd76148eac89f888728b91b54cf3a07a122f8e011163defd4505958664a9e75def1813a9784e81de44c964bf4c3a
+  checksum: 10/caf3960d71aacb226fc4fd6908746a0faa7a4a1de3192e3b51387c1f5c48ccf45443bed3ff7c34a6efb8420e647d6bc7c7799e1398de68ba72472ec783bdc761
   languageName: node
   linkType: hard
 
@@ -4487,7 +4694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.48.0-next.0&npm=0.2.23-next.0, @backstage/plugin-notifications-node@npm:0.2.23-next.0, @backstage/plugin-notifications-node@npm:^0.2.23-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.48.0-next.1&npm=0.2.23-next.0, @backstage/plugin-notifications-node@npm:0.2.23-next.0, @backstage/plugin-notifications-node@npm:^0.2.23-next.0":
   version: 0.2.23-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.23-next.0"
   dependencies:
@@ -4502,17 +4709,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.48.0-next.0&npm=0.5.14-next.0, @backstage/plugin-notifications@npm:^0.5.14-next.0":
-  version: 0.5.14-next.0
-  resolution: "@backstage/plugin-notifications@npm:0.5.14-next.0"
+"@backstage/plugin-notifications@backstage:^::backstage=1.48.0-next.1&npm=0.5.14-next.1, @backstage/plugin-notifications@npm:^0.5.14-next.1":
+  version: 0.5.14-next.1
+  resolution: "@backstage/plugin-notifications@npm:0.5.14-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
     "@backstage/plugin-notifications-common": "npm:0.2.0"
     "@backstage/plugin-signals-react": "npm:0.0.19-next.0"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
     lodash: "npm:^4.17.21"
@@ -4528,20 +4735,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2035f1011ba4d20fa45a49cfcaec3556ebe078b9ff1f3a520540b1e4add1486f6b2df3c46dc60d67ee4e5cb0e13846d6860d97f1c03095830a267b908d96910d
+  checksum: 10/4323bae68d6f8f10ea887193def7424f276dc5d4f08d89d9561d1ba6a4018cf4ff22613d34d807e3df0bd65e1e8c3bc50bd06b8e623c38216221f42bc4bde6e6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.48.0-next.0&npm=0.6.49-next.0, @backstage/plugin-org@npm:^0.6.49-next.0":
-  version: 0.6.49-next.0
-  resolution: "@backstage/plugin-org@npm:0.6.49-next.0"
+"@backstage/plugin-org@backstage:^::backstage=1.48.0-next.1&npm=0.6.49-next.1, @backstage/plugin-org@npm:^0.6.49-next.1":
+  version: 0.6.49-next.1
+  resolution: "@backstage/plugin-org@npm:0.6.49-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.8-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -4558,7 +4765,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/66d4b2232b83e6b73ee7a8156cdc16b2aa4e4f5ad57f10b0e3aa1688188d00bb0a57b6f028ce7bb179dbe303abaeea2eca87466f5aa66b8b539f5e456d48510a
+  checksum: 10/cc3814b35dc27702b135065e054edc0b15088ef7592b05d3b5a3b2df4aae9bccbfb698165208041e17f74b44fa5fad67417d68a0fd30a5596a62e5008f1a4716
   languageName: node
   linkType: hard
 
@@ -4577,6 +4784,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:0.9.6-next.0":
+  version: 0.9.6-next.0
+  resolution: "@backstage/plugin-permission-common@npm:0.9.6-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/types": "npm:1.2.2"
+    cross-fetch: "npm:^4.0.0"
+    uuid: "npm:^11.0.0"
+    zod: "npm:^3.25.76"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10/d99c30a7e9bc1b47f4f25ecb1de3739829cc9b3742305a8c3798150e97f4ae562862117f28dc2e27f21a4e64e22f979500e0d7993924e25b65639ff812aa6a5e
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-common@npm:^0.9.3, @backstage/plugin-permission-common@npm:^0.9.4":
   version: 0.9.4
   resolution: "@backstage/plugin-permission-common@npm:0.9.4"
@@ -4589,6 +4811,24 @@ __metadata:
     zod: "npm:^3.22.4"
     zod-to-json-schema: "npm:^3.25.1"
   checksum: 10/7718aa83e5baaa0c73bc37bf1c802fbf1c965b6fd99bc6371ae6f76bc807776e8de273f6058c1051f618e8abb39403237b6913ab2b6e78dfe138b0b4cb47cc94
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-node@npm:0.10.10-next.0":
+  version: 0.10.10-next.0
+  resolution: "@backstage/plugin-permission-node@npm:0.10.10-next.0"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
+    "@backstage/config": "npm:1.3.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/plugin-auth-node": "npm:0.6.13-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
+    "@types/express": "npm:^4.17.6"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    zod: "npm:^3.25.76"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10/2eae3bed04eb8e0b8cb30cf7f7b52087075cde0452de6fcea60d824a9208474a87bd75829322f465ca1a4a86dc1b566c3a5cfa32aa7b8a12494ec1669cb5dd12
   languageName: node
   linkType: hard
 
@@ -4668,7 +4908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.48.0-next.0&npm=0.6.10-next.0, @backstage/plugin-proxy-backend@npm:^0.6.10-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.48.0-next.1&npm=0.6.10-next.0, @backstage/plugin-proxy-backend@npm:^0.6.10-next.0":
   version: 0.6.10-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.10-next.0"
   dependencies:
@@ -4691,110 +4931,110 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.18-next.0":
-  version: 0.2.18-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.18-next.0"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.18-next.1":
+  version: 0.2.18-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.18-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.4-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.5-next.1"
     azure-devops-node-api: "npm:^14.0.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/44b0547024fb1ba19a044afaf3f5d51d2ea59d5743b34d8c9d294ac35660bbf3186f5d8c7e4e6af99af6e0e559d7bc1908cc98ceea12ae85ecaee64fd555d66a
+  checksum: 10/e1d1bb88e0a8feda8e51f178886e8eab8533f10bba0d4f4679804c9497039a485100efb9eedcf431e1ecb21d007bfa94be3533f0fed2d9c58ca04b4b3fc064d3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.3.2-next.0":
-  version: 0.3.2-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.3.2-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.3.3-next.1":
+  version: 0.3.3-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.3.3-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.7-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.4-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.7-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.5-next.1"
     bitbucket: "npm:^2.12.0"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.25.76"
-  checksum: 10/534171b192f8b9a55a2d70cc3f53896ae1bf706b35c549bb6984da6e17b837cb6f8d92a15d50f980f9c2f3971a894fbbe4abd52934377258875a3adfdacb4383
+  checksum: 10/c7476cc4f17459babeb37f706ebdfd461e7b789da98fcc751cbd54ba2df7e0af6afc10ad963824003da3ab15e3c32d478b8102bba3ff66f090829e6724ebd334
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.18-next.0":
-  version: 0.2.18-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.18-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.18-next.1":
+  version: 0.2.18-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.18-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.4-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.5-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/1cbcd31815e30ba124ec12aa7e9d1b67a8ec99b9446e1b60cdcd46e53b188d8b07588db9a3efc6205563d89298bbe760acfaf07d2a8a0dc45af520206d92764a
+  checksum: 10/ad096fbf9511ce284acf212c738850f48116dcd2e135feea842d31cbf7cb49d0ec3373a167b49a77432cb65291c0f6fa2c49b7c956b11c48a3bfffab31f80665
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.19-next.0":
-  version: 0.3.19-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.19-next.0"
+"@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.19-next.1":
+  version: 0.3.19-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket@npm:0.3.19-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.3.2-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.18-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.4-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.3.3-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.18-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.5-next.1"
     fs-extra: "npm:^11.2.0"
     yaml: "npm:^2.0.0"
-  checksum: 10/a00f98eee7a8385797d7819f014d3936e0a3dfe9565d6e950e9eb41434a2c95e6c79d4e8f1f7b29fa19e0168939cfd087a102ba09507b84d9a201cf0ce1ac6f8
+  checksum: 10/1744bb4f59ad2ca61d232f7b0b840e3c5269a015665ad58ef594c81b36fc4620479be50c90ca5965b805dff006a1d40996f260ff2c64ae0fd6f8547f67cd171c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.18-next.0":
-  version: 0.2.18-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.18-next.0"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.18-next.1":
+  version: 0.2.18-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.18-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.4-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.5-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/2eeabf8afca02dd6992b7172e03c1cc0f4e6c2a9206906cc35e32ed08a970a29d2bd9fcea0c298b9595cf73a4a3aad12f5c7dfeacbf66dfdf5ce636869fd2836
+  checksum: 10/b6a69def67feed5a941b07736e0831bfe9cefa4c5c305f44adf4794f6bc455b64463a9e12499b89729baa56fd72000364a8b02658b18c822e7d5c73298ec52d5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.18-next.0":
-  version: 0.2.18-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.18-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.18-next.1":
+  version: 0.2.18-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitea@npm:0.2.18-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.4-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.5-next.1"
     yaml: "npm:^2.0.0"
-  checksum: 10/09c5bc64d90b64fb851c7a9e79952ac5d797bfb835abd2c7d37d426817573c2f495cf7d77c684f2d2c2a11bd5b7a00fa8c3169fd014471981a3226cf4f05b56d
+  checksum: 10/fa6581afff10357ec3b19c16b08f5763128410db0012388a1f218c2012c59614958f941656a1a0e2bbc8b206f70895f67d74df5d2965a335759978c86f466fcb
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.48.0-next.0&npm=0.9.5-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.5-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.5-next.0":
-  version: 0.9.5-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.5-next.0"
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.48.0-next.1&npm=0.9.6-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:0.9.6-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.6-next.1":
+  version: 0.9.6-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.6-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
     "@backstage/plugin-catalog-node": "npm:1.21.0-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.4-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.5-next.1"
     "@backstage/types": "npm:1.2.2"
     "@octokit/webhooks": "npm:^10.9.2"
     libsodium-wrappers: "npm:^0.7.11"
@@ -4802,29 +5042,29 @@ __metadata:
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.25.76"
-  checksum: 10/def3cd69212e9aff6b116cd2707c0afd1aa88987182d7e2e8f7b63845575102972e73ee37b5021b3dd9ed2746924ccfc141937d0cd528e14f84aed0b03aae9db
+  checksum: 10/e92550d557ebaa6702e90fac42aa0a42dbe7264cbccd99be87574e87c1d5dbabf67f7a32dfee6dca8e28db4cbf7e501b7caf86db21379e8d0e52e3b0905eb1a0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.11.2-next.0":
-  version: 0.11.2-next.0
-  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.11.2-next.0"
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.11.3-next.1":
+  version: 0.11.3-next.1
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.11.3-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.4-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.5-next.1"
     "@gitbeaker/requester-utils": "npm:^41.2.0"
     "@gitbeaker/rest": "npm:^41.2.0"
     luxon: "npm:^3.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.25.76"
-  checksum: 10/eb18115af60ea83abdec2541036ed527521ed1b56aeefd22c25de36c1ab85e730424f783e064a2d5ee994af3b1d57a9ce8121c0e1c7419a284db3f054d8142ef
+  checksum: 10/81cb77fb6743939c66f11b42e43a2dffd32d5ca20df9f96a1467453e8353661f7c99be8942a510dc430946fa20a9ec1629e1c660ac84f265c7b13bb2597ce717
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.48.0-next.0&npm=0.1.19-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.19-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.48.0-next.1&npm=0.1.19-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.19-next.0":
   version: 0.1.19-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.19-next.0"
   dependencies:
@@ -4837,34 +5077,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.48.0-next.0&npm=3.1.2-next.0, @backstage/plugin-scaffolder-backend@npm:^3.1.2-next.0":
-  version: 3.1.2-next.0
-  resolution: "@backstage/plugin-scaffolder-backend@npm:3.1.2-next.0"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.48.0-next.1&npm=3.1.3-next.1, @backstage/plugin-scaffolder-backend@npm:^3.1.3-next.1":
+  version: 3.1.3-next.1
+  resolution: "@backstage/plugin-scaffolder-backend@npm:3.1.3-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.15.1-next.0"
+    "@backstage/backend-defaults": "npm:0.15.2-next.1"
     "@backstage/backend-openapi-utils": "npm:0.6.6-next.0"
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/plugin-auth-node": "npm:0.6.12-next.0"
-    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.7-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-auth-node": "npm:0.6.13-next.0"
+    "@backstage/plugin-bitbucket-cloud-common": "npm:0.3.7-next.1"
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:0.2.17-next.0"
     "@backstage/plugin-catalog-node": "npm:1.21.0-next.0"
     "@backstage/plugin-events-node": "npm:0.4.19-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.5-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.9-next.0"
-    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.18-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.19-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.3.2-next.0"
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.18-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.18-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.18-next.0"
-    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.9.5-next.0"
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.11.2-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.7.6-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.12.4-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.10-next.0"
+    "@backstage/plugin-scaffolder-backend-module-azure": "npm:0.2.18-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket": "npm:0.3.19-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "npm:0.3.3-next.1"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "npm:0.2.18-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "npm:0.2.18-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitea": "npm:0.2.18-next.1"
+    "@backstage/plugin-scaffolder-backend-module-github": "npm:0.9.6-next.1"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "npm:0.11.3-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:1.7.6-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.12.5-next.1"
     "@backstage/types": "npm:1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     "@types/luxon": "npm:^3.0.0"
@@ -4891,7 +5131,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.25.76"
     zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10/1b5748ec120493f04250f5d98519a53703de70c1c1afdb8ea336baba66ecbd5d39e14705d191cf452e1a29db693967a2d94b41df1e5c838ef17a6466b2a703d7
+  checksum: 10/ccdbc33d379c0761e883c24fcb3794ffbc893d2916d0036baea4fcfd668d681b7b10fd59e794460209838524dbe3b2658bc59aa5b53484fa1e1f364032d19a1f
   languageName: node
   linkType: hard
 
@@ -4911,6 +5151,25 @@ __metadata:
     uri-template: "npm:^2.0.0"
     zen-observable: "npm:^0.10.0"
   checksum: 10/1afaa63a948981a1cbf08d045863c6e045c35be52cf374c0f59896399002b870b5a3b66f2be6d53aade27183f9dbc69d8a5121ad3e675d413627483a9aab18d2
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-common@npm:1.7.6-next.1":
+  version: 1.7.6-next.1
+  resolution: "@backstage/plugin-scaffolder-common@npm:1.7.6-next.1"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.7.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@microsoft/fetch-event-source": "npm:^2.0.1"
+    "@types/json-schema": "npm:^7.0.9"
+    cross-fetch: "npm:^4.0.0"
+    json-schema: "npm:^0.4.0"
+    uri-template: "npm:^2.0.0"
+    zen-observable: "npm:^0.10.0"
+  checksum: 10/6ba30163a14ad29194a69ccc31871252e895972a90e1b86b131325e59e1af874c5d75af90dc48285ffc4e72ab51b6c608182cb048066c7c85ebcca111d4d5e7c
   languageName: node
   linkType: hard
 
@@ -4942,19 +5201,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:1.19.6-next.0":
-  version: 1.19.6-next.0
-  resolution: "@backstage/plugin-scaffolder-react@npm:1.19.6-next.0"
+"@backstage/plugin-scaffolder-node@npm:0.12.5-next.1":
+  version: 0.12.5-next.1
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.12.5-next.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
+    "@backstage/catalog-model": "npm:1.7.6"
+    "@backstage/errors": "npm:1.2.7"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.7.6-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
+    concat-stream: "npm:^2.0.0"
+    fs-extra: "npm:^11.2.0"
+    globby: "npm:^11.0.0"
+    isomorphic-git: "npm:^1.23.0"
+    jsonschema: "npm:^1.5.0"
+    lodash: "npm:^4.17.21"
+    p-limit: "npm:^3.1.0"
+    tar: "npm:^7.5.6"
+    winston: "npm:^3.2.1"
+    winston-transport: "npm:^4.7.0"
+    zod: "npm:^3.25.76"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10/831fe233874143d5de1093033008833f282b04cc95f591f7dc39cb90fdbd5b99718748e2151f0427b12981c854eb602aaf41c01dcd612f08fd65742ddadf8083
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-react@npm:1.19.7-next.1":
+  version: 1.19.7-next.1
+  resolution: "@backstage/plugin-scaffolder-react@npm:1.19.7-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.40-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.7.6-next.0"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/plugin-scaffolder-common": "npm:1.7.6-next.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -4990,27 +5277,27 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a08987eda434f0cd663026a28ad8fd6b7337d86b6b936fb5633aeeb388eca10b48bca18ae31df58f4399725360b87bf9a13f5ca066d42ab57d2a57aa634f73f6
+  checksum: 10/5a1150a0810efa2d5a60e783feb65b5037c4e869d664e3f2ea4300e8c3706c0b96abc7a85b9645f0ecd1137ade89a9f904d6c148216bd9d466040950ec7f7968
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.48.0-next.0&npm=1.35.2-next.0, @backstage/plugin-scaffolder@npm:^1.35.2-next.0":
-  version: 1.35.2-next.0
-  resolution: "@backstage/plugin-scaffolder@npm:1.35.2-next.0"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.48.0-next.1&npm=1.35.3-next.1, @backstage/plugin-scaffolder@npm:^1.35.3-next.1":
+  version: 1.35.3-next.1
+  resolution: "@backstage/plugin-scaffolder@npm:1.35.3-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/integration-react": "npm:1.2.15-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/integration-react": "npm:1.2.15-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.8-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/plugin-permission-react": "npm:0.4.40-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:1.7.6-next.0"
-    "@backstage/plugin-scaffolder-react": "npm:1.19.6-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:1.7.6-next.1"
+    "@backstage/plugin-scaffolder-react": "npm:1.19.7-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.8-next.0"
     "@backstage/types": "npm:1.2.2"
@@ -5051,11 +5338,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/eb3f8fb9d23c36aafede4785ded58fedc22fd4825234ffa3a2c0463bb1d95879dafb975c6c2859e4f33874fe9b6977ef9861de128b1a5e7084183421380cc5a9
+  checksum: 10/a96866a491dbed1aeee726525751ff174cf9cdf23e363dde82942cd7eba08f3b9889347ca4e44971180fe86a8727123f78b0ebba1b2c5a5b6795083de96996e8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.48.0-next.0&npm=0.3.12-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.12-next.0":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.48.0-next.1&npm=0.3.12-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.12-next.0":
   version: 0.3.12-next.0
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.12-next.0"
   dependencies:
@@ -5109,17 +5396,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.48.0-next.0&npm=2.0.11-next.0, @backstage/plugin-search-backend@npm:^2.0.11-next.0":
-  version: 2.0.11-next.0
-  resolution: "@backstage/plugin-search-backend@npm:2.0.11-next.0"
+"@backstage/plugin-search-backend@backstage:^::backstage=1.48.0-next.1&npm=2.0.12-next.0, @backstage/plugin-search-backend@npm:^2.0.12-next.0":
+  version: 2.0.12-next.0
+  resolution: "@backstage/plugin-search-backend@npm:2.0.12-next.0"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.15.1-next.0"
+    "@backstage/backend-defaults": "npm:0.15.2-next.1"
     "@backstage/backend-openapi-utils": "npm:0.6.6-next.0"
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/plugin-permission-common": "npm:0.9.5-next.0"
-    "@backstage/plugin-permission-node": "npm:0.10.9-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
+    "@backstage/plugin-permission-node": "npm:0.10.10-next.0"
     "@backstage/plugin-search-backend-node": "npm:1.4.1-next.0"
     "@backstage/plugin-search-common": "npm:1.2.22-next.0"
     "@backstage/types": "npm:1.2.2"
@@ -5129,7 +5416,7 @@ __metadata:
     qs: "npm:^6.10.1"
     yn: "npm:^4.0.0"
     zod: "npm:^3.25.76"
-  checksum: 10/746d09b12c35070eb453a9bed42c1f25ae6f6734ac321509328f7dccd133c889d41a2f8a73174198dd56df9a932dbde9345e1c5921769101ff123a3b4f2ddc91
+  checksum: 10/081a6cfced8650ef356bbb9c31303f0e1a7107828f082051dfeef3bd344e9a8b4c6717088813676b1a71558342a93e405cbf6e3f5a892b13ab351ff5818a5460
   languageName: node
   linkType: hard
 
@@ -5153,15 +5440,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.48.0-next.0&npm=1.10.3-next.0, @backstage/plugin-search-react@npm:1.10.3-next.0, @backstage/plugin-search-react@npm:^1.10.3-next.0":
-  version: 1.10.3-next.0
-  resolution: "@backstage/plugin-search-react@npm:1.10.3-next.0"
+"@backstage/plugin-search-react@backstage:^::backstage=1.48.0-next.1&npm=1.10.3-next.1, @backstage/plugin-search-react@npm:1.10.3-next.1, @backstage/plugin-search-react@npm:^1.10.3-next.1":
+  version: 1.10.3-next.1
+  resolution: "@backstage/plugin-search-react@npm:1.10.3-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
     "@backstage/plugin-search-common": "npm:1.2.22-next.0"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -5179,7 +5466,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5e946ca4c6d5dee4802978bf4136f515574579bd3cc1b93aa9a1da6e6c5202835684eaf0f1214c469ee4e5fd605a27736116edb823456d251dfaa2cb5ccfdcd0
+  checksum: 10/9780159d5a7f058bd9c818122f5e0cf0b55397ede095b3ca44b1dc0d6efe0ab63698c20b85c5c6d287aaefea39124c23ede98fedfd154c7d8a8d62cd8f6bf306
   languageName: node
   linkType: hard
 
@@ -5213,17 +5500,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.48.0-next.0&npm=1.5.4-next.0, @backstage/plugin-search@npm:^1.5.4-next.0":
-  version: 1.5.4-next.0
-  resolution: "@backstage/plugin-search@npm:1.5.4-next.0"
+"@backstage/plugin-search@backstage:^::backstage=1.48.0-next.1&npm=1.6.0-next.1, @backstage/plugin-search@npm:^1.6.0-next.1":
+  version: 1.6.0-next.1
+  resolution: "@backstage/plugin-search@npm:1.6.0-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/plugin-search-common": "npm:1.2.22-next.0"
-    "@backstage/plugin-search-react": "npm:1.10.3-next.0"
+    "@backstage/plugin-search-react": "npm:1.10.3-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.11"
     "@material-ui/core": "npm:^4.12.2"
@@ -5238,11 +5525,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fa82744f8a4c955e4af1a898ca24818c0d96fece84449790ebf8743a516a2c2c5baeebe4b6660dc3fbf7c11e9a789ee9217364ee10fe225555de0791d5cd43a0
+  checksum: 10/d08826feb4d391893c4d7fd00c2cfc74a12209de9f1191472e56d3334228f7979b085aec2538181fc9730a32c999fa50f17b572c18e13848e7cfa52f285192ff
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.48.0-next.0&npm=0.3.12-next.0, @backstage/plugin-signals-backend@npm:^0.3.12-next.0":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.48.0-next.1&npm=0.3.12-next.0, @backstage/plugin-signals-backend@npm:^0.3.12-next.0":
   version: 0.3.12-next.0
   resolution: "@backstage/plugin-signals-backend@npm:0.3.12-next.0"
   dependencies:
@@ -5294,15 +5581,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.48.0-next.0&npm=0.0.28-next.0, @backstage/plugin-signals@npm:^0.0.28-next.0":
-  version: 0.0.28-next.0
-  resolution: "@backstage/plugin-signals@npm:0.0.28-next.0"
+"@backstage/plugin-signals@backstage:^::backstage=1.48.0-next.1&npm=0.0.28-next.1, @backstage/plugin-signals@npm:^0.0.28-next.1":
+  version: 0.0.28-next.1
+  resolution: "@backstage/plugin-signals@npm:0.0.28-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.19-next.0"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.4"
     uuid: "npm:^11.0.0"
@@ -5314,23 +5601,23 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a56c4fed8f447a8162c7c1e2b3140618710760055060bc17ffe6283abcbd88435372e042c2360e1d1910f67bbf6ee0f575af0368bb59f8f4b34d57b63b590038
+  checksum: 10/edb8f75845c93402082e0d91702590eec645a2a047ece892bfc69e9b649425c418e2819f0ecb91e21d865c3a9833144d0a31674a5b95877ab978c2ff61a563f3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.48.0-next.0&npm=2.1.5-next.0, @backstage/plugin-techdocs-backend@npm:^2.1.5-next.0":
-  version: 2.1.5-next.0
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.1.5-next.0"
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.48.0-next.1&npm=2.1.5-next.1, @backstage/plugin-techdocs-backend@npm:^2.1.5-next.1":
+  version: 2.1.5-next.1
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.1.5-next.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:0.15.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-defaults": "npm:0.15.2-next.1"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
     "@backstage/plugin-catalog-node": "npm:1.21.0-next.0"
-    "@backstage/plugin-techdocs-node": "npm:1.14.1-next.0"
+    "@backstage/plugin-techdocs-node": "npm:1.14.2-next.1"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
@@ -5338,7 +5625,7 @@ __metadata:
     knex: "npm:^3.0.0"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/770de843d0d155cb66abe871c561639c05f2fdeee7f6c819a79e117fd51f973d5fbb2707073a64ed2359e405410dface9953e4caebe58e26a37cbd03739b5391
+  checksum: 10/90fba7401a39106d1fc428a7f9321b68d559da3e1bdb5730dd36846fc3fda4db5f14ab41b4d105a377136a5ca1d8912a7fcc6be1aac6013fa69cf1e3148d3d1a
   languageName: node
   linkType: hard
 
@@ -5349,15 +5636,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.48.0-next.0&npm=1.1.33-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.33-next.0":
-  version: 1.1.33-next.0
-  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.33-next.0"
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.48.0-next.1&npm=1.1.33-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.33-next.1":
+  version: 1.1.33-next.1
+  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.33-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/integration-react": "npm:1.2.15-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/integration-react": "npm:1.2.15-next.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.8-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5372,13 +5659,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8fcc73888295be9caa3f8c032360a86523d428e51a9d6dbef304595c9a2c32d1b9379569a7e7c11c0797d68a2a092411a35ddb1ca6560e49f49ff52712ff9df3
+  checksum: 10/6ae3930117045a0a20d4f7694de51d79490af2abe4314b6b43e4f286a952d09c7424e708f5f7ea32f3152aa05667c2bff070ad893f50fc3513eb742d2487cacb
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.48.0-next.0&npm=1.14.1-next.0, @backstage/plugin-techdocs-node@npm:1.14.1-next.0, @backstage/plugin-techdocs-node@npm:^1.14.1-next.0":
-  version: 1.14.1-next.0
-  resolution: "@backstage/plugin-techdocs-node@npm:1.14.1-next.0"
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.48.0-next.1&npm=1.14.2-next.1, @backstage/plugin-techdocs-node@npm:1.14.2-next.1, @backstage/plugin-techdocs-node@npm:^1.14.2-next.1":
+  version: 1.14.2-next.1
+  resolution: "@backstage/plugin-techdocs-node@npm:1.14.2-next.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -5386,11 +5673,11 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-plugin-api": "npm:1.7.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.7.0-next.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/integration": "npm:1.19.3-next.0"
+    "@backstage/integration": "npm:1.20.0-next.1"
     "@backstage/integration-aws-node": "npm:0.1.20-next.0"
     "@backstage/plugin-search-common": "npm:1.2.22-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
@@ -5409,11 +5696,11 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/a01aa4a76b990e79abac00bf7646fc16e733fa0f03ef6b2b7021487adaa91a575b66d834e8295299937b176ae20704de98651ec7dae8d31bd97134ec5d8ef2b9
+  checksum: 10/7c939bb8817ef73630735ab9cbc2edeadeac286234f8f86b40f2a0d81d14cd1fd6c8ee47677058f921f7a0564d29b57913bd04e0a5e68d0c904084d1c4896d54
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.48.0-next.0&npm=1.3.8-next.0, @backstage/plugin-techdocs-react@npm:1.3.8-next.0, @backstage/plugin-techdocs-react@npm:^1.3.8-next.0":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.48.0-next.1&npm=1.3.8-next.0, @backstage/plugin-techdocs-react@npm:1.3.8-next.0, @backstage/plugin-techdocs-react@npm:^1.3.8-next.0":
   version: 1.3.8-next.0
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.8-next.0"
   dependencies:
@@ -5442,26 +5729,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.48.0-next.0&npm=1.16.3-next.0, @backstage/plugin-techdocs@npm:^1.16.3-next.0":
-  version: 1.16.3-next.0
-  resolution: "@backstage/plugin-techdocs@npm:1.16.3-next.0"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.48.0-next.1&npm=1.16.3-next.1, @backstage/plugin-techdocs@npm:^1.16.3-next.1":
+  version: 1.16.3-next.1
+  resolution: "@backstage/plugin-techdocs@npm:1.16.3-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.12.1"
     "@backstage/catalog-model": "npm:1.7.6"
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/integration": "npm:1.19.3-next.0"
-    "@backstage/integration-react": "npm:1.2.15-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/integration": "npm:1.20.0-next.1"
+    "@backstage/integration-react": "npm:1.2.15-next.1"
     "@backstage/plugin-auth-react": "npm:0.1.24-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/plugin-search-common": "npm:1.2.22-next.0"
-    "@backstage/plugin-search-react": "npm:1.10.3-next.0"
+    "@backstage/plugin-search-react": "npm:1.10.3-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.8-next.0"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5480,7 +5767,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a18a3292d48dc638876068b1ba7a9675a987fd834309342882c174448054966d3cb1879d9892137bf27fcf3cc65466eb408bbbec87965fd0e9884b0bd2109000
+  checksum: 10/a5bb3eabb31d8299055a38804319d8e5b2c50d16481d50786e425837cd8a3d4666b56f475222e2d279eb20b2fd97828d426c5b83fd77f5c80a49916eab4bf65d
   languageName: node
   linkType: hard
 
@@ -5491,20 +5778,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.48.0-next.0&npm=0.8.32-next.0, @backstage/plugin-user-settings@npm:^0.8.32-next.0":
-  version: 0.8.32-next.0
-  resolution: "@backstage/plugin-user-settings@npm:0.8.32-next.0"
+"@backstage/plugin-user-settings@backstage:^::backstage=1.48.0-next.1&npm=0.8.32-next.1, @backstage/plugin-user-settings@npm:^0.8.32-next.1":
+  version: 0.8.32-next.1
+  resolution: "@backstage/plugin-user-settings@npm:0.8.32-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.7.6"
-    "@backstage/core-app-api": "npm:1.19.4-next.0"
-    "@backstage/core-components": "npm:0.18.6-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
+    "@backstage/core-app-api": "npm:1.19.5-next.0"
+    "@backstage/core-components": "npm:0.18.7-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
     "@backstage/errors": "npm:1.2.7"
-    "@backstage/frontend-plugin-api": "npm:0.14.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:1.21.6-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.14.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:1.22.0-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.19-next.0"
     "@backstage/plugin-user-settings-common": "npm:0.0.1"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5519,7 +5806,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/85356c3802465f1dc5421c972616c3572badfd8ebb04321082111507346f573077c4bde0fbbaf8e5b25c19e3d08228e2b787a54e3043349281ea40775fd8f902
+  checksum: 10/1dc41331896b3cd7811268f672c15d6e19b9027e20cdff02b14e9f07034da80bce22389ea8fa7c6469fe2df73cefce2d7a31844b5d2757bb4c5b73ab741373c0
   languageName: node
   linkType: hard
 
@@ -5530,16 +5817,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/test-utils@npm:1.7.15-next.0":
-  version: 1.7.15-next.0
-  resolution: "@backstage/test-utils@npm:1.7.15-next.0"
+"@backstage/test-utils@npm:1.7.15-next.1":
+  version: 1.7.15-next.1
+  resolution: "@backstage/test-utils@npm:1.7.15-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.6"
-    "@backstage/core-app-api": "npm:1.19.4-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.2-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.5-next.0"
+    "@backstage/core-app-api": "npm:1.19.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.3-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.6-next.0"
     "@backstage/plugin-permission-react": "npm:0.4.40-next.0"
-    "@backstage/theme": "npm:0.7.1"
+    "@backstage/theme": "npm:0.7.2-next.0"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5555,7 +5842,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2f52e038c5655f314aa00f3af34206997265f2ba092a854695788489a7152810d04c65354dc79768abaab6bacc4533aa4f07aec1aebbcaf548abf50daec81a8d
+  checksum: 10/1df43a13cb8ab6148ca79da54a5a7a196f79bfcffa68a3c2845e92cf6f7e6b1ee396651681ac8726908d2ed8193a1bdbc37fea6dab9bc85e53ded1ae24e6884d
   languageName: node
   linkType: hard
 
@@ -5588,7 +5875,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.48.0-next.0&npm=0.7.1, @backstage/theme@npm:0.7.1, @backstage/theme@npm:^0.7.1":
+"@backstage/theme@backstage:^::backstage=1.48.0-next.1&npm=0.7.2-next.0, @backstage/theme@npm:0.7.2-next.0, @backstage/theme@npm:^0.7.2-next.0":
+  version: 0.7.2-next.0
+  resolution: "@backstage/theme@npm:0.7.2-next.0"
+  dependencies:
+    "@emotion/react": "npm:^11.10.5"
+    "@emotion/styled": "npm:^11.10.5"
+    "@mui/material": "npm:^5.12.2"
+  peerDependencies:
+    "@material-ui/core": ^4.12.2
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/2a31590a27d7e7ebc481412b8cb75abbf11a0713bc313f6666f5b1f238ede861df7382e0cbc034bd99320ccd53d45c961ded44e7c6259ac8154e918d460115c8
+  languageName: node
+  linkType: hard
+
+"@backstage/theme@npm:0.7.1, @backstage/theme@npm:^0.7.1":
   version: 0.7.1
   resolution: "@backstage/theme@npm:0.7.1"
   dependencies:
@@ -5615,9 +5922,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.48.0-next.0&npm=0.12.0-next.0, @backstage/ui@npm:^0.12.0-next.0":
-  version: 0.12.0-next.0
-  resolution: "@backstage/ui@npm:0.12.0-next.0"
+"@backstage/ui@backstage:^::backstage=1.48.0-next.1&npm=0.12.0-next.1, @backstage/ui@npm:0.12.0-next.1, @backstage/ui@npm:^0.12.0-next.1":
+  version: 0.12.0-next.1
+  resolution: "@backstage/ui@npm:0.12.0-next.1"
   dependencies:
     "@backstage/version-bridge": "npm:1.0.11"
     "@remixicon/react": "npm:^4.6.0"
@@ -5632,7 +5939,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/9e6152cecc53038e256f5ecc2b9e515ea3c6aa41aeb1ec0124477c88691cd2ab3e4958599ac7f204c10e065d596cfd4c0cb39d5b64d7c8522632c65ab9fb666d
+  checksum: 10/a53d4fa46550c2493cec2ecd5fc90ca777eec9d8a859d13d376664bb3fe0de5b718807d59990e04f163e351257a402a117269c66de09ba8b875d2c5dafd30918
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.48.0-next.1 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.48.0-next.1](https://github.com/backstage/backstage/blob/master/docs/releases/v1.48.0-next.1-changelog.md)
- Upgrade Helper: [From 1.48.0-next.0 to 1.48.0-next.1](https://backstage.github.io/upgrade-helper/?from=1.48.0-next.0&to=1.48.0-next.1)
 
Created by [Version Bump 21667528486](https://github.com/backstage/demo/actions/runs/21667528486)
 