### PR TITLE
v1.51.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,6 @@ nodeLinker: node-modules
 plugins:
   - checksum: 0cfdc882d3c1395592aa6d4690958e70ebbc3a8ee1d888d523dc9e3c74796de26f744c37df66a69212280634f422a88074ba625dce0f7886fbdf2a904a0c38a2
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.51.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.51.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.51.0-next.1"
+  "version": "1.51.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2062,7 +2062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.51.0-next.1&npm=0.17.1-next.1, @backstage/backend-defaults@npm:^0.17.1-next.1":
+"@backstage/backend-defaults@backstage:^::backstage=1.51.0-next.2&npm=0.17.1-next.1, @backstage/backend-defaults@npm:^0.17.1-next.1":
   version: 0.17.1-next.1
   resolution: "@backstage/backend-defaults@npm:0.17.1-next.1"
   dependencies:
@@ -2294,7 +2294,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.51.0-next.1&npm=1.9.1-next.0, @backstage/backend-plugin-api@npm:1.9.1-next.0, @backstage/backend-plugin-api@npm:^1.9.1-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.51.0-next.2&npm=1.9.1-next.0, @backstage/backend-plugin-api@npm:1.9.1-next.0, @backstage/backend-plugin-api@npm:^1.9.1-next.0":
   version: 1.9.1-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.9.1-next.0"
   dependencies:
@@ -2366,7 +2366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.51.0-next.1&npm=1.8.1-next.1, @backstage/catalog-model@npm:1.8.1-next.1, @backstage/catalog-model@npm:^1.8.1-next.1":
+"@backstage/catalog-model@backstage:^::backstage=1.51.0-next.2&npm=1.8.1-next.1, @backstage/catalog-model@npm:1.8.1-next.1, @backstage/catalog-model@npm:^1.8.1-next.1":
   version: 1.8.1-next.1
   resolution: "@backstage/catalog-model@npm:1.8.1-next.1"
   dependencies:
@@ -2432,7 +2432,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-defaults@backstage:^::backstage=1.51.0-next.1&npm=0.1.2-next.0, @backstage/cli-defaults@npm:0.1.2-next.0, @backstage/cli-defaults@npm:^0.1.2-next.0":
+"@backstage/cli-defaults@backstage:^::backstage=1.51.0-next.2&npm=0.1.2-next.0, @backstage/cli-defaults@npm:0.1.2-next.0, @backstage/cli-defaults@npm:^0.1.2-next.0":
   version: 0.1.2-next.0
   resolution: "@backstage/cli-defaults@npm:0.1.2-next.0"
   dependencies:
@@ -2847,7 +2847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.51.0-next.1&npm=0.36.2-next.1, @backstage/cli@npm:^0.36.2-next.1":
+"@backstage/cli@backstage:^::backstage=1.51.0-next.2&npm=0.36.2-next.1, @backstage/cli@npm:^0.36.2-next.1":
   version: 0.36.2-next.1
   resolution: "@backstage/cli@npm:0.36.2-next.1"
   dependencies:
@@ -2950,7 +2950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.51.0-next.1&npm=1.3.8-next.0, @backstage/config@npm:1.3.8-next.0, @backstage/config@npm:^1.3.8-next.0":
+"@backstage/config@backstage:^::backstage=1.51.0-next.2&npm=1.3.8-next.0, @backstage/config@npm:1.3.8-next.0, @backstage/config@npm:^1.3.8-next.0":
   version: 1.3.8-next.0
   resolution: "@backstage/config@npm:1.3.8-next.0"
   dependencies:
@@ -2972,7 +2972,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.51.0-next.1&npm=1.20.1-next.0, @backstage/core-app-api@npm:1.20.1-next.0, @backstage/core-app-api@npm:^1.20.1-next.0":
+"@backstage/core-app-api@backstage:^::backstage=1.51.0-next.2&npm=1.20.1-next.0, @backstage/core-app-api@npm:1.20.1-next.0, @backstage/core-app-api@npm:^1.20.1-next.0":
   version: 1.20.1-next.0
   resolution: "@backstage/core-app-api@npm:1.20.1-next.0"
   dependencies:
@@ -3001,7 +3001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.51.0-next.1&npm=0.5.11-next.0, @backstage/core-compat-api@npm:0.5.11-next.0, @backstage/core-compat-api@npm:^0.5.11-next.0":
+"@backstage/core-compat-api@backstage:^::backstage=1.51.0-next.2&npm=0.5.11-next.0, @backstage/core-compat-api@npm:0.5.11-next.0, @backstage/core-compat-api@npm:^0.5.11-next.0":
   version: 0.5.11-next.0
   resolution: "@backstage/core-compat-api@npm:0.5.11-next.0"
   dependencies:
