### PR TITLE
v1.51.0-next.1 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 0cfdc882d3c1395592aa6d4690958e70ebbc3a8ee1d888d523dc9e3c74796de26f744c37df66a69212280634f422a88074ba625dce0f7886fbdf2a904a0c38a2
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.51.0-next.0/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.51.0-next.1/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.51.0-next.0"
+  "version": "1.51.0-next.1"
 }

--- a/packages/app/src/overrides/catalog.tsx
+++ b/packages/app/src/overrides/catalog.tsx
@@ -1,8 +1,10 @@
+import { FrontendFeature } from '@backstage/frontend-plugin-api';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
 
 import { entityOverviewLayoutExtension } from '../components/catalog/EntityOverviewLayout';
 import { badgesContextMenuItem } from './badges';
 
-export const catalogNavItemOverride = catalogPlugin.withOverrides({
-  extensions: [entityOverviewLayoutExtension, badgesContextMenuItem],
-});
+export const catalogNavItemOverride: FrontendFeature =
+  catalogPlugin.withOverrides({
+    extensions: [entityOverviewLayoutExtension, badgesContextMenuItem],
+  });

--- a/packages/app/src/overrides/home.tsx
+++ b/packages/app/src/overrides/home.tsx
@@ -1,3 +1,4 @@
+import { FrontendFeature } from '@backstage/frontend-plugin-api';
 import { HomePageWidgetBlueprint } from '@backstage/plugin-home-react/alpha';
 import homePlugin from '@backstage/plugin-home/alpha';
 
@@ -6,7 +7,7 @@ import { tools } from '../components/home/shared';
 // page:home in NFS is already a customizable widget grid. Register the widgets
 // that don't have built-in NFS extensions yet, and override the toolkit with
 // the app's custom tools.
