### PR TITLE
Add AiResource and MCP server API examples

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -125,7 +125,18 @@ auth:
 catalog:
   readonly: true
   rules:
-    - allow: [Component, API, System, Domain, Resource, Location, User, Group]
+    - allow:
+        [
+          Component,
+          API,
+          System,
+          Domain,
+          Resource,
+          Location,
+          User,
+          Group,
+          AiResource,
+        ]
   locations:
     # Backstage example components
     - type: url
@@ -154,6 +165,14 @@ catalog:
     # The backstage demo deployment (this)
     - type: url
       target: https://github.com/backstage/demo/blob/master/catalog-info.yaml
+
+    # Backstage AI Resources (skills for AI coding tools)
+    - type: url
+      target: https://github.com/backstage/demo/blob/master/examples/ai-resources.yaml
+
+    # Backstage MCP Server API examples
+    - type: url
+      target: https://github.com/backstage/demo/blob/master/examples/mcp-server-api.yaml
 
     # The backstage library repository
     - type: url

--- a/examples/ai-resources.yaml
+++ b/examples/ai-resources.yaml
@@ -1,0 +1,137 @@
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: mui-to-bui-migration
+  title: MUI to BUI Migration
+  description: Migrate Backstage plugins from Material-UI (MUI) to Backstage UI (BUI)
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/mui-to-bui-migration
+  links:
+    - url: https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/mui-to-bui-migration
+      title: Skill Source
+spec:
+  type: skill
+  lifecycle: production
+  owner: backstage/maintainers
+  system: backstage
+  disciplines:
+    - web
+  categories:
+    - migration
+  agents:
+    - claude-code
+---
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: app-frontend-system-migration
+  title: App Frontend System Migration
+  description: Migrate a Backstage app from the old frontend system to the new one
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/app-frontend-system-migration
+  links:
+    - url: https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/app-frontend-system-migration
+      title: Skill Source
+spec:
+  type: skill
+  lifecycle: production
+  owner: backstage/maintainers
+  system: backstage
+  disciplines:
+    - web
+  categories:
+    - migration
+  agents:
+    - claude-code
+---
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: plugin-new-frontend-system-support
+  title: Plugin New Frontend System Support
+  description: Add new frontend system support to an existing Backstage plugin while keeping the old system working
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/plugin-new-frontend-system-support
+  links:
+    - url: https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/plugin-new-frontend-system-support
+      title: Skill Source
+spec:
+  type: skill
+  lifecycle: production
+  owner: backstage/maintainers
+  system: backstage
+  disciplines:
+    - web
+  categories:
+    - migration
+  agents:
+    - claude-code
+---
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: plugin-full-frontend-system-migration
+  title: Plugin Full Frontend System Migration
+  description: Fully migrate a Backstage plugin to the new frontend system, dropping all old system support
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/plugin-full-frontend-system-migration
+  links:
+    - url: https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/plugin-full-frontend-system-migration
+      title: Skill Source
+spec:
+  type: skill
+  lifecycle: production
+  owner: backstage/maintainers
+  system: backstage
+  disciplines:
+    - web
+  categories:
+    - migration
+  agents:
+    - claude-code
+---
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: plugin-analytics-instrumentation
+  title: Plugin Analytics Instrumentation
+  description: Instrument a Backstage frontend plugin with analytics events using the Backstage Analytics API
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/plugin-analytics-instrumentation
+  links:
+    - url: https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/plugin-analytics-instrumentation
+      title: Skill Source
+spec:
+  type: skill
+  lifecycle: production
+  owner: backstage/maintainers
+  system: backstage
+  disciplines:
+    - web
+  categories:
+    - observability
+  agents:
+    - claude-code
+---
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: onboard-to-openapi-server
+  title: Onboard to OpenAPI Server
+  description: Migrate an existing Backstage backend plugin to typed OpenAPI tooling
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/onboard-to-openapi-server
+  links:
+    - url: https://github.com/backstage/backstage/tree/master/docs/.well-known/skills/onboard-to-openapi-server
+      title: Skill Source
+spec:
+  type: skill
+  lifecycle: production
+  owner: backstage/maintainers
+  system: backstage
+  disciplines:
+    - web
+  categories:
+    - api
+  agents:
+    - claude-code