@@ -3052,7 +3052,65 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.51.0-next.1&npm=0.18.10-next.0, @backstage/core-components@npm:0.18.10-next.0, @backstage/core-components@npm:^0.18.10-next.0":
+"@backstage/core-components@backstage:^::backstage=1.51.0-next.2&npm=0.18.10-next.1, @backstage/core-components@npm:^0.18.10-next.1":
+  version: 0.18.10-next.1
+  resolution: "@backstage/core-components@npm:0.18.10-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.8-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.6-next.1"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/theme": "npm:0.7.3"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    csstype: "npm:^3.0.2"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.1.0"
+    linkify-react: "npm:4.3.2"
+    linkifyjs: "npm:4.3.2"
+    lodash: "npm:^4.17.21"
+    parse5: "npm:^6.0.0"
+    qs: "npm:^6.9.4"
+    rc-progress: "npm:3.5.1"
+    react-full-screen: "npm:^1.1.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    rehype-raw: "npm:^6.0.0"
+    rehype-sanitize: "npm:^5.0.0"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/7dfcb11f7a1f59a16fed57d189e938d7f6ecee7e008ed69f8d48c3dde8217bd5e908f897312c55efe1d3c7a538a2d640c1fe3ff7f5991babeb09845b10132294
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.18.10-next.0":
   version: 0.18.10-next.0
   resolution: "@backstage/core-components@npm:0.18.10-next.0"
   dependencies:
@@ -3168,7 +3226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.51.0-next.1&npm=1.12.6-next.1, @backstage/core-plugin-api@npm:1.12.6-next.1, @backstage/core-plugin-api@npm:^1.12.6-next.1":
+"@backstage/core-plugin-api@backstage:^::backstage=1.51.0-next.2&npm=1.12.6-next.1, @backstage/core-plugin-api@npm:1.12.6-next.1, @backstage/core-plugin-api@npm:^1.12.6-next.1":
   version: 1.12.6-next.1
   resolution: "@backstage/core-plugin-api@npm:1.12.6-next.1"
   dependencies:
@@ -3237,7 +3295,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.51.0-next.1&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.51.0-next.2&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
   version: 0.1.2
   resolution: "@backstage/e2e-test-utils@npm:0.1.2"
   dependencies:
@@ -3335,7 +3393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.51.0-next.1&npm=0.5.2-next.1, @backstage/frontend-defaults@npm:0.5.2-next.1, @backstage/frontend-defaults@npm:^0.5.2-next.1":
+"@backstage/frontend-defaults@backstage:^::backstage=1.51.0-next.2&npm=0.5.2-next.1, @backstage/frontend-defaults@npm:0.5.2-next.1, @backstage/frontend-defaults@npm:^0.5.2-next.1":
   version: 0.5.2-next.1
   resolution: "@backstage/frontend-defaults@npm:0.5.2-next.1"
   dependencies:
@@ -3358,7 +3416,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.51.0-next.1&npm=0.17.0-next.1, @backstage/frontend-plugin-api@npm:0.17.0-next.1, @backstage/frontend-plugin-api@npm:^0.17.0-next.1":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.51.0-next.2&npm=0.17.0-next.1, @backstage/frontend-plugin-api@npm:0.17.0-next.1, @backstage/frontend-plugin-api@npm:^0.17.0-next.1":
   version: 0.17.0-next.1
   resolution: "@backstage/frontend-plugin-api@npm:0.17.0-next.1"
   dependencies:
@@ -3500,7 +3558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.51.0-next.1&npm=1.2.18-next.0, @backstage/integration-react@npm:1.2.18-next.0, @backstage/integration-react@npm:^1.2.18-next.0":
+"@backstage/integration-react@backstage:^::backstage=1.51.0-next.2&npm=1.2.18-next.0, @backstage/integration-react@npm:1.2.18-next.0, @backstage/integration-react@npm:^1.2.18-next.0":
   version: 1.2.18-next.0
   resolution: "@backstage/integration-react@npm:1.2.18-next.0"
   dependencies:
@@ -3561,6 +3619,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration@npm:2.0.2-next.1":
+  version: 2.0.2-next.1
+  resolution: "@backstage/integration@npm:2.0.2-next.1"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:1.3.8-next.0"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    p-throttle: "npm:^4.1.1"
+  checksum: 10/6bc008675a0cba355a90ffda7a7ed7ffba810af8c2be2bed8459d62d33bf097b2430443e0ce7f1219bd7a8d4c09d1bd10f709446db4c17a243535e41e23825dd
+  languageName: node
+  linkType: hard
+
 "@backstage/integration@npm:^2.0.1":
   version: 2.0.1
   resolution: "@backstage/integration@npm:2.0.1"