-export const homeWidgetsOverride = homePlugin.withOverrides({
+export const homeWidgetsOverride: FrontendFeature = homePlugin.withOverrides({
   extensions: [
     // Override home-page-widget:home/toolkit with custom tools
     HomePageWidgetBlueprint.make({

--- a/packages/app/src/overrides/userSettings.tsx
+++ b/packages/app/src/overrides/userSettings.tsx
@@ -1,20 +1,24 @@
-import { SubPageBlueprint } from '@backstage/frontend-plugin-api';
+import {
+  FrontendFeature,
+  SubPageBlueprint,
+} from '@backstage/frontend-plugin-api';
 import userSettingsPlugin from '@backstage/plugin-user-settings/alpha';
 
 // Add NotificationSettings as a sub-page under user-settings
-export const userSettingsOverride = userSettingsPlugin.withOverrides({
-  extensions: [
-    SubPageBlueprint.make({
-      name: 'notifications',
-      params: {
-        path: 'notifications',
-        title: 'Notifications',
-        loader: async () => {
-          const { NotificationSettings } =
-            await import('../components/settings/NotificationSettings');
-          return <NotificationSettings />;
+export const userSettingsOverride: FrontendFeature =
+  userSettingsPlugin.withOverrides({
+    extensions: [
+      SubPageBlueprint.make({
+        name: 'notifications',
+        params: {
+          path: 'notifications',
+          title: 'Notifications',
+          loader: async () => {
+            const { NotificationSettings } =
+              await import('../components/settings/NotificationSettings');
+            return <NotificationSettings />;
+          },
         },
-      },
-    }),
-  ],
-});
+      }),
+    ],
+  });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,9 +2046,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.51.0-next.0&npm=0.17.1-next.0, @backstage/backend-defaults@npm:^0.17.1-next.0":
-  version: 0.17.1-next.0
-  resolution: "@backstage/backend-defaults@npm:0.17.1-next.0"
+"@backstage/backend-defaults@backstage:^::backstage=1.51.0-next.1&npm=0.17.1-next.1, @backstage/backend-defaults@npm:^0.17.1-next.1":
+  version: 0.17.1-next.1
+  resolution: "@backstage/backend-defaults@npm:0.17.1-next.1"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -2061,15 +2061,15 @@ __metadata:
     "@backstage/backend-app-api": "npm:1.7.0-next.0"
     "@backstage/backend-dev-utils": "npm:0.1.7"
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
-    "@backstage/cli-node": "npm:0.3.2-next.0"
+    "@backstage/cli-node": "npm:0.3.2-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/config-loader": "npm:1.10.11-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
     "@backstage/integration": "npm:2.0.2-next.0"
     "@backstage/integration-aws-node": "npm:0.1.22-next.0"
-    "@backstage/plugin-auth-node": "npm:0.7.1-next.0"
+    "@backstage/plugin-auth-node": "npm:0.7.1-next.1"
     "@backstage/plugin-events-node": "npm:0.4.22-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.9-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9-next.1"
     "@backstage/plugin-permission-node": "npm:0.10.13-next.0"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/storage": "npm:^7.0.0"
@@ -2116,7 +2116,6 @@ __metadata:
     selfsigned: "npm:^2.0.0"
     tar: "npm:^7.5.6"
     triple-beam: "npm:^1.4.1"
-    uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     winston-transport: "npm:^4.5.0"
     yauzl: "npm:^3.2.1"
@@ -2131,7 +2130,7 @@ __metadata:
       optional: true
     better-sqlite3:
       optional: true
-  checksum: 10/92eed70c7b37e538ba52826acf44f292deed73250c83e4531ace9b447b5ce1f2bc837f73ee0afd7bf1fc0d1c3b1413add1617e0a9c55acf99164ea792508e8a5
+  checksum: 10/18eb7d3c1fc73c056666dda1b59701b3620083a6466ed8a98da9de4326a406c7a0c4a8d23df51040e9b89967a6337213e4b4e46291f3dd927e88bd5bad8340d2
   languageName: node
   linkType: hard
 
@@ -2366,7 +2365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.51.0-next.0&npm=1.9.1-next.0, @backstage/backend-plugin-api@npm:1.9.1-next.0, @backstage/backend-plugin-api@npm:^1.9.1-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.51.0-next.1&npm=1.9.1-next.0, @backstage/backend-plugin-api@npm:1.9.1-next.0, @backstage/backend-plugin-api@npm:^1.9.1-next.0":
   version: 1.9.1-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.9.1-next.0"
   dependencies:
@@ -2438,7 +2437,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.51.0-next.0&npm=1.8.1-next.0, @backstage/catalog-model@npm:1.8.1-next.0, @backstage/catalog-model@npm:^1.8.1-next.0":
+"@backstage/catalog-model@backstage:^::backstage=1.51.0-next.1&npm=1.8.1-next.1, @backstage/catalog-model@npm:1.8.1-next.1, @backstage/catalog-model@npm:^1.8.1-next.1":
+  version: 1.8.1-next.1
+  resolution: "@backstage/catalog-model@npm:1.8.1-next.1"
+  dependencies:
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/types": "npm:1.2.2"
+    ajv: "npm:^8.10.0"
+    ajv-errors: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    zod: "npm:^3.25.76"
+  checksum: 10/340ac3fad4feb86027d8238bf08556486287a26dfdb44bea22179a7a58fabfcfa7c8d49211559f5cdff515e3a4a8c319d8c5069554c26101bef134eedbfee737
+  languageName: node
+  linkType: hard
+
+"@backstage/catalog-model@npm:1.8.1-next.0":
   version: 1.8.1-next.0
   resolution: "@backstage/catalog-model@npm:1.8.1-next.0"
   dependencies:
@@ -2502,7 +2515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-defaults@backstage:^::backstage=1.51.0-next.0&npm=0.1.2-next.0, @backstage/cli-defaults@npm:0.1.2-next.0, @backstage/cli-defaults@npm:^0.1.2-next.0":
+"@backstage/cli-defaults@backstage:^::backstage=1.51.0-next.1&npm=0.1.2-next.0, @backstage/cli-defaults@npm:0.1.2-next.0, @backstage/cli-defaults@npm:^0.1.2-next.0":
   version: 0.1.2-next.0
   resolution: "@backstage/cli-defaults@npm:0.1.2-next.0"
   dependencies:
@@ -2855,6 +2868,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/cli-node@npm:0.3.2-next.1":
+  version: 0.3.2-next.1
+  resolution: "@backstage/cli-node@npm:0.3.2-next.1"
+  dependencies:
+    "@backstage/cli-common": "npm:0.2.2-next.0"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@yarnpkg/lockfile": "npm:^1.1.0"
+    "@yarnpkg/parsers": "npm:^3.0.0"
+    chalk: "npm:^4.0.0"
+    commander: "npm:^12.0.0"
+    fs-extra: "npm:^11.2.0"
+    keytar: "npm:^7.9.0"
+    pirates: "npm:^4.0.6"
+    proper-lockfile: "npm:^4.1.2"
+    semver: "npm:^7.5.3"
+    yaml: "npm:^2.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@swc/core": ^1.15.6
+  dependenciesMeta:
+    keytar:
+      optional: true
+  peerDependenciesMeta:
+    "@swc/core":
+      optional: true
+  checksum: 10/acd8949b1e9034de599606e97be861139c5db36c8d29f99787b3289c4d9a4814aad97fe46ffb98548242165e9f29494d21df3e7b24b2978b46c58e29009b70e4
+  languageName: node
+  linkType: hard
+
 "@backstage/cli-node@npm:^0.2.18":
   version: 0.2.18
   resolution: "@backstage/cli-node@npm:0.2.18"
@@ -2902,17 +2946,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.51.0-next.0&npm=0.36.2-next.0, @backstage/cli@npm:^0.36.2-next.0":
-  version: 0.36.2-next.0
-  resolution: "@backstage/cli@npm:0.36.2-next.0"
+"@backstage/cli@backstage:^::backstage=1.51.0-next.1&npm=0.36.2-next.1, @backstage/cli@npm:^0.36.2-next.1":
+  version: 0.36.2-next.1
+  resolution: "@backstage/cli@npm:0.36.2-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.2.2-next.0"
     "@backstage/cli-defaults": "npm:0.1.2-next.0"
     "@backstage/cli-module-build": "npm:0.1.3-next.0"
     "@backstage/cli-module-test-jest": "npm:0.1.2-next.0"
-    "@backstage/cli-node": "npm:0.3.2-next.0"
+    "@backstage/cli-node": "npm:0.3.2-next.1"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/eslint-plugin": "npm:0.2.3"
+    "@backstage/eslint-plugin": "npm:0.3.0-next.0"
     "@manypkg/get-packages": "npm:^1.1.3"
     "@spotify/eslint-config-base": "npm:^15.0.0"
     "@spotify/eslint-config-react": "npm:^15.0.0"
@@ -2955,7 +2999,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/219bed86332021789ec5753be8e3041dbfe6286962daa6cc50923fa04c45c188148a97cf199dc965440c56338ab6e7964eebd13f091b7f403ada4444bfe5a666
+  checksum: 10/4bc305840c74b8469e5cbfa727efc6bf05e8b0edcbb8b47114e7fbdbd32c276af3680266d71241f494e3bbc6c06274166a5bdd63304257642b272b171a12d694
   languageName: node
   linkType: hard
 
@@ -3005,7 +3049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.51.0-next.0&npm=1.3.8-next.0, @backstage/config@npm:1.3.8-next.0, @backstage/config@npm:^1.3.8-next.0":
+"@backstage/config@backstage:^::backstage=1.51.0-next.1&npm=1.3.8-next.0, @backstage/config@npm:1.3.8-next.0, @backstage/config@npm:^1.3.8-next.0":
   version: 1.3.8-next.0
   resolution: "@backstage/config@npm:1.3.8-next.0"
   dependencies:
@@ -3027,7 +3071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.51.0-next.0&npm=1.20.1-next.0, @backstage/core-app-api@npm:1.20.1-next.0, @backstage/core-app-api@npm:^1.20.1-next.0":
+"@backstage/core-app-api@backstage:^::backstage=1.51.0-next.1&npm=1.20.1-next.0, @backstage/core-app-api@npm:1.20.1-next.0, @backstage/core-app-api@npm:^1.20.1-next.0":
   version: 1.20.1-next.0
   resolution: "@backstage/core-app-api@npm:1.20.1-next.0"
   dependencies:
@@ -3056,7 +3100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.51.0-next.0&npm=0.5.11-next.0, @backstage/core-compat-api@npm:0.5.11-next.0, @backstage/core-compat-api@npm:^0.5.11-next.0":
+"@backstage/core-compat-api@backstage:^::backstage=1.51.0-next.1&npm=0.5.11-next.0, @backstage/core-compat-api@npm:0.5.11-next.0, @backstage/core-compat-api@npm:^0.5.11-next.0":
   version: 0.5.11-next.0
   resolution: "@backstage/core-compat-api@npm:0.5.11-next.0"
   dependencies:
@@ -3107,7 +3151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.51.0-next.0&npm=0.18.10-next.0, @backstage/core-components@npm:0.18.10-next.0, @backstage/core-components@npm:^0.18.10-next.0":
+"@backstage/core-components@backstage:^::backstage=1.51.0-next.1&npm=0.18.10-next.0, @backstage/core-components@npm:0.18.10-next.0, @backstage/core-components@npm:^0.18.10-next.0":
   version: 0.18.10-next.0
   resolution: "@backstage/core-components@npm:0.18.10-next.0"
   dependencies:
@@ -3223,7 +3267,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.51.0-next.0&npm=1.12.6-next.0, @backstage/core-plugin-api@npm:1.12.6-next.0, @backstage/core-plugin-api@npm:^1.12.6-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.51.0-next.1&npm=1.12.6-next.1, @backstage/core-plugin-api@npm:1.12.6-next.1, @backstage/core-plugin-api@npm:^1.12.6-next.1":
+  version: 1.12.6-next.1
+  resolution: "@backstage/core-plugin-api@npm:1.12.6-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.8-next.0"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    history: "npm:^5.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/369ea339d3803bdc9b1f82d22b8968e235528fe585224afbdd2a27ede7eb27430261b9f8b9a6dab1285105e191031d3c2e98422a9fbe387b22a5dd3bce2dcb28
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:1.12.6-next.0":
   version: 1.12.6-next.0
   resolution: "@backstage/core-plugin-api@npm:1.12.6-next.0"
   dependencies:
@@ -3269,7 +3336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.51.0-next.0&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.51.0-next.1&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
   version: 0.1.2
   resolution: "@backstage/e2e-test-utils@npm:0.1.2"
   dependencies:
@@ -3304,13 +3371,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/eslint-plugin@npm:0.2.3":
-  version: 0.2.3
-  resolution: "@backstage/eslint-plugin@npm:0.2.3"
+"@backstage/eslint-plugin@npm:0.3.0-next.0":
+  version: 0.3.0-next.0
+  resolution: "@backstage/eslint-plugin@npm:0.3.0-next.0"
   dependencies:
     "@manypkg/get-packages": "npm:^1.1.3"
     minimatch: "npm:^10.2.1"
-  checksum: 10/f261f946e862117a62fa5e7586940705c7ca9ee240ea07bf058a9194941cfe10611f81cd2e3a3f9b5ba37eaf439826c9a906164fadda0a74b1f64e6c7cfc9904
+  checksum: 10/5c8b6694f1852bb3b4384fad30cc8641334796b892a48a31fc2783c9c54154a70960f08047f8eb780bf15387cd914dbbdbde50d4ef7624a44ee913adf3d95832
   languageName: node
   linkType: hard
 
@@ -3340,17 +3407,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-app-api@npm:0.16.3-next.0":
-  version: 0.16.3-next.0
-  resolution: "@backstage/frontend-app-api@npm:0.16.3-next.0"
+"@backstage/frontend-app-api@npm:0.16.3-next.1":
+  version: 0.16.3-next.1
+  resolution: "@backstage/frontend-app-api@npm:0.16.3-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/core-app-api": "npm:1.20.1-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
     "@backstage/errors": "npm:1.3.1-next.0"
     "@backstage/filter-predicates": "npm:0.1.3-next.0"
-    "@backstage/frontend-defaults": "npm:0.5.2-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
+    "@backstage/frontend-defaults": "npm:0.5.2-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.12"
     lodash: "npm:^4.17.21"
@@ -3363,20 +3430,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2706494bf9fcdca1cd7bebcb7178ca4d43a870e638fa264ee3a83f0cb4cf4e8e46d46529b555b3a83f74a7465772761f190ffe30134dc693d1ca2ddb40cc5b7f
+  checksum: 10/682fb22067c2f8e9b9aa6ac031d5485935243fb69c609f4120008edaff82012d68c70b2637e884ac6df775188cbc32363e3a938816560bf0f84f8dd64443eb39
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.51.0-next.0&npm=0.5.2-next.0, @backstage/frontend-defaults@npm:0.5.2-next.0, @backstage/frontend-defaults@npm:^0.5.2-next.0":
-  version: 0.5.2-next.0
-  resolution: "@backstage/frontend-defaults@npm:0.5.2-next.0"
+"@backstage/frontend-defaults@backstage:^::backstage=1.51.0-next.1&npm=0.5.2-next.1, @backstage/frontend-defaults@npm:0.5.2-next.1, @backstage/frontend-defaults@npm:^0.5.2-next.1":
+  version: 0.5.2-next.1
+  resolution: "@backstage/frontend-defaults@npm:0.5.2-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/core-components": "npm:0.18.10-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/frontend-app-api": "npm:0.16.3-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
-    "@backstage/plugin-app": "npm:0.4.6-next.0"
+    "@backstage/frontend-app-api": "npm:0.16.3-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
+    "@backstage/plugin-app": "npm:0.4.6-next.1"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -3386,11 +3453,34 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7e5046292a95f5e083a597945bf4e0c49bc60fab82c0e2d69296faf1ecdfab97c8cdf5393137d1275cc92d17194e9bad941d4ffd00e010cc50138f3307bbcdab
+  checksum: 10/a374f0102ffe725d1777d221797d3e06442fcff0cdfd28f3727e34dbf7eb5ddf32f8ed50c38ee119844088204bd510f2e2a4bcb252bac1023dec92a317106fd7
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.51.0-next.0&npm=0.17.0-next.0, @backstage/frontend-plugin-api@npm:0.17.0-next.0, @backstage/frontend-plugin-api@npm:^0.17.0-next.0":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.51.0-next.1&npm=0.17.0-next.1, @backstage/frontend-plugin-api@npm:0.17.0-next.1, @backstage/frontend-plugin-api@npm:^0.17.0-next.1":
+  version: 0.17.0-next.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.17.0-next.1"
+  dependencies:
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/filter-predicates": "npm:0.1.3-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@standard-schema/spec": "npm:^1.1.0"
+    zod: "npm:^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/1647cfd7e20e42e46dbcebf8a30b14126fe8e441aa70af795fe773a79d9e8c21ac75945bc77b5ddced144b612003cc88069ac0c6a7fe9bdb3445125db9a63b7f
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:0.17.0-next.0":
   version: 0.17.0-next.0
   resolution: "@backstage/frontend-plugin-api@npm:0.17.0-next.0"
   dependencies:
@@ -3509,7 +3599,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.51.0-next.0&npm=1.2.18-next.0, @backstage/integration-react@npm:1.2.18-next.0, @backstage/integration-react@npm:^1.2.18-next.0":
+"@backstage/integration-react@backstage:^::backstage=1.51.0-next.1&npm=1.2.18-next.0, @backstage/integration-react@npm:1.2.18-next.0, @backstage/integration-react@npm:^1.2.18-next.0":
   version: 1.2.18-next.0
   resolution: "@backstage/integration-react@npm:1.2.18-next.0"
   dependencies:
@@ -3632,25 +3722,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.51.0-next.0&npm=0.14.1-next.0, @backstage/plugin-api-docs@npm:^0.14.1-next.0":
-  version: 0.14.1-next.0
-  resolution: "@backstage/plugin-api-docs@npm:0.14.1-next.0"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.51.0-next.1&npm=0.14.1-next.1, @backstage/plugin-api-docs@npm:^0.14.1-next.1":
+  version: 0.14.1-next.1
+  resolution: "@backstage/plugin-api-docs@npm:0.14.1-next.1"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
     "@backstage/plugin-catalog": "npm:2.0.5-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.10-next.0"
-    "@backstage/plugin-catalog-react": "npm:2.1.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:2.1.5-next.1"
     "@backstage/plugin-permission-react": "npm:0.5.1-next.0"
-    "@backstage/ui": "npm:0.15.0-next.0"
+    "@backstage/ui": "npm:0.15.0-next.1"
     "@graphiql/react": "npm:0.29.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@remixicon/react": "npm:^4.6.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     graphiql: "npm:^3.9.0"
     graphql: "npm:^16.0.0"
     graphql-ws: "npm:^5.4.1"
@@ -3663,11 +3753,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/315ec146efbb4c81069b9e6bae14f079d78a6d7fa15a6c2620bdf2a57ce0761d9b25ff677228f0da3dba83f029e9b84418430a27133b3330767bb7c938fd3012
+  checksum: 10/14d20d4c20d3809f999eb62684fa1052f2a0b3e03cc03aae0d133b0db841477b2497d436b413ec62fa2c36e029b25bcff3b2bc9019048901822e4ca62b77ebd8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.51.0-next.0&npm=0.5.14-next.0, @backstage/plugin-app-backend@npm:^0.5.14-next.0":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.51.0-next.1&npm=0.5.14-next.0, @backstage/plugin-app-backend@npm:^0.5.14-next.0":
   version: 0.5.14-next.0
   resolution: "@backstage/plugin-app-backend@npm:0.5.14-next.0"
   dependencies:
@@ -3703,7 +3793,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-react@backstage:^::backstage=1.51.0-next.0&npm=0.2.3-next.0, @backstage/plugin-app-react@npm:0.2.3-next.0, @backstage/plugin-app-react@npm:^0.2.3-next.0":
+"@backstage/plugin-app-react@backstage:^::backstage=1.51.0-next.1&npm=0.2.3-next.0, @backstage/plugin-app-react@npm:0.2.3-next.0, @backstage/plugin-app-react@npm:^0.2.3-next.0":
   version: 0.2.3-next.0
   resolution: "@backstage/plugin-app-react@npm:0.2.3-next.0"
   dependencies:
@@ -3741,15 +3831,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-visualizer@backstage:^::backstage=1.51.0-next.0&npm=0.2.4-next.0, @backstage/plugin-app-visualizer@npm:^0.2.4-next.0":
-  version: 0.2.4-next.0
-  resolution: "@backstage/plugin-app-visualizer@npm:0.2.4-next.0"
+"@backstage/plugin-app-visualizer@backstage:^::backstage=1.51.0-next.1&npm=0.2.4-next.1, @backstage/plugin-app-visualizer@npm:^0.2.4-next.1":
+  version: 0.2.4-next.1
+  resolution: "@backstage/plugin-app-visualizer@npm:0.2.4-next.1"
   dependencies:
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
-    "@backstage/ui": "npm:0.15.0-next.0"
-    "@remixicon/react": "npm:^4.6.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
+    "@backstage/ui": "npm:0.15.0-next.1"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     react-aria-components: "npm:~1.17.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -3759,30 +3849,30 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a45b338a59967a4dd78aef4343f0075515d6a1ca253c186721378b1f82eff70ecaa66f3c3dfdf7ab15c102ca1d3989c229ca2b0902e05e9d1ee4e672a36fb505
+  checksum: 10/c69769079b1fb279be3609b9b6e12830ca9743c861c890c77118128c26963d139f77b76079af8d3ab4a418356b23fe37419ec2024eeab5967af8be8c7a4915a9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@backstage:^::backstage=1.51.0-next.0&npm=0.4.6-next.0, @backstage/plugin-app@npm:0.4.6-next.0, @backstage/plugin-app@npm:^0.4.6-next.0":
-  version: 0.4.6-next.0
-  resolution: "@backstage/plugin-app@npm:0.4.6-next.0"
+"@backstage/plugin-app@backstage:^::backstage=1.51.0-next.1&npm=0.4.6-next.1, @backstage/plugin-app@npm:0.4.6-next.1, @backstage/plugin-app@npm:^0.4.6-next.1":
+  version: 0.4.6-next.1
+  resolution: "@backstage/plugin-app@npm:0.4.6-next.1"
   dependencies:
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
     "@backstage/filter-predicates": "npm:0.1.3-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
     "@backstage/integration-react": "npm:1.2.18-next.0"
     "@backstage/plugin-app-react": "npm:0.2.3-next.0"
     "@backstage/plugin-permission-react": "npm:0.5.1-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.15.0-next.0"
+    "@backstage/ui": "npm:0.15.0-next.1"
     "@backstage/version-bridge": "npm:1.0.12"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.61"
     "@react-hookz/web": "npm:^24.0.0"
-    "@remixicon/react": "npm:^4.6.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     motion: "npm:^12.0.0"
     react-aria: "npm:~3.48.0"
     react-stately: "npm:~3.46.0"
@@ -3797,11 +3887,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c447655c523138ff49c26ec1e7d035ff91965341d272bc5fb3a1350dda10d08bf2a20471845070aa6a782cbc52aa9920c67ed8ad007a8ce48e261a5b77388ca0
+  checksum: 10/b89e30a174e521eff2fb8bb3c7519aac9bc4fcc300b42c4fdf127641cc2f08e171a7759ca0dd19ebc902691cc828b225823d2296ec4dce943e24e304dd5d9022
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.51.0-next.0&npm=0.5.3-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.3-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.51.0-next.1&npm=0.5.3-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.3-next.0":
   version: 0.5.3-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.5.3-next.0"
   dependencies:
@@ -3813,7 +3903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.51.0-next.0&npm=0.2.19-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.19-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.51.0-next.1&npm=0.2.19-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.19-next.0":
   version: 0.2.19-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.19-next.0"
   dependencies:
@@ -3826,16 +3916,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.51.0-next.0&npm=0.28.1-next.0, @backstage/plugin-auth-backend@npm:^0.28.1-next.0":
-  version: 0.28.1-next.0
-  resolution: "@backstage/plugin-auth-backend@npm:0.28.1-next.0"
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.51.0-next.1&npm=0.28.1-next.1, @backstage/plugin-auth-backend@npm:^0.28.1-next.1":
+  version: 0.28.1-next.1
+  resolution: "@backstage/plugin-auth-backend@npm:0.28.1-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/plugin-auth-node": "npm:0.7.1-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.1-next.0"
+    "@backstage/plugin-auth-node": "npm:0.7.1-next.1"
+    "@backstage/plugin-catalog-node": "npm:2.2.1-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/firestore": "npm:^7.0.0"
     connect-session-knex: "npm:^4.0.0"
@@ -3851,10 +3941,9 @@ __metadata:
     matcher: "npm:^4.0.0"
     minimatch: "npm:^10.2.1"
     passport: "npm:^0.7.0"
-    uuid: "npm:^11.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-validation-error: "npm:^5.0.0"
-  checksum: 10/2f63856e2b7a9cf505865faf4731e2961bd16801d2068a3c94ab6a52a9913657f373b1cd0cdd3add21cf71128a2cbb7aad0cec36360b11bf98cc6787e8af7a99
+  checksum: 10/426454802f948dd6048e0bd3ba6b0af88345e399bdf6039a860187c9479a9b3bb4aa7d024b7b0eb6845130c9009c9d5d3198467d419db5bb1f224da93fa28183
   languageName: node
   linkType: hard
 
@@ -3878,6 +3967,29 @@ __metadata:
     zod-to-json-schema: "npm:^3.25.1"
     zod-validation-error: "npm:^4.0.2"
   checksum: 10/2d5e7f5363dbc2f3d5371f2a35412a561f18e1c050e7bbb460e8b1cb67ac84cb85b4ad3a9d8a9cae386d79bf8332e7d6df2affb4aba41a644a3ca7dd538d4dd2
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-auth-node@npm:0.7.1-next.1":
+  version: 0.7.1-next.1
+  resolution: "@backstage/plugin-auth-node@npm:0.7.1-next.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
+    "@backstage/catalog-client": "npm:1.15.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
+    "@backstage/config": "npm:1.3.8-next.0"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.22.0"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10/6fe793c64078deb21ea9dae3b471b4ba06d53fb9d1fc3fe15a71827560289c100bfa15f4b0ca07eacf09b105e5ff33638ecff0cf5cf4af9ecd3e62a1cb051960
   languageName: node
   linkType: hard
 
@@ -3948,15 +4060,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth@backstage:^::backstage=1.51.0-next.0&npm=0.1.8-next.0, @backstage/plugin-auth@npm:^0.1.8-next.0":
-  version: 0.1.8-next.0
-  resolution: "@backstage/plugin-auth@npm:0.1.8-next.0"
+"@backstage/plugin-auth@backstage:^::backstage=1.51.0-next.1&npm=0.1.8-next.1, @backstage/plugin-auth@npm:^0.1.8-next.1":
+  version: 0.1.8-next.1
+  resolution: "@backstage/plugin-auth@npm:0.1.8-next.1"
   dependencies:
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
     "@backstage/theme": "npm:0.7.3"
-    "@backstage/ui": "npm:0.15.0-next.0"
-    "@remixicon/react": "npm:^4.6.0"
+    "@backstage/ui": "npm:0.15.0-next.1"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     react-use: "npm:^17.2.4"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -3966,40 +4078,39 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/30bb1cdc222e525db9e823d88bd013ac8549e7578fdafd94470b4e730497dc2fbe104f4008493863e7617d0e7919b346093d61fd9b8e9da7fb0c044843d321f2
+  checksum: 10/89be172de12af86c57e375c7514dc782f364f80e15b817c0c9c89406d963958bfc86f06c76f2da7d5e2a6ab3e25c1e148ba361616ba8e2ecb9d95c3beccab5e0
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.51.0-next.0&npm=0.5.14-next.0, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.14-next.0":
-  version: 0.5.14-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-backstage-openapi@npm:0.5.14-next.0"
+"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.51.0-next.1&npm=0.5.14-next.1, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.14-next.1":
+  version: 0.5.14-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-backstage-openapi@npm:0.5.14-next.1"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.6.9-next.0"
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.1-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.1-next.1"
     cross-fetch: "npm:^4.0.0"
     lodash: "npm:^4.17.21"
     openapi-merge: "npm:^1.3.2"
-    uuid: "npm:^11.0.0"
     yaml: "npm:^2.7.0"
-  checksum: 10/66e62143ad1fb58b56e6f5a9337569926365dde1264fa9efd5f446e6eb1f6853f9bae8e9f52696df66351f2d1e4c9795c8cbc6bbf2fa8099848a1f36f8e6907c
+  checksum: 10/481ae3878f47a93bb6f85d5a82f48faa74dc34e74ba3427eb23877c83c249a4e6605c2231662a16c8d4fc9667f655b6c385619bb01590c2b0aa4eebf9994e1bf
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.51.0-next.0&npm=0.13.2-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.13.2-next.0":
-  version: 0.13.2-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.13.2-next.0"
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.51.0-next.1&npm=0.13.2-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.13.2-next.1":
+  version: 0.13.2-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.13.2-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
     "@backstage/integration": "npm:2.0.2-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.10-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.1-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.1-next.1"
     "@backstage/plugin-events-node": "npm:0.4.22-next.0"
     "@backstage/types": "npm:1.2.2"
     "@octokit/auth-callback": "npm:^5.0.0"
@@ -4013,12 +4124,11 @@ __metadata:
     lodash: "npm:^4.17.21"
     minimatch: "npm:^10.2.1"
     octokit: "npm:^3.0.0"
-    uuid: "npm:^11.0.0"
-  checksum: 10/94eded268948854b82e99cd5ff06afcca58029d258052d818127bde9c8c8f27b858c26c3c5c93d1fac145e936cf1597ca2ecf4aa6c8038747d2b4e8617f3a33a
+  checksum: 10/7f0e54e5bf246e8e6355487d5b010617c88ee7e5e577042615189b9f018009f11cf7c5a55f789fafd13b13cfec2f2e1e208868c64cd6c2ff6615ce531b9591f1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.51.0-next.0&npm=0.1.22-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.22-next.0":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.51.0-next.1&npm=0.1.22-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.22-next.0":
   version: 0.1.22-next.0
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.22-next.0"
   dependencies:
@@ -4029,7 +4139,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.51.0-next.0&npm=0.2.20-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.20-next.0":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.51.0-next.1&npm=0.2.20-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.20-next.0":
   version: 0.2.20-next.0
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.20-next.0"
   dependencies:
@@ -4042,7 +4152,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.51.0-next.0&npm=3.6.1-next.0, @backstage/plugin-catalog-backend@npm:3.6.1-next.0, @backstage/plugin-catalog-backend@npm:^3.6.1-next.0":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.51.0-next.1&npm=3.6.2-next.1, @backstage/plugin-catalog-backend@npm:^3.6.2-next.1":
+  version: 3.6.2-next.1
+  resolution: "@backstage/plugin-catalog-backend@npm:3.6.2-next.1"
+  dependencies:
+    "@backstage/backend-openapi-utils": "npm:0.6.9-next.0"
+    "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
+    "@backstage/catalog-client": "npm:1.15.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
+    "@backstage/config": "npm:1.3.8-next.0"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/filter-predicates": "npm:0.1.3-next.0"
+    "@backstage/integration": "npm:2.0.2-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.10-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.1-next.1"
+    "@backstage/plugin-events-node": "npm:0.4.22-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.13-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@opentelemetry/api": "npm:^1.9.0"
+    ajv: "npm:^8.10.0"
+    ajv-errors: "npm:^3.0.0"
+    codeowners-utils: "npm:^1.0.2"
+    core-js: "npm:^3.6.5"
+    express: "npm:^4.22.0"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    fs-extra: "npm:^11.2.0"
+    git-url-parse: "npm:^15.0.0"
+    glob: "npm:^13.0.0"
+    knex: "npm:^3.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    minimatch: "npm:^10.2.1"
+    p-limit: "npm:^3.0.2"
+    prom-client: "npm:^15.0.0"
+    yaml: "npm:^2.0.0"
+    yn: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-validation-error: "npm:^4.0.2"
+  checksum: 10/86213bcb871a2add6bd2bc3258c2e913fc103c5fa38cb498f227285e82990a9c0bc5508c494a6c6617bd1e0751948035c8542b9f3f5ec77b6ecd053d915a9fa7
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend@npm:3.6.1-next.0":
   version: 3.6.1-next.0
   resolution: "@backstage/plugin-catalog-backend@npm:3.6.1-next.0"
   dependencies:
@@ -4085,7 +4237,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.51.0-next.0&npm=1.1.10-next.0, @backstage/plugin-catalog-common@npm:1.1.10-next.0, @backstage/plugin-catalog-common@npm:^1.1.10-next.0":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.51.0-next.1&npm=1.1.10-next.0, @backstage/plugin-catalog-common@npm:1.1.10-next.0, @backstage/plugin-catalog-common@npm:^1.1.10-next.0":
   version: 1.1.10-next.0
   resolution: "@backstage/plugin-catalog-common@npm:1.1.10-next.0"
   dependencies:
@@ -4107,22 +4259,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.51.0-next.0&npm=0.6.4-next.0, @backstage/plugin-catalog-graph@npm:^0.6.4-next.0":
-  version: 0.6.4-next.0
-  resolution: "@backstage/plugin-catalog-graph@npm:0.6.4-next.0"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.51.0-next.1&npm=0.6.4-next.1, @backstage/plugin-catalog-graph@npm:^0.6.4-next.1":
+  version: 0.6.4-next.1
+  resolution: "@backstage/plugin-catalog-graph@npm:0.6.4-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.15.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:2.1.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:2.1.5-next.1"
     "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.15.0-next.0"
+    "@backstage/ui": "npm:0.15.0-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@remixicon/react": "npm:^4.6.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     classnames: "npm:^2.3.1"
     lodash: "npm:^4.17.15"
     qs: "npm:^6.9.4"
@@ -4136,11 +4288,35 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a228af8a69b802d377acb5ddc0890acbc48e5e38466550ebb0ddc960fd2fa2ec2640e35a4e2d57262f686dd73ed5e398e4cd5a7c0183ef675a0ca0b7222c6183
+  checksum: 10/88cfc2093602c3f2c61fb659cc5d6f63ae2aad11c1ae4b0187815eceae41a9938867a930dad6242ea605960be7ba99052af8e07133b18b75c3f05d473093c918
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.51.0-next.0&npm=2.2.1-next.0, @backstage/plugin-catalog-node@npm:2.2.1-next.0, @backstage/plugin-catalog-node@npm:^2.2.1-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.51.0-next.1&npm=2.2.1-next.1, @backstage/plugin-catalog-node@npm:2.2.1-next.1, @backstage/plugin-catalog-node@npm:^2.2.1-next.1":
+  version: 2.2.1-next.1
+  resolution: "@backstage/plugin-catalog-node@npm:2.2.1-next.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
+    "@backstage/catalog-client": "npm:1.15.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/plugin-catalog-common": "npm:1.1.10-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.13-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@opentelemetry/api": "npm:^1.9.0"
+    lodash: "npm:^4.17.21"
+    yaml: "npm:^2.0.0"
+  peerDependencies:
+    "@backstage/backend-test-utils": 1.11.3-next.1
+  peerDependenciesMeta:
+    "@backstage/backend-test-utils":
+      optional: true
+  checksum: 10/1e6694244d3f35848a1d38123db8676858f34df0e5889ca3b1b74e20d52307fdbea6d48f3fbd182cb6a6f8b25e68d6ea6d82981f0d7a08022221679778895ce3
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-node@npm:2.2.1-next.0":
   version: 2.2.1-next.0
   resolution: "@backstage/plugin-catalog-node@npm:2.2.1-next.0"
   dependencies:
@@ -4188,7 +4364,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.51.0-next.0&npm=2.1.5-next.0, @backstage/plugin-catalog-react@npm:2.1.5-next.0, @backstage/plugin-catalog-react@npm:^2.1.5-next.0":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.51.0-next.1&npm=2.1.5-next.1, @backstage/plugin-catalog-react@npm:2.1.5-next.1, @backstage/plugin-catalog-react@npm:^2.1.5-next.1":
+  version: 2.1.5-next.1
+  resolution: "@backstage/plugin-catalog-react@npm:2.1.5-next.1"
+  dependencies:
+    "@backstage/catalog-client": "npm:1.15.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
+    "@backstage/core-compat-api": "npm:0.5.11-next.0"
+    "@backstage/core-components": "npm:0.18.10-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/filter-predicates": "npm:0.1.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
+    "@backstage/integration-react": "npm:1.2.18-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9-next.1"
+    "@backstage/plugin-permission-react": "npm:0.5.1-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/ui": "npm:0.15.0-next.1"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    classnames: "npm:^2.2.6"
+    lodash: "npm:^4.17.21"
+    material-ui-popup-state: "npm:^5.3.6"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.2.4"
+    yaml: "npm:^2.0.0"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^4.0.0"
+  peerDependencies:
+    "@backstage/frontend-test-utils": 0.5.3-next.1
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@backstage/frontend-test-utils":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/8423ce7468643dcf29ff0d8d16fe5c5b11a8c11237a728d6987cdaac53ad63acd8abc7ded5e2a19286dd62f0c271003cb6c66c19e8b80011544857cf4beedb2d
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-react@npm:2.1.5-next.0":
   version: 2.1.5-next.0
   resolution: "@backstage/plugin-catalog-react@npm:2.1.5-next.0"
   dependencies:
@@ -4281,7 +4503,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.51.0-next.0&npm=2.0.5-next.0, @backstage/plugin-catalog@npm:2.0.5-next.0, @backstage/plugin-catalog@npm:^2.0.5-next.0":
+"@backstage/plugin-catalog@backstage:^::backstage=1.51.0-next.1&npm=2.0.5-next.0, @backstage/plugin-catalog@npm:2.0.5-next.0, @backstage/plugin-catalog@npm:^2.0.5-next.0":
   version: 2.0.5-next.0
   resolution: "@backstage/plugin-catalog@npm:2.0.5-next.0"
   dependencies:
@@ -4328,7 +4550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.51.0-next.0&npm=0.4.12-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.12-next.0":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.51.0-next.1&npm=0.4.12-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.12-next.0":
   version: 0.4.12-next.0
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.12-next.0"
   dependencies:
@@ -4345,7 +4567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.51.0-next.0&npm=0.6.2-next.0, @backstage/plugin-events-backend@npm:^0.6.2-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.51.0-next.1&npm=0.6.2-next.0, @backstage/plugin-events-backend@npm:^0.6.2-next.0":
   version: 0.6.2-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.6.2-next.0"
   dependencies:
@@ -4398,7 +4620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@backstage:^::backstage=1.51.0-next.0&npm=0.1.38-next.0, @backstage/plugin-home-react@npm:0.1.38-next.0, @backstage/plugin-home-react@npm:^0.1.38-next.0":
+"@backstage/plugin-home-react@backstage:^::backstage=1.51.0-next.1&npm=0.1.38-next.0, @backstage/plugin-home-react@npm:0.1.38-next.0, @backstage/plugin-home-react@npm:^0.1.38-next.0":
   version: 0.1.38-next.0
   resolution: "@backstage/plugin-home-react@npm:0.1.38-next.0"
   dependencies:
@@ -4421,19 +4643,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.51.0-next.0&npm=0.9.5-next.0, @backstage/plugin-home@npm:^0.9.5-next.0":
-  version: 0.9.5-next.0
-  resolution: "@backstage/plugin-home@npm:0.9.5-next.0"
+"@backstage/plugin-home@backstage:^::backstage=1.51.0-next.1&npm=0.9.6-next.0, @backstage/plugin-home@npm:^0.9.6-next.0":
+  version: 0.9.6-next.0
+  resolution: "@backstage/plugin-home@npm:0.9.6-next.0"
   dependencies:
     "@backstage/catalog-client": "npm:1.15.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/core-app-api": "npm:1.20.1-next.0"
     "@backstage/core-compat-api": "npm:0.5.11-next.0"
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:2.1.5-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
+    "@backstage/plugin-catalog-react": "npm:2.1.5-next.1"
     "@backstage/plugin-home-react": "npm:0.1.38-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@material-ui/core": "npm:^4.12.2"
@@ -4457,11 +4679,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/163400d657ad1497509a8c2c90fb5f2bbf20886d0eb73bd2d3b741841fd1bc566f63173f08002efe093a32c5c921c6aa85f61e65caac455091f04e1e40285cff
+  checksum: 10/50169b570e6cf9bd7cacb0ec75e3f0312d50cc2d9222e304d4a67fb0b107673a61816bbadcdc98850f47d018bf16734a29deee5d0712d80b6ab8162284956674
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.51.0-next.0&npm=0.21.4-next.0, @backstage/plugin-kubernetes-backend@npm:^0.21.4-next.0":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.51.0-next.1&npm=0.21.4-next.0, @backstage/plugin-kubernetes-backend@npm:^0.21.4-next.0":
   version: 0.21.4-next.0
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.4-next.0"
   dependencies:
@@ -4563,7 +4785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.51.0-next.0&npm=0.12.19-next.0, @backstage/plugin-kubernetes@npm:^0.12.19-next.0":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.51.0-next.1&npm=0.12.19-next.0, @backstage/plugin-kubernetes@npm:^0.12.19-next.0":
   version: 0.12.19-next.0
   resolution: "@backstage/plugin-kubernetes@npm:0.12.19-next.0"
   dependencies:
@@ -4588,7 +4810,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.51.0-next.0&npm=0.1.13-next.0, @backstage/plugin-mcp-actions-backend@npm:^0.1.13-next.0":
+"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.51.0-next.1&npm=0.1.13-next.0, @backstage/plugin-mcp-actions-backend@npm:^0.1.13-next.0":
   version: 0.1.13-next.0
   resolution: "@backstage/plugin-mcp-actions-backend@npm:0.1.13-next.0"
   dependencies:
@@ -4608,7 +4830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.51.0-next.0&npm=0.2.7-next.0, @backstage/plugin-mui-to-bui@npm:^0.2.7-next.0":
+"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.51.0-next.1&npm=0.2.7-next.0, @backstage/plugin-mui-to-bui@npm:^0.2.7-next.0":
   version: 0.2.7-next.0
   resolution: "@backstage/plugin-mui-to-bui@npm:0.2.7-next.0"
   dependencies:
@@ -4630,15 +4852,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.51.0-next.0&npm=0.6.5-next.0, @backstage/plugin-notifications-backend@npm:^0.6.5-next.0":
-  version: 0.6.5-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.6.5-next.0"
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.51.0-next.1&npm=0.6.5-next.1, @backstage/plugin-notifications-backend@npm:^0.6.5-next.1":
+  version: 0.6.5-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.6.5-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.1-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.1-next.1"
     "@backstage/plugin-notifications-common": "npm:0.2.3-next.0"
     "@backstage/plugin-notifications-node": "npm:0.2.26-next.0"
     "@backstage/plugin-signals-node": "npm:0.2.1-next.0"
@@ -4647,8 +4869,7 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     p-throttle: "npm:^4.1.1"
-    uuid: "npm:^11.0.0"
-  checksum: 10/07892a2f0ba6bd5bb3d08652fd3937e349a06d3c91714e332bcc313402d9fd8c6867b24fc5e7e0e93a898a0c763daf97775c880dc5831498109b481de16bfc7e
+  checksum: 10/5c5347a0ab25c536b0aba796085cf5478ccc1f77b65a676cb0729baf4e53c81ac7b1976bd76adc997dd782203c6bb4fc14ad59787d2a37a37ac28a27637a3bc6
   languageName: node
   linkType: hard
 
@@ -4662,7 +4883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.51.0-next.0&npm=0.2.26-next.0, @backstage/plugin-notifications-node@npm:0.2.26-next.0, @backstage/plugin-notifications-node@npm:^0.2.26-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.51.0-next.1&npm=0.2.26-next.0, @backstage/plugin-notifications-node@npm:0.2.26-next.0, @backstage/plugin-notifications-node@npm:^0.2.26-next.0":
   version: 0.2.26-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.26-next.0"
   dependencies:
@@ -4672,19 +4893,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.51.0-next.0&npm=0.5.17-next.0, @backstage/plugin-notifications@npm:^0.5.17-next.0":
-  version: 0.5.17-next.0
-  resolution: "@backstage/plugin-notifications@npm:0.5.17-next.0"
+"@backstage/plugin-notifications@backstage:^::backstage=1.51.0-next.1&npm=0.5.17-next.1, @backstage/plugin-notifications@npm:^0.5.17-next.1":
+  version: 0.5.17-next.1
+  resolution: "@backstage/plugin-notifications@npm:0.5.17-next.1"
   dependencies:
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
     "@backstage/plugin-notifications-common": "npm:0.2.3-next.0"
     "@backstage/plugin-signals-react": "npm:0.0.22-next.0"
     "@backstage/theme": "npm:0.7.3"
-    "@backstage/ui": "npm:0.15.0-next.0"
-    "@remixicon/react": "npm:^4.6.0"
+    "@backstage/ui": "npm:0.15.0-next.1"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     lodash: "npm:^4.17.21"
     notistack: "npm:^3.0.1"
     react-aria-components: "npm:~1.17.0"
@@ -4698,25 +4919,25 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/33e82121872c62b2921b1dab33b8ed88501952ef284ee9752d91a6450100a48d96b7003b089548782debd56993f6f631b767a662ab3f37f5737e1273a96de72e
+  checksum: 10/561d304772cbb143f04a7f26bec21b2843a15c622c7e7a037c2dcd976fecc8e6cf041a9148094cfbf70b0cb900d5d88d2effc09a30ccc5f6e79316983179f1ef
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.51.0-next.0&npm=0.7.4-next.0, @backstage/plugin-org@npm:^0.7.4-next.0":
-  version: 0.7.4-next.0
-  resolution: "@backstage/plugin-org@npm:0.7.4-next.0"
+"@backstage/plugin-org@backstage:^::backstage=1.51.0-next.1&npm=0.7.4-next.1, @backstage/plugin-org@npm:^0.7.4-next.1":
+  version: 0.7.4-next.1
+  resolution: "@backstage/plugin-org@npm:0.7.4-next.1"
   dependencies:
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.10-next.0"
-    "@backstage/plugin-catalog-react": "npm:2.1.5-next.0"
-    "@backstage/ui": "npm:0.15.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:2.1.5-next.1"
+    "@backstage/ui": "npm:0.15.0-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@remixicon/react": "npm:^4.6.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
     pluralize: "npm:^8.0.0"
@@ -4731,7 +4952,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/838b7d91fcff902b531b99093c958b0d73213dc6b9bd8304aabeae1010d45a1fb7394a14ca0c419a8e1966c6d3b98d1477040558265e4b12d160ae769288bb37
+  checksum: 10/d58374d234bb2a73c1a55f7d9bcfa65011f6ed1a09220afa10aba686f3f2f278403a71e78a31fb071a4fdf5aaf454250fc61fb4cf1b04ed5f02f4004b27417fb
   languageName: node
   linkType: hard
 
@@ -4747,6 +4968,20 @@ __metadata:
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   checksum: 10/e075ea2dd5cc7ef88ac01098417e337338861aca9473801d027b9064d1cde4a599b7c0bc3fa16676f9fdee8ad958a29e2400fb2638575572fe755f2658da97dc
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-common@npm:0.9.9-next.1":
+  version: 0.9.9-next.1
+  resolution: "@backstage/plugin-permission-common@npm:0.9.9-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.8-next.0"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/types": "npm:1.2.2"
+    cross-fetch: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10/cd3ea5187ff8b09a84b2fbfd9a69c939c5550566b5f55f53be6cb7a26781560f8de6faea3a150aaf6a9a6974383e0dee8e77a54ae350447820827411e91642e3
   languageName: node
   linkType: hard
 
@@ -4841,7 +5076,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.51.0-next.0&npm=0.6.13-next.0, @backstage/plugin-proxy-backend@npm:^0.6.13-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.51.0-next.1&npm=0.6.13-next.0, @backstage/plugin-proxy-backend@npm:^0.6.13-next.0":
   version: 0.6.13-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.13-next.0"
   dependencies:
@@ -4864,7 +5099,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.51.0-next.0&npm=0.9.9-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.9-next.0":
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.51.0-next.1&npm=0.9.9-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.9-next.0":
   version: 0.9.9-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.9-next.0"
   dependencies:
@@ -4887,7 +5122,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.51.0-next.0&npm=0.1.22-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.22-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.51.0-next.1&npm=0.1.22-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.22-next.0":
   version: 0.1.22-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.22-next.0"
   dependencies:
@@ -4900,22 +5135,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.51.0-next.0&npm=3.4.1-next.0, @backstage/plugin-scaffolder-backend@npm:^3.4.1-next.0":
-  version: 3.4.1-next.0
-  resolution: "@backstage/plugin-scaffolder-backend@npm:3.4.1-next.0"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.51.0-next.1&npm=3.5.0-next.1, @backstage/plugin-scaffolder-backend@npm:^3.5.0-next.1":
+  version: 3.5.0-next.1
+  resolution: "@backstage/plugin-scaffolder-backend@npm:3.5.0-next.1"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.6.9-next.0"
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
     "@backstage/integration": "npm:2.0.2-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.1-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.1-next.1"
     "@backstage/plugin-events-node": "npm:0.4.22-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.9-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9-next.1"
     "@backstage/plugin-permission-node": "npm:0.10.13-next.0"
     "@backstage/plugin-scaffolder-common": "npm:2.1.1-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.13.3-next.0"
+    "@backstage/plugin-scaffolder-node": "npm:0.13.3-next.1"
     "@backstage/types": "npm:1.2.2"
     "@types/luxon": "npm:^3.0.0"
     express: "npm:^4.22.0"
@@ -4932,14 +5167,13 @@ __metadata:
     p-queue: "npm:^6.6.2"
     prom-client: "npm:^15.0.0"
     triple-beam: "npm:^1.4.1"
-    uuid: "npm:^11.0.0"
     winston: "npm:^3.2.1"
     winston-transport: "npm:^4.7.0"
     yaml: "npm:^2.0.0"
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10/432610fd65824d73e3bea773e476a780a73c8578857e73df6c8e974b63b0fbdd245d55860c970fa57513916cfa2865e0e27f9c5f0ac6fc5c2680da995179953c
+  checksum: 10/54fa1064b86e4a0fd91769a85f97f0a0dbdd98dae1f72cfcc38390c3617ca311b2dd16f0197f05099e87605ba02f36c3ed114c266012714f55b75f8032f9c990
   languageName: node
   linkType: hard
 
@@ -4993,6 +5227,40 @@ __metadata:
     "@backstage/backend-test-utils":
       optional: true
   checksum: 10/b1801297a0c132407bc50285747f71b84f040d0c72e39887ce2a1e8fd5db6e3ab160e4d5935b3a1a9d863d78af757dc00d1dfd11989ca92e5638abaaf4ae4328
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-node@npm:0.13.3-next.1":
+  version: 0.13.3-next.1
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.13.3-next.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/integration": "npm:2.0.2-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9-next.1"
+    "@backstage/plugin-permission-node": "npm:0.10.13-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:2.1.1-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
+    concat-stream: "npm:^2.0.0"
+    fs-extra: "npm:^11.2.0"
+    globby: "npm:^11.0.0"
+    isomorphic-git: "npm:^1.23.0"
+    jsonschema: "npm:^1.5.0"
+    lodash: "npm:^4.17.21"
+    p-limit: "npm:^3.1.0"
+    tar: "npm:^7.5.6"
+    winston: "npm:^3.2.1"
+    winston-transport: "npm:^4.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@backstage/backend-test-utils": 1.11.3-next.1
+  peerDependenciesMeta:
+    "@backstage/backend-test-utils":
+      optional: true
+  checksum: 10/65ad62dcbe989363b3a2a0368ad7cc90c39ece80924980adc4071e53bb9eb7002b4b3e8aa3ad27f481b3636b47f7c0e6ed08565ce1d3541f35f97a751dc2fb5d
   languageName: node
   linkType: hard
 
@@ -5052,27 +5320,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.51.0-next.0&npm=1.36.3-next.0, @backstage/plugin-scaffolder@npm:^1.36.3-next.0":
-  version: 1.36.3-next.0
-  resolution: "@backstage/plugin-scaffolder@npm:1.36.3-next.0"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.51.0-next.1&npm=1.36.3-next.1, @backstage/plugin-scaffolder@npm:^1.36.3-next.1":
+  version: 1.36.3-next.1
+  resolution: "@backstage/plugin-scaffolder@npm:1.36.3-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.15.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
     "@backstage/integration": "npm:2.0.2-next.0"
     "@backstage/integration-react": "npm:1.2.18-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.10-next.0"
-    "@backstage/plugin-catalog-react": "npm:2.1.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:2.1.5-next.1"
     "@backstage/plugin-permission-react": "npm:0.5.1-next.0"
     "@backstage/plugin-scaffolder-common": "npm:2.1.1-next.0"
     "@backstage/plugin-scaffolder-react": "npm:1.20.2-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.11-next.0"
     "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.15.0-next.0"
+    "@backstage/ui": "npm:0.15.0-next.1"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
     "@codemirror/view": "npm:^6.0.0"
@@ -5080,7 +5348,7 @@ __metadata:
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
     "@react-hookz/web": "npm:^24.0.0"
-    "@remixicon/react": "npm:^4.6.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     "@rjsf/core": "npm:5.24.13"
     "@rjsf/material-ui": "npm:5.24.13"
     "@rjsf/utils": "npm:5.24.13"
@@ -5111,11 +5379,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7741007a3333b63be1db3e4f461d1ec8fc4c02f2d83adf0522adbcf4873f1b53f5c10b729d97310c51f4f46057fa93d1c36eb023172c23ca94df0004bb416ad3
+  checksum: 10/010c67964834028c71e9afa32a17ac71bb5dbfdac6b249e1ca12ffca9c838964803e3336c5f7bc1db7dcd27779f07d9eaefb68ea616cf6c2fc1c4d9211997184
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.51.0-next.0&npm=0.3.15-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.15-next.0":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.51.0-next.1&npm=0.3.15-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.15-next.0":
   version: 0.3.15-next.0
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.15-next.0"
   dependencies:
@@ -5169,7 +5437,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.51.0-next.0&npm=2.1.2-next.0, @backstage/plugin-search-backend@npm:^2.1.2-next.0":
+"@backstage/plugin-search-backend@backstage:^::backstage=1.51.0-next.1&npm=2.1.2-next.0, @backstage/plugin-search-backend@npm:^2.1.2-next.0":
   version: 2.1.2-next.0
   resolution: "@backstage/plugin-search-backend@npm:2.1.2-next.0"
   dependencies:
@@ -5211,7 +5479,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.51.0-next.0&npm=1.11.4-next.0, @backstage/plugin-search-react@npm:1.11.4-next.0, @backstage/plugin-search-react@npm:^1.11.4-next.0":
+"@backstage/plugin-search-react@backstage:^::backstage=1.51.0-next.1&npm=1.11.4-next.1, @backstage/plugin-search-react@npm:1.11.4-next.1, @backstage/plugin-search-react@npm:^1.11.4-next.1":
+  version: 1.11.4-next.1
+  resolution: "@backstage/plugin-search-react@npm:1.11.4-next.1"
+  dependencies:
+    "@backstage/core-components": "npm:0.18.10-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.24-next.0"
+    "@backstage/theme": "npm:0.7.3"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    lodash: "npm:^4.17.21"
+    qs: "npm:^6.9.4"
+    react-use: "npm:^17.3.2"
+    zod: "npm:^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/685ee6eb50caa5b50b22e971cbf69b9415c03f96f0c9f776659e3214a610df72b4d9f3d576a1bbaa1bbd4af8187c6d082c346c250de7270008d7cd4372e30aa7
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-react@npm:1.11.4-next.0":
   version: 1.11.4-next.0
   resolution: "@backstage/plugin-search-react@npm:1.11.4-next.0"
   dependencies:
@@ -5273,7 +5571,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.51.0-next.0&npm=1.7.4-next.0, @backstage/plugin-search@npm:^1.7.4-next.0":
+"@backstage/plugin-search@backstage:^::backstage=1.51.0-next.1&npm=1.7.4-next.0, @backstage/plugin-search@npm:^1.7.4-next.0":
   version: 1.7.4-next.0
   resolution: "@backstage/plugin-search@npm:1.7.4-next.0"
   dependencies:
@@ -5304,9 +5602,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.51.0-next.0&npm=0.3.15-next.0, @backstage/plugin-signals-backend@npm:^0.3.15-next.0":
-  version: 0.3.15-next.0
-  resolution: "@backstage/plugin-signals-backend@npm:0.3.15-next.0"
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.51.0-next.1&npm=0.3.15-next.1, @backstage/plugin-signals-backend@npm:^0.3.15-next.1":
+  version: 0.3.15-next.1
+  resolution: "@backstage/plugin-signals-backend@npm:0.3.15-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
     "@backstage/config": "npm:1.3.8-next.0"
@@ -5315,9 +5613,8 @@ __metadata:
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
-    uuid: "npm:^11.0.0"
     ws: "npm:^8.18.0"
-  checksum: 10/c5cf11531fd34466a886c09be566199e2464c8c8140cc6158ed07fd6ed959cd9b72d568abaf8c015822880a9bbcd1c419e4b1134f6bbda4d7f622b6fac41e15b
+  checksum: 10/8fee6ed081936b94f3496ba83f5aae4ad04705fcd6fc0fcf9e12e15062ef73a30a99d32f5ada6899e14c8882a779ca96487a4864fb28d310e616f7c8f474bb60
   languageName: node
   linkType: hard
 
@@ -5351,19 +5648,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.51.0-next.0&npm=0.0.31-next.0, @backstage/plugin-signals@npm:^0.0.31-next.0":
-  version: 0.0.31-next.0
-  resolution: "@backstage/plugin-signals@npm:0.0.31-next.0"
+"@backstage/plugin-signals@backstage:^::backstage=1.51.0-next.1&npm=0.0.31-next.1, @backstage/plugin-signals@npm:^0.0.31-next.1":
+  version: 0.0.31-next.1
+  resolution: "@backstage/plugin-signals@npm:0.0.31-next.1"
   dependencies:
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
     "@backstage/plugin-signals-react": "npm:0.0.22-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.4"
-    "@remixicon/react": "npm:^4.6.0"
-    uuid: "npm:^11.0.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
@@ -5372,11 +5668,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/60d7b378cc14164bdaa2bdb14dfd3526fe0be143daecc08fbbd0cca8579e2332c3ccb6254ea92c6195ffcd36782122a875964cf2f9050bca3a590230737a1928
+  checksum: 10/8d71e411f3b8e45b339f599ca8ab188c5146bcfcae1c5dd484cc536e627e7a1ca00a87ac1f4adaa8096d223b83f96cea1d1cd0afd8794aa10782496428212cd6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.51.0-next.0&npm=2.1.8-next.0, @backstage/plugin-techdocs-backend@npm:^2.1.8-next.0":
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.51.0-next.1&npm=2.1.8-next.0, @backstage/plugin-techdocs-backend@npm:^2.1.8-next.0":
   version: 2.1.8-next.0
   resolution: "@backstage/plugin-techdocs-backend@npm:2.1.8-next.0"
   dependencies:
@@ -5406,7 +5702,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.51.0-next.0&npm=1.1.36-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.36-next.0":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.51.0-next.1&npm=1.1.36-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.36-next.0":
   version: 1.1.36-next.0
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.36-next.0"
   dependencies:
@@ -5433,7 +5729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.51.0-next.0&npm=1.14.6-next.0, @backstage/plugin-techdocs-node@npm:1.14.6-next.0, @backstage/plugin-techdocs-node@npm:^1.14.6-next.0":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.51.0-next.1&npm=1.14.6-next.0, @backstage/plugin-techdocs-node@npm:1.14.6-next.0, @backstage/plugin-techdocs-node@npm:^1.14.6-next.0":
   version: 1.14.6-next.0
   resolution: "@backstage/plugin-techdocs-node@npm:1.14.6-next.0"
   dependencies:
@@ -5470,7 +5766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.51.0-next.0&npm=1.3.11-next.0, @backstage/plugin-techdocs-react@npm:1.3.11-next.0, @backstage/plugin-techdocs-react@npm:^1.3.11-next.0":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.51.0-next.1&npm=1.3.11-next.0, @backstage/plugin-techdocs-react@npm:1.3.11-next.0, @backstage/plugin-techdocs-react@npm:^1.3.11-next.0":
   version: 1.3.11-next.0
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.11-next.0"
   dependencies:
@@ -5527,33 +5823,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.51.0-next.0&npm=1.17.6-next.0, @backstage/plugin-techdocs@npm:^1.17.6-next.0":
-  version: 1.17.6-next.0
-  resolution: "@backstage/plugin-techdocs@npm:1.17.6-next.0"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.51.0-next.1&npm=1.17.6-next.1, @backstage/plugin-techdocs@npm:^1.17.6-next.1":
+  version: 1.17.6-next.1
+  resolution: "@backstage/plugin-techdocs@npm:1.17.6-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.15.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/core-components": "npm:0.18.10-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.6-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.0-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.17.0-next.1"
     "@backstage/integration": "npm:2.0.2-next.0"
     "@backstage/integration-react": "npm:1.2.18-next.0"
     "@backstage/plugin-auth-react": "npm:0.1.27-next.0"
-    "@backstage/plugin-catalog-react": "npm:2.1.5-next.0"
+    "@backstage/plugin-catalog-react": "npm:2.1.5-next.1"
     "@backstage/plugin-search-common": "npm:1.2.24-next.0"
-    "@backstage/plugin-search-react": "npm:1.11.4-next.0"
+    "@backstage/plugin-search-react": "npm:1.11.4-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.11-next.0"
     "@backstage/theme": "npm:0.7.3"
-    "@backstage/ui": "npm:0.15.0-next.0"
+    "@backstage/ui": "npm:0.15.0-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
     "@material-ui/styles": "npm:^4.10.0"
     "@microsoft/fetch-event-source": "npm:^2.0.1"
-    "@remixicon/react": "npm:^4.6.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     dompurify: "npm:^3.3.2"
     git-url-parse: "npm:^15.0.0"
     lodash: "npm:^4.17.21"
@@ -5568,7 +5864,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/c8580cb93af0d97befe385dc55d6faff1f6c9eb43a294265fa64c255795ad11aa3424b8704b2169f152b61cbe4466368874c8281ed484b44319b3fc2cfa34972
+  checksum: 10/82cffce9c887fece9392f532029cc98214967fb65f63558df31c51b0380e3dcba2448ae220b0fd20894aaf74e77ea36d4d3e4e43b2f39ff602e4f873de7e8835
   languageName: node
   linkType: hard
 
@@ -5581,7 +5877,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.51.0-next.0&npm=0.9.3-next.0, @backstage/plugin-user-settings@npm:^0.9.3-next.0":
+"@backstage/plugin-user-settings@backstage:^::backstage=1.51.0-next.1&npm=0.9.3-next.0, @backstage/plugin-user-settings@npm:^0.9.3-next.0":
   version: 0.9.3-next.0
   resolution: "@backstage/plugin-user-settings@npm:0.9.3-next.0"
   dependencies:
@@ -5622,7 +5918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.51.0-next.0&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.2, @backstage/theme@npm:^0.7.3":
+"@backstage/theme@backstage:^::backstage=1.51.0-next.1&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.2, @backstage/theme@npm:^0.7.3":
   version: 0.7.3
   resolution: "@backstage/theme@npm:0.7.3"
   dependencies:
@@ -5649,7 +5945,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.51.0-next.0&npm=0.15.0-next.0, @backstage/ui@npm:0.15.0-next.0, @backstage/ui@npm:^0.15.0-next.0":
+"@backstage/ui@backstage:^::backstage=1.51.0-next.1&npm=0.15.0-next.1, @backstage/ui@npm:0.15.0-next.1, @backstage/ui@npm:^0.15.0-next.1":
+  version: 0.15.0-next.1
+  resolution: "@backstage/ui@npm:0.15.0-next.1"
+  dependencies:
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@braintree/sanitize-url": "npm:^7.1.2"
+    "@internationalized/date": "npm:^3.12.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    "@tanstack/react-table": "npm:^8.21.3"
+    clsx: "npm:^2.1.1"
+    marked: "npm:^15.0.12"
+    react-aria: "npm:~3.48.0"
+    react-aria-components: "npm:~1.17.0"
+    react-stately: "npm:~3.46.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/84c4b8b6903f3afc3e00595d2d24439ba02643b7c8c5b39317a2ee1905c7f67ebd8359b7a9837391811019df1ddf0dc786d9d779be39edb97cac2076ad740d06
+  languageName: node
+  linkType: hard
+
+"@backstage/ui@npm:0.15.0-next.0":
   version: 0.15.0-next.0
   resolution: "@backstage/ui@npm:0.15.0-next.0"
   dependencies:
@@ -5727,7 +6050,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@braintree/sanitize-url@npm:^7.1.1":
+"@braintree/sanitize-url@npm:^7.1.1, @braintree/sanitize-url@npm:^7.1.2":
   version: 7.1.2
   resolution: "@braintree/sanitize-url@npm:7.1.2"
   checksum: 10/d9626ff8f8eb5e192cd055e6e743449c21102c76bb59e405b7028fe56230fa080bfcc80dfb1e21850a6876e75adda9f7b3c888cf0685942bb74da4d2866d6ec3
@@ -11847,6 +12170,15 @@ __metadata:
   version: 1.23.2
   resolution: "@remix-run/router@npm:1.23.2"
   checksum: 10/50eb497854881bbd2e1016d4eb83c935ecd618e1c3888b74718851317e3b04edbaae9fe1baa49ec08c5c52cfe7118f4664e37144813d9500f45f922d6602a782
+  languageName: node
+  linkType: hard
+
+"@remixicon/react@npm:>=4.6.0 <4.9.0":
+  version: 4.8.0
+  resolution: "@remixicon/react@npm:4.8.0"
+  peerDependencies:
+    react: ">=18.2.0"
+  checksum: 10/10241f2e07826ce7d595cf9687a35c96cc9cf9eb68a9431d7dfa1b9df479dbef302874d28c0502cee2a536cf34722de7c49ed12d10a2b071e4e42ba4a278c516
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.51.0-next.1 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.51.0-next.1](https://github.com/backstage/backstage/blob/master/docs/releases/v1.51.0-next.1-changelog.md)
- Upgrade Helper: [From 1.51.0-next.0 to 1.51.0-next.1](https://backstage.github.io/upgrade-helper/?from=1.51.0-next.0&to=1.51.0-next.1)
 
Created by [Version Bump 25104202959](https://github.com/backstage/demo/actions/runs/25104202959)
 