--- a/examples/mcp-server-api.yaml
+++ b/examples/mcp-server-api.yaml
@@ -1,0 +1,20 @@
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: github-mcp-server
+  title: GitHub MCP Server
+  description: |
+    GitHub's official MCP server providing tools for repository management,
+    file operations, issues, pull requests, code search, and more.
+  links:
+    - url: https://github.com/github/github-mcp-server
+      title: GitHub Repository
+    - url: https://modelcontextprotocol.io
+      title: MCP Specification
+spec:
+  type: mcp-server
+  lifecycle: production
+  owner: backstage/maintainers
+  remotes:
+    - type: streamable-http
+      url: https://api.githubcopilot.com/mcp/

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,6 +27,7 @@
     "@backstage/plugin-auth-backend-module-github-provider": "backstage:^",
     "@backstage/plugin-auth-backend-module-guest-provider": "backstage:^",
     "@backstage/plugin-catalog-backend": "backstage:^",
+    "@backstage/plugin-catalog-backend-module-ai-model": "backstage:^",
     "@backstage/plugin-catalog-backend-module-backstage-openapi": "backstage:^",
     "@backstage/plugin-catalog-backend-module-github": "backstage:^",
     "@backstage/plugin-catalog-backend-module-logs": "backstage:^",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -11,6 +11,7 @@ backend.add(import('@backstage/plugin-catalog-backend'));
 backend.add(
   import('@backstage/plugin-catalog-backend-module-backstage-openapi'),
 );
+backend.add(import('@backstage/plugin-catalog-backend-module-ai-model'));
 backend.add(import('@backstage/plugin-catalog-backend-module-logs'));
 backend.add(import('@backstage/plugin-catalog-backend-module-github'));
 backend.add(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3734,6 +3734,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-catalog-backend-module-ai-model@backstage:^::backstage=1.54.0-next.1&npm=0.1.3-next.0, @backstage/plugin-catalog-backend-module-ai-model@npm:^0.1.3-next.0":
+  version: 0.1.3-next.0
+  resolution: "@backstage/plugin-catalog-backend-module-ai-model@npm:0.1.3-next.0"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
+    "@backstage/catalog-model": "npm:1.9.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.4-next.0"
+  checksum: 10/10b8d56e8c086df1479bbfa7488783d72e97c0998bb9836d5996451cb1e8f96f17c8fda33d03f10554776ac2fa5f8ee4fe8d7844178d4e51b16f63226b75606d
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.54.0-next.1&npm=0.5.17-next.0, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.17-next.0":
   version: 0.5.17-next.0
   resolution: "@backstage/plugin-catalog-backend-module-backstage-openapi@npm:0.5.17-next.0"
@@ -17204,6 +17215,7 @@ __metadata:
     "@backstage/plugin-auth-backend-module-github-provider": "backstage:^"
     "@backstage/plugin-auth-backend-module-guest-provider": "backstage:^"
     "@backstage/plugin-catalog-backend": "backstage:^"
+    "@backstage/plugin-catalog-backend-module-ai-model": "backstage:^"
     "@backstage/plugin-catalog-backend-module-backstage-openapi": "backstage:^"
     "@backstage/plugin-catalog-backend-module-github": "backstage:^"
     "@backstage/plugin-catalog-backend-module-logs": "backstage:^"


### PR DESCRIPTION
## Summary

- Install `@backstage/plugin-catalog-backend-module-ai-model` to enable AiResource and MCP server API entity support
- Add example AiResource entities for the 6 skills from the Backstage `.well-known/skills` directory
- Add example MCP server API entity for the GitHub MCP Server using `spec.type: 'mcp-server'` with `spec.remotes`
- Add `AiResource` to catalog allowed entity kinds

## Test plan

- [x] Backend builds cleanly
- [x] AiResource entities appear in catalog
- [x] MCP server API entity appears in catalog with correct `streamable-http` remote
- [x] Verified `definition` field is not used for `mcp-server` APIs per upstream schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)