@@ -3605,7 +3682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.51.0-next.1&npm=0.14.1-next.1, @backstage/plugin-api-docs@npm:^0.14.1-next.1":
+"@backstage/plugin-api-docs@backstage:^::backstage=1.51.0-next.2&npm=0.14.1-next.1, @backstage/plugin-api-docs@npm:^0.14.1-next.1":
   version: 0.14.1-next.1
   resolution: "@backstage/plugin-api-docs@npm:0.14.1-next.1"
   dependencies:
@@ -3640,7 +3717,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.51.0-next.1&npm=0.5.14-next.0, @backstage/plugin-app-backend@npm:^0.5.14-next.0":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.51.0-next.2&npm=0.5.14-next.0, @backstage/plugin-app-backend@npm:^0.5.14-next.0":
   version: 0.5.14-next.0
   resolution: "@backstage/plugin-app-backend@npm:0.5.14-next.0"
   dependencies:
@@ -3676,7 +3753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-react@backstage:^::backstage=1.51.0-next.1&npm=0.2.3-next.0, @backstage/plugin-app-react@npm:0.2.3-next.0, @backstage/plugin-app-react@npm:^0.2.3-next.0":
+"@backstage/plugin-app-react@backstage:^::backstage=1.51.0-next.2&npm=0.2.3-next.0, @backstage/plugin-app-react@npm:0.2.3-next.0, @backstage/plugin-app-react@npm:^0.2.3-next.0":
   version: 0.2.3-next.0
   resolution: "@backstage/plugin-app-react@npm:0.2.3-next.0"
   dependencies:
@@ -3714,7 +3791,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-visualizer@backstage:^::backstage=1.51.0-next.1&npm=0.2.4-next.1, @backstage/plugin-app-visualizer@npm:^0.2.4-next.1":
+"@backstage/plugin-app-visualizer@backstage:^::backstage=1.51.0-next.2&npm=0.2.4-next.1, @backstage/plugin-app-visualizer@npm:^0.2.4-next.1":
   version: 0.2.4-next.1
   resolution: "@backstage/plugin-app-visualizer@npm:0.2.4-next.1"
   dependencies:
@@ -3736,7 +3813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@backstage:^::backstage=1.51.0-next.1&npm=0.4.6-next.1, @backstage/plugin-app@npm:0.4.6-next.1, @backstage/plugin-app@npm:^0.4.6-next.1":
+"@backstage/plugin-app@backstage:^::backstage=1.51.0-next.2&npm=0.4.6-next.1, @backstage/plugin-app@npm:0.4.6-next.1, @backstage/plugin-app@npm:^0.4.6-next.1":
   version: 0.4.6-next.1
   resolution: "@backstage/plugin-app@npm:0.4.6-next.1"
   dependencies:
@@ -3774,7 +3851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.51.0-next.1&npm=0.5.3-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.3-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.51.0-next.2&npm=0.5.3-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.3-next.0":
   version: 0.5.3-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.5.3-next.0"
   dependencies:
@@ -3786,7 +3863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.51.0-next.1&npm=0.2.19-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.19-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.51.0-next.2&npm=0.2.19-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.19-next.0":
   version: 0.2.19-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.19-next.0"
   dependencies:
@@ -3799,7 +3876,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.51.0-next.1&npm=0.28.1-next.1, @backstage/plugin-auth-backend@npm:^0.28.1-next.1":
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.51.0-next.2&npm=0.28.1-next.1, @backstage/plugin-auth-backend@npm:^0.28.1-next.1":
   version: 0.28.1-next.1
   resolution: "@backstage/plugin-auth-backend@npm:0.28.1-next.1"
   dependencies:
@@ -3920,7 +3997,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth@backstage:^::backstage=1.51.0-next.1&npm=0.1.8-next.1, @backstage/plugin-auth@npm:^0.1.8-next.1":
+"@backstage/plugin-auth@backstage:^::backstage=1.51.0-next.2&npm=0.1.8-next.1, @backstage/plugin-auth@npm:^0.1.8-next.1":
   version: 0.1.8-next.1
   resolution: "@backstage/plugin-auth@npm:0.1.8-next.1"
   dependencies:
@@ -3942,7 +4019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.51.0-next.1&npm=0.5.14-next.1, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.14-next.1":
+"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.51.0-next.2&npm=0.5.14-next.1, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.14-next.1":
   version: 0.5.14-next.1
   resolution: "@backstage/plugin-catalog-backend-module-backstage-openapi@npm:0.5.14-next.1"
   dependencies:
@@ -3960,7 +4037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.51.0-next.1&npm=0.13.2-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.13.2-next.1":
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.51.0-next.2&npm=0.13.2-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.13.2-next.1":
   version: 0.13.2-next.1
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.13.2-next.1"
   dependencies:
@@ -3988,7 +4065,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.51.0-next.1&npm=0.1.22-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.22-next.0":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.51.0-next.2&npm=0.1.22-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.22-next.0":
   version: 0.1.22-next.0
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.22-next.0"
   dependencies:
@@ -3999,7 +4076,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.51.0-next.1&npm=0.2.20-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.20-next.0":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.51.0-next.2&npm=0.2.20-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.20-next.0":
   version: 0.2.20-next.0
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.20-next.0"
   dependencies:
@@ -4012,7 +4089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.51.0-next.1&npm=3.6.2-next.1, @backstage/plugin-catalog-backend@npm:^3.6.2-next.1":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.51.0-next.2&npm=3.6.2-next.1, @backstage/plugin-catalog-backend@npm:^3.6.2-next.1":
   version: 3.6.2-next.1
   resolution: "@backstage/plugin-catalog-backend@npm:3.6.2-next.1"
   dependencies:
@@ -4097,7 +4174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.51.0-next.1&npm=1.1.10-next.0, @backstage/plugin-catalog-common@npm:1.1.10-next.0, @backstage/plugin-catalog-common@npm:^1.1.10-next.0":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.51.0-next.2&npm=1.1.10-next.0, @backstage/plugin-catalog-common@npm:1.1.10-next.0, @backstage/plugin-catalog-common@npm:^1.1.10-next.0":
   version: 1.1.10-next.0
   resolution: "@backstage/plugin-catalog-common@npm:1.1.10-next.0"
   dependencies:
@@ -4119,7 +4196,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.51.0-next.1&npm=0.6.4-next.1, @backstage/plugin-catalog-graph@npm:^0.6.4-next.1":
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.51.0-next.2&npm=0.6.4-next.1, @backstage/plugin-catalog-graph@npm:^0.6.4-next.1":
   version: 0.6.4-next.1
   resolution: "@backstage/plugin-catalog-graph@npm:0.6.4-next.1"
   dependencies:
@@ -4152,7 +4229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.51.0-next.1&npm=2.2.1-next.1, @backstage/plugin-catalog-node@npm:2.2.1-next.1, @backstage/plugin-catalog-node@npm:^2.2.1-next.1":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.51.0-next.2&npm=2.2.1-next.1, @backstage/plugin-catalog-node@npm:2.2.1-next.1, @backstage/plugin-catalog-node@npm:^2.2.1-next.1":
   version: 2.2.1-next.1
   resolution: "@backstage/plugin-catalog-node@npm:2.2.1-next.1"
   dependencies:
@@ -4224,7 +4301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.51.0-next.1&npm=2.1.5-next.1, @backstage/plugin-catalog-react@npm:2.1.5-next.1, @backstage/plugin-catalog-react@npm:^2.1.5-next.1":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.51.0-next.2&npm=2.1.5-next.1, @backstage/plugin-catalog-react@npm:2.1.5-next.1, @backstage/plugin-catalog-react@npm:^2.1.5-next.1":
   version: 2.1.5-next.1
   resolution: "@backstage/plugin-catalog-react@npm:2.1.5-next.1"
   dependencies:
@@ -4363,7 +4440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.51.0-next.1&npm=2.0.5-next.0, @backstage/plugin-catalog@npm:2.0.5-next.0, @backstage/plugin-catalog@npm:^2.0.5-next.0":
+"@backstage/plugin-catalog@backstage:^::backstage=1.51.0-next.2&npm=2.0.5-next.0, @backstage/plugin-catalog@npm:2.0.5-next.0, @backstage/plugin-catalog@npm:^2.0.5-next.0":
   version: 2.0.5-next.0
   resolution: "@backstage/plugin-catalog@npm:2.0.5-next.0"
   dependencies:
@@ -4410,7 +4487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.51.0-next.1&npm=0.4.12-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.12-next.0":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.51.0-next.2&npm=0.4.12-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.12-next.0":
   version: 0.4.12-next.0
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.12-next.0"
   dependencies:
@@ -4427,7 +4504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.51.0-next.1&npm=0.6.2-next.0, @backstage/plugin-events-backend@npm:^0.6.2-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.51.0-next.2&npm=0.6.2-next.0, @backstage/plugin-events-backend@npm:^0.6.2-next.0":
   version: 0.6.2-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.6.2-next.0"
   dependencies:
@@ -4480,7 +4557,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@backstage:^::backstage=1.51.0-next.1&npm=0.1.38-next.0, @backstage/plugin-home-react@npm:0.1.38-next.0, @backstage/plugin-home-react@npm:^0.1.38-next.0":
+"@backstage/plugin-home-react@backstage:^::backstage=1.51.0-next.2&npm=0.1.38-next.0, @backstage/plugin-home-react@npm:0.1.38-next.0, @backstage/plugin-home-react@npm:^0.1.38-next.0":
   version: 0.1.38-next.0
   resolution: "@backstage/plugin-home-react@npm:0.1.38-next.0"
   dependencies:
@@ -4503,7 +4580,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.51.0-next.1&npm=0.9.6-next.0, @backstage/plugin-home@npm:^0.9.6-next.0":
+"@backstage/plugin-home@backstage:^::backstage=1.51.0-next.2&npm=0.9.6-next.0, @backstage/plugin-home@npm:^0.9.6-next.0":
   version: 0.9.6-next.0
   resolution: "@backstage/plugin-home@npm:0.9.6-next.0"
   dependencies:
@@ -4543,7 +4620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.51.0-next.1&npm=0.21.4-next.0, @backstage/plugin-kubernetes-backend@npm:^0.21.4-next.0":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.51.0-next.2&npm=0.21.4-next.0, @backstage/plugin-kubernetes-backend@npm:^0.21.4-next.0":
   version: 0.21.4-next.0
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.4-next.0"
   dependencies:
@@ -4645,7 +4722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.51.0-next.1&npm=0.12.19-next.0, @backstage/plugin-kubernetes@npm:^0.12.19-next.0":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.51.0-next.2&npm=0.12.19-next.0, @backstage/plugin-kubernetes@npm:^0.12.19-next.0":
   version: 0.12.19-next.0
   resolution: "@backstage/plugin-kubernetes@npm:0.12.19-next.0"
   dependencies:
@@ -4670,7 +4747,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.51.0-next.1&npm=0.1.13-next.0, @backstage/plugin-mcp-actions-backend@npm:^0.1.13-next.0":
+"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.51.0-next.2&npm=0.1.13-next.0, @backstage/plugin-mcp-actions-backend@npm:^0.1.13-next.0":
   version: 0.1.13-next.0
   resolution: "@backstage/plugin-mcp-actions-backend@npm:0.1.13-next.0"
   dependencies:
@@ -4690,7 +4767,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.51.0-next.1&npm=0.2.7-next.0, @backstage/plugin-mui-to-bui@npm:^0.2.7-next.0":
+"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.51.0-next.2&npm=0.2.7-next.0, @backstage/plugin-mui-to-bui@npm:^0.2.7-next.0":
   version: 0.2.7-next.0
   resolution: "@backstage/plugin-mui-to-bui@npm:0.2.7-next.0"
   dependencies:
@@ -4712,7 +4789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.51.0-next.1&npm=0.6.5-next.1, @backstage/plugin-notifications-backend@npm:^0.6.5-next.1":
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.51.0-next.2&npm=0.6.5-next.1, @backstage/plugin-notifications-backend@npm:^0.6.5-next.1":
   version: 0.6.5-next.1
   resolution: "@backstage/plugin-notifications-backend@npm:0.6.5-next.1"
   dependencies:
@@ -4743,7 +4820,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.51.0-next.1&npm=0.2.26-next.0, @backstage/plugin-notifications-node@npm:0.2.26-next.0, @backstage/plugin-notifications-node@npm:^0.2.26-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.51.0-next.2&npm=0.2.26-next.0, @backstage/plugin-notifications-node@npm:0.2.26-next.0, @backstage/plugin-notifications-node@npm:^0.2.26-next.0":
   version: 0.2.26-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.26-next.0"
   dependencies:
@@ -4753,7 +4830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.51.0-next.1&npm=0.5.17-next.1, @backstage/plugin-notifications@npm:^0.5.17-next.1":
+"@backstage/plugin-notifications@backstage:^::backstage=1.51.0-next.2&npm=0.5.17-next.1, @backstage/plugin-notifications@npm:^0.5.17-next.1":
   version: 0.5.17-next.1
   resolution: "@backstage/plugin-notifications@npm:0.5.17-next.1"
   dependencies:
@@ -4783,7 +4860,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.51.0-next.1&npm=0.7.4-next.1, @backstage/plugin-org@npm:^0.7.4-next.1":
+"@backstage/plugin-org@backstage:^::backstage=1.51.0-next.2&npm=0.7.4-next.1, @backstage/plugin-org@npm:^0.7.4-next.1":
   version: 0.7.4-next.1
   resolution: "@backstage/plugin-org@npm:0.7.4-next.1"
   dependencies:
@@ -4936,7 +5013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.51.0-next.1&npm=0.6.13-next.0, @backstage/plugin-proxy-backend@npm:^0.6.13-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.51.0-next.2&npm=0.6.13-next.0, @backstage/plugin-proxy-backend@npm:^0.6.13-next.0":
   version: 0.6.13-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.13-next.0"
   dependencies:
@@ -4959,7 +5036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.51.0-next.1&npm=0.9.9-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.9-next.0":
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.51.0-next.2&npm=0.9.9-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.9-next.0":
   version: 0.9.9-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.9-next.0"
   dependencies:
@@ -4982,7 +5059,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.51.0-next.1&npm=0.1.22-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.22-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.51.0-next.2&npm=0.1.22-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.22-next.0":
   version: 0.1.22-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.22-next.0"
   dependencies:
@@ -4995,7 +5072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.51.0-next.1&npm=3.5.0-next.1, @backstage/plugin-scaffolder-backend@npm:^3.5.0-next.1":
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.51.0-next.2&npm=3.5.0-next.1, @backstage/plugin-scaffolder-backend@npm:^3.5.0-next.1":
   version: 3.5.0-next.1
   resolution: "@backstage/plugin-scaffolder-backend@npm:3.5.0-next.1"
   dependencies:
@@ -5180,7 +5257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.51.0-next.1&npm=1.36.3-next.1, @backstage/plugin-scaffolder@npm:^1.36.3-next.1":
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.51.0-next.2&npm=1.36.3-next.1, @backstage/plugin-scaffolder@npm:^1.36.3-next.1":
   version: 1.36.3-next.1
   resolution: "@backstage/plugin-scaffolder@npm:1.36.3-next.1"
   dependencies:
@@ -5243,7 +5320,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.51.0-next.1&npm=0.3.15-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.15-next.0":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.51.0-next.2&npm=0.3.15-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.15-next.0":
   version: 0.3.15-next.0
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.15-next.0"
   dependencies:
@@ -5279,6 +5356,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-search-backend-node@npm:1.4.4-next.1":
+  version: 1.4.4-next.1
+  resolution: "@backstage/plugin-search-backend-node@npm:1.4.4-next.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
+    "@backstage/config": "npm:1.3.8-next.0"
+    "@backstage/errors": "npm:1.3.1-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.24-next.0"
+    "@types/lunr": "npm:^2.3.3"
+    lodash: "npm:^4.17.21"
+    lunr: "npm:^2.3.9"
+    ndjson: "npm:^2.0.0"
+  checksum: 10/8a329196c5201296d6d5f64df06f1557b613ee9d2b706c2fe77eb1763d8ad4aee46c7124b296588245af435ef87bde5818a2df544a9e5ae6dfe96c87438a2590
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-backend-node@npm:^1.4.2":
   version: 1.4.3
   resolution: "@backstage/plugin-search-backend-node@npm:1.4.3"
@@ -5297,17 +5391,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.51.0-next.1&npm=2.1.2-next.0, @backstage/plugin-search-backend@npm:^2.1.2-next.0":
-  version: 2.1.2-next.0
-  resolution: "@backstage/plugin-search-backend@npm:2.1.2-next.0"
+"@backstage/plugin-search-backend@backstage:^::backstage=1.51.0-next.2&npm=2.1.2-next.1, @backstage/plugin-search-backend@npm:^2.1.2-next.1":
+  version: 2.1.2-next.1
+  resolution: "@backstage/plugin-search-backend@npm:2.1.2-next.1"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.6.9-next.0"
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.9-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9-next.1"
     "@backstage/plugin-permission-node": "npm:0.10.13-next.0"
-    "@backstage/plugin-search-backend-node": "npm:1.4.4-next.0"
+    "@backstage/plugin-search-backend-node": "npm:1.4.4-next.1"
     "@backstage/plugin-search-common": "npm:1.2.24-next.0"
     "@backstage/types": "npm:1.2.2"
     dataloader: "npm:^2.0.0"
@@ -5315,7 +5409,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     qs: "npm:^6.10.1"
     zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10/1b24be05cb1c0857b57978c4da28772569b564a1e5a00c300f150e39a54288063770b5b8071b49f1f7c2a243e7505bbfbda1ddcad615be21c09ed2d68dd35f3b
+  checksum: 10/c7d2d218289cb8d1dbbb6ec48654b23fbfda4ab09df76a30690585826fe7511e0499639f4ecb79e4c4c33cdaad0efe6bf2f17f952cfc2357fc61d35504fd6216
   languageName: node
   linkType: hard
 
@@ -5339,7 +5433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.51.0-next.1&npm=1.11.4-next.1, @backstage/plugin-search-react@npm:1.11.4-next.1, @backstage/plugin-search-react@npm:^1.11.4-next.1":
+"@backstage/plugin-search-react@backstage:^::backstage=1.51.0-next.2&npm=1.11.4-next.1, @backstage/plugin-search-react@npm:1.11.4-next.1, @backstage/plugin-search-react@npm:^1.11.4-next.1":
   version: 1.11.4-next.1
   resolution: "@backstage/plugin-search-react@npm:1.11.4-next.1"
   dependencies:
@@ -5431,7 +5525,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.51.0-next.1&npm=1.7.4-next.0, @backstage/plugin-search@npm:^1.7.4-next.0":
+"@backstage/plugin-search@backstage:^::backstage=1.51.0-next.2&npm=1.7.4-next.0, @backstage/plugin-search@npm:^1.7.4-next.0":
   version: 1.7.4-next.0
   resolution: "@backstage/plugin-search@npm:1.7.4-next.0"
   dependencies:
@@ -5462,7 +5556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.51.0-next.1&npm=0.3.15-next.1, @backstage/plugin-signals-backend@npm:^0.3.15-next.1":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.51.0-next.2&npm=0.3.15-next.1, @backstage/plugin-signals-backend@npm:^0.3.15-next.1":
   version: 0.3.15-next.1
   resolution: "@backstage/plugin-signals-backend@npm:0.3.15-next.1"
   dependencies:
@@ -5508,7 +5602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.51.0-next.1&npm=0.0.31-next.1, @backstage/plugin-signals@npm:^0.0.31-next.1":
+"@backstage/plugin-signals@backstage:^::backstage=1.51.0-next.2&npm=0.0.31-next.1, @backstage/plugin-signals@npm:^0.0.31-next.1":
   version: 0.0.31-next.1
   resolution: "@backstage/plugin-signals@npm:0.0.31-next.1"
   dependencies:
@@ -5532,18 +5626,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.51.0-next.1&npm=2.1.8-next.0, @backstage/plugin-techdocs-backend@npm:^2.1.8-next.0":
-  version: 2.1.8-next.0
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.1.8-next.0"
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.51.0-next.2&npm=2.2.0-next.1, @backstage/plugin-techdocs-backend@npm:^2.2.0-next.1":
+  version: 2.2.0-next.1
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.2.0-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
     "@backstage/catalog-client": "npm:1.15.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/integration": "npm:2.0.2-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.1-next.0"
-    "@backstage/plugin-techdocs-node": "npm:1.14.6-next.0"
+    "@backstage/integration": "npm:2.0.2-next.1"
+    "@backstage/plugin-catalog-node": "npm:2.2.1-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.15.0-next.1"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
@@ -5551,7 +5645,7 @@ __metadata:
     knex: "npm:^3.0.0"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/79f600c26936834a00626507056680a7a5b06d97bcf08b3fb61aaeb6537ea1fcc3571b44b2d79d51053f80e659d4754a1d83f12dfb2939659c48a848f29473f5
+  checksum: 10/532ff9bcb6b52ebf894e928ebea65e5b1dbef2de1d0a52c26d12ed01907717548aeb082fc98b4d38c3398d73682472871d604bb84908baf673a11c545de0046c
   languageName: node
   linkType: hard
 
@@ -5562,7 +5656,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.51.0-next.1&npm=1.1.36-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.36-next.0":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.51.0-next.2&npm=1.1.36-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.36-next.0":
   version: 1.1.36-next.0
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.36-next.0"
   dependencies:
@@ -5589,9 +5683,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.51.0-next.1&npm=1.14.6-next.0, @backstage/plugin-techdocs-node@npm:1.14.6-next.0, @backstage/plugin-techdocs-node@npm:^1.14.6-next.0":
-  version: 1.14.6-next.0
-  resolution: "@backstage/plugin-techdocs-node@npm:1.14.6-next.0"
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.51.0-next.2&npm=1.15.0-next.1, @backstage/plugin-techdocs-node@npm:1.15.0-next.1, @backstage/plugin-techdocs-node@npm:^1.15.0-next.1":
+  version: 1.15.0-next.1
+  resolution: "@backstage/plugin-techdocs-node@npm:1.15.0-next.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -5600,10 +5694,10 @@ __metadata:
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
     "@backstage/backend-plugin-api": "npm:1.9.1-next.0"
-    "@backstage/catalog-model": "npm:1.8.1-next.0"
+    "@backstage/catalog-model": "npm:1.8.1-next.1"
     "@backstage/config": "npm:1.3.8-next.0"
     "@backstage/errors": "npm:1.3.1-next.0"
-    "@backstage/integration": "npm:2.0.2-next.0"
+    "@backstage/integration": "npm:2.0.2-next.1"
     "@backstage/integration-aws-node": "npm:0.1.22-next.0"
     "@backstage/plugin-search-common": "npm:1.2.24-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
@@ -5622,11 +5716,11 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/254d951aa5653b0e1fba1e40a65199564f9acf86ffe13763b02df7348dece6402fd6945340d2db3daabacf4d3bca5625a59cb8590753501151b71f142fa65a2e
+  checksum: 10/419c7ed31e5479c6150204b352ae37e8d16a9c843028ad6de1e02a91a65ced294ec8c3db9a9df515a4378c8d55b93aafa005b9b193856a4460d4db2fa81397a3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.51.0-next.1&npm=1.3.11-next.0, @backstage/plugin-techdocs-react@npm:1.3.11-next.0, @backstage/plugin-techdocs-react@npm:^1.3.11-next.0":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.51.0-next.2&npm=1.3.11-next.0, @backstage/plugin-techdocs-react@npm:1.3.11-next.0, @backstage/plugin-techdocs-react@npm:^1.3.11-next.0":
   version: 1.3.11-next.0
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.11-next.0"
   dependencies:
@@ -5683,7 +5777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.51.0-next.1&npm=1.17.6-next.1, @backstage/plugin-techdocs@npm:^1.17.6-next.1":
+"@backstage/plugin-techdocs@backstage:^::backstage=1.51.0-next.2&npm=1.17.6-next.1, @backstage/plugin-techdocs@npm:^1.17.6-next.1":
   version: 1.17.6-next.1
   resolution: "@backstage/plugin-techdocs@npm:1.17.6-next.1"
   dependencies:
@@ -5737,7 +5831,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.51.0-next.1&npm=0.9.3-next.0, @backstage/plugin-user-settings@npm:^0.9.3-next.0":
+"@backstage/plugin-user-settings@backstage:^::backstage=1.51.0-next.2&npm=0.9.3-next.0, @backstage/plugin-user-settings@npm:^0.9.3-next.0":
   version: 0.9.3-next.0
   resolution: "@backstage/plugin-user-settings@npm:0.9.3-next.0"
   dependencies:
@@ -5778,7 +5872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.51.0-next.1&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.2, @backstage/theme@npm:^0.7.3":
+"@backstage/theme@backstage:^::backstage=1.51.0-next.2&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.2, @backstage/theme@npm:^0.7.3":
   version: 0.7.3
   resolution: "@backstage/theme@npm:0.7.3"
   dependencies:
@@ -5805,9 +5899,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.51.0-next.1&npm=0.15.0-next.1, @backstage/ui@npm:0.15.0-next.1, @backstage/ui@npm:^0.15.0-next.1":
-  version: 0.15.0-next.1
-  resolution: "@backstage/ui@npm:0.15.0-next.1"
+"@backstage/ui@backstage:^::backstage=1.51.0-next.2&npm=0.15.0-next.2, @backstage/ui@npm:^0.15.0-next.2":
+  version: 0.15.0-next.2
+  resolution: "@backstage/ui@npm:0.15.0-next.2"
   dependencies:
     "@backstage/version-bridge": "npm:1.0.12"
     "@braintree/sanitize-url": "npm:^7.1.2"
@@ -5828,7 +5922,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/84c4b8b6903f3afc3e00595d2d24439ba02643b7c8c5b39317a2ee1905c7f67ebd8359b7a9837391811019df1ddf0dc786d9d779be39edb97cac2076ad740d06
+  checksum: 10/7dd1891485df310c3663b41c9f777b17ac56da321a5d5135f0ac134ce1152abb6aa71a80190cdb17cbc45f42c5cbec2829b5bb547aeb725060358cf7aaef129a
   languageName: node
   linkType: hard
 
@@ -5854,6 +5948,33 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/3d78f46d3044bdd6d9cf7ce89bcbc61929de3c435a81d557014353f79bfb6d236b53d036b1947c9e376fa1f56275ad5fcb9262df198d6e2cac2483a77aa5587e
+  languageName: node
+  linkType: hard
+
+"@backstage/ui@npm:0.15.0-next.1":
+  version: 0.15.0-next.1
+  resolution: "@backstage/ui@npm:0.15.0-next.1"
+  dependencies:
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@braintree/sanitize-url": "npm:^7.1.2"
+    "@internationalized/date": "npm:^3.12.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    "@tanstack/react-table": "npm:^8.21.3"
+    clsx: "npm:^2.1.1"
+    marked: "npm:^15.0.12"
+    react-aria: "npm:~3.48.0"
+    react-aria-components: "npm:~1.17.0"
+    react-stately: "npm:~3.46.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/84c4b8b6903f3afc3e00595d2d24439ba02643b7c8c5b39317a2ee1905c7f67ebd8359b7a9837391811019df1ddf0dc786d9d779be39edb97cac2076ad740d06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.51.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.51.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.51.0-next.2-changelog.md)
- Upgrade Helper: [From 1.51.0-next.1 to 1.51.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.51.0-next.1&to=1.51.0-next.2)
 
Created by [Version Bump 25430600095](https://github.com/backstage/demo/actions/runs/25430600095)
 