### PR TITLE
v1.53.0-next.1 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,6 +12,6 @@ npmPreapprovedPackages:
 plugins:
   - checksum: 0cfdc882d3c1395592aa6d4690958e70ebbc3a8ee1d888d523dc9e3c74796de26f744c37df66a69212280634f422a88074ba625dce0f7886fbdf2a904a0c38a2
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.53.0-next.0/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.53.0-next.1/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.53.0-next.0"
+  "version": "1.53.0-next.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,9 +2064,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.53.0-next.0&npm=0.17.4-next.0, @backstage/backend-defaults@npm:^0.17.4-next.0":
-  version: 0.17.4-next.0
-  resolution: "@backstage/backend-defaults@npm:0.17.4-next.0"
+"@backstage/backend-defaults@backstage:^::backstage=1.53.0-next.1&npm=0.17.5-next.1, @backstage/backend-defaults@npm:^0.17.5-next.1":
+  version: 0.17.5-next.1
+  resolution: "@backstage/backend-defaults@npm:0.17.5-next.1"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -2081,7 +2081,7 @@ __metadata:
     "@backstage/backend-plugin-api": "npm:1.9.3-next.0"
     "@backstage/cli-node": "npm:0.3.3"
     "@backstage/config": "npm:1.3.8"
-    "@backstage/config-loader": "npm:1.11.0-next.0"
+    "@backstage/config-loader": "npm:1.11.0-next.1"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/integration": "npm:2.0.3"
     "@backstage/integration-aws-node": "npm:0.2.0"
@@ -2149,7 +2149,7 @@ __metadata:
       optional: true
     better-sqlite3:
       optional: true
-  checksum: 10/59347e222e7111d161976cedfb60bc4815bdac47c1f7e268e7e15e1c4a95a6d26fdb8a2b03314968c130f6ff5996ad6173c447f00a45621a11e5e68d0c6bfd30
+  checksum: 10/fad6e2960ef13183bb98a5c409c803323e5c4a6caba148def89db6e95f9c351e825b1980fd1d8f35d3eab4139f8d5bd45c846721962047f7a6702007eba9ef16
   languageName: node
   linkType: hard
 
@@ -2297,7 +2297,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.53.0-next.0&npm=1.9.3-next.0, @backstage/backend-plugin-api@npm:1.9.3-next.0, @backstage/backend-plugin-api@npm:^1.9.3-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.53.0-next.1&npm=1.9.3-next.0, @backstage/backend-plugin-api@npm:1.9.3-next.0, @backstage/backend-plugin-api@npm:^1.9.3-next.0":
   version: 1.9.3-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.9.3-next.0"
   dependencies:
@@ -2369,7 +2369,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.53.0-next.0&npm=1.9.0, @backstage/catalog-model@npm:1.9.0, @backstage/catalog-model@npm:^1.7.7, @backstage/catalog-model@npm:^1.8.0, @backstage/catalog-model@npm:^1.9.0":
+"@backstage/catalog-model@backstage:^::backstage=1.53.0-next.1&npm=1.9.0, @backstage/catalog-model@npm:1.9.0, @backstage/catalog-model@npm:^1.7.7, @backstage/catalog-model@npm:^1.8.0, @backstage/catalog-model@npm:^1.9.0":
   version: 1.9.0
   resolution: "@backstage/catalog-model@npm:1.9.0"
   dependencies:
@@ -2395,7 +2395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-defaults@backstage:^::backstage=1.53.0-next.0&npm=0.1.4-next.0, @backstage/cli-defaults@npm:0.1.4-next.0, @backstage/cli-defaults@npm:^0.1.4-next.0":
+"@backstage/cli-defaults@backstage:^::backstage=1.53.0-next.1&npm=0.1.4-next.0, @backstage/cli-defaults@npm:0.1.4-next.0, @backstage/cli-defaults@npm:^0.1.4-next.0":
   version: 0.1.4-next.0
   resolution: "@backstage/cli-defaults@npm:0.1.4-next.0"
   dependencies:
@@ -2529,6 +2529,82 @@ __metadata:
   bin:
     cli-module-build: bin/backstage-cli-module-build
   checksum: 10/8311447f02101173969ed8478eee8ad2568e8310673308aa789b6b97d1c9c775f2897c8308d67237acfd9eaea4cac97bd03a3d839fb17144e8d2ca58c8e90673
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-module-build@npm:0.1.5-next.1":
+  version: 0.1.5-next.1
+  resolution: "@backstage/cli-module-build@npm:0.1.5-next.1"
+  dependencies:
+    "@backstage/cli-common": "npm:0.2.2"
+    "@backstage/cli-node": "npm:0.3.3"
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/config-loader": "npm:1.11.0-next.1"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/module-federation-common": "npm:0.1.4"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@module-federation/enhanced": "npm:^2.3.3"
+    "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.6.0"
+    "@rollup/plugin-commonjs": "npm:^26.0.0"
+    "@rollup/plugin-json": "npm:^6.0.0"
+    "@rollup/plugin-node-resolve": "npm:^15.0.0"
+    "@rollup/plugin-yaml": "npm:^4.0.0"
+    "@rspack/core": "npm:^1.4.11"
+    "@rspack/dev-server": "npm:^1.1.4"
+    "@rspack/plugin-react-refresh": "npm:^1.4.3"
+    "@swc/core": "npm:^1.15.6"
+    bfj: "npm:^9.0.2"
+    buffer: "npm:^6.0.3"
+    chalk: "npm:^4.0.0"
+    chokidar: "npm:^3.3.1"
+    cleye: "npm:^2.6.0"
+    cross-spawn: "npm:^7.0.3"
+    css-loader: "npm:^6.5.1"
+    ctrlc-windows: "npm:^2.1.0"
+    esbuild-loader: "npm:^4.0.0"
+    eslint-rspack-plugin: "npm:^4.2.1"
+    eslint-webpack-plugin: "npm:^4.2.0"
+    fork-ts-checker-webpack-plugin: "npm:^9.0.0"
+    fs-extra: "npm:^11.2.0"
+    glob: "npm:^13.0.0"
+    html-webpack-plugin: "npm:^5.6.3"
+    lodash: "npm:^4.17.21"
+    mini-css-extract-plugin: "npm:^2.4.2"
+    node-stdlib-browser: "npm:^1.3.1"
+    npm-packlist: "npm:^5.0.0"
+    p-queue: "npm:^6.6.2"
+    portfinder: "npm:^1.0.32"
+    postcss: "npm:^8.1.0"
+    postcss-import: "npm:^16.1.0"
+    process: "npm:^0.11.10"
+    raw-loader: "npm:^4.0.2"
+    react-dev-utils: "npm:^12.0.0-next.60"
+    react-refresh: "npm:^0.18.0"
+    rollup: "npm:^4.59.0"
+    rollup-plugin-dts: "npm:^6.1.0"
+    rollup-plugin-esbuild: "npm:^6.1.1"
+    rollup-plugin-postcss: "npm:^4.0.0"
+    rollup-pluginutils: "npm:^2.8.2"
+    shell-quote: "npm:^1.8.1"
+    style-loader: "npm:^3.3.1"
+    swc-loader: "npm:^0.2.3"
+    tar: "npm:^7.5.6"
+    ts-checker-rspack-plugin: "npm:^1.1.5"
+    ts-morph: "npm:^24.0.0"
+    util: "npm:^0.12.3"
+    webpack: "npm:~5.105.0"
+    webpack-dev-server: "npm:^5.0.0"
+    yml-loader: "npm:^2.1.0"
+    yn: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    embedded-postgres: ^18.3.0-beta.16
+  peerDependenciesMeta:
+    embedded-postgres:
+      optional: true
+  bin:
+    cli-module-build: bin/backstage-cli-module-build
+  checksum: 10/2815d388fb21dea158c9be25b795381e467ad6d0bc2599d97c14596b0c899538d558fab84b1227f80947132c33ea96e71ffbf55394bc514999c60351a4b0c983
   languageName: node
   linkType: hard
 
@@ -2748,13 +2824,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.53.0-next.0&npm=0.36.4-next.0, @backstage/cli@npm:^0.36.4-next.0":
-  version: 0.36.4-next.0
-  resolution: "@backstage/cli@npm:0.36.4-next.0"
+"@backstage/cli@backstage:^::backstage=1.53.0-next.1&npm=0.36.4-next.1, @backstage/cli@npm:^0.36.4-next.1":
+  version: 0.36.4-next.1
+  resolution: "@backstage/cli@npm:0.36.4-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.2.2"
     "@backstage/cli-defaults": "npm:0.1.4-next.0"
-    "@backstage/cli-module-build": "npm:0.1.5-next.0"
+    "@backstage/cli-module-build": "npm:0.1.5-next.1"
     "@backstage/cli-module-test-jest": "npm:0.1.3"
     "@backstage/cli-node": "npm:0.3.3"
     "@backstage/eslint-plugin": "npm:0.3.1"
@@ -2799,7 +2875,7 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/77d9b72a5ac0557d6489dc7d155233ed4bd5dec22d7c4cf65398beca9a4288416577f23524074460d2da31baf14ba685145a5bde525308a5a4a215d75ec87810
+  checksum: 10/2a07e9944b125e6f356b248faa9bde91bec14daf40d279d7988b80e9c994204d1787ce0e96aab0e1c4d034988bb925e626054734471fb7babbc061f2553ebb1f
   languageName: node
   linkType: hard
 
@@ -2826,6 +2902,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config-loader@npm:1.11.0-next.1":
+  version: 1.11.0-next.1
+  resolution: "@backstage/config-loader@npm:1.11.0-next.1"
+  dependencies:
+    "@backstage/cli-common": "npm:0.2.2"
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    "@types/json-schema": "npm:^7.0.6"
+    ajv: "npm:^8.10.0"
+    chokidar: "npm:^3.5.2"
+    fs-extra: "npm:^11.2.0"
+    json-schema-merge-allof: "npm:^0.8.1"
+    json-schema-traverse: "npm:^1.0.0"
+    lodash: "npm:^4.17.21"
+    minimist: "npm:^1.2.5"
+    ts-json-schema-generator: "npm:^2.9.0"
+    typescript: "npm:^5.9.3"
+    yaml: "npm:^2.0.0"
+  checksum: 10/75a71b8b2acedec97ea09c90c60e319ac46805d313515ef6723ae2138c15b40499b1a130384c1305d410534aae4dfef66b854134f209ddd688c9689a2b949991
+  languageName: node
+  linkType: hard
+
 "@backstage/config-loader@npm:^1.10.12":
   version: 1.10.12
   resolution: "@backstage/config-loader@npm:1.10.12"
@@ -2848,7 +2947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.53.0-next.0&npm=1.3.8, @backstage/config@npm:1.3.8, @backstage/config@npm:^1.3.6, @backstage/config@npm:^1.3.8":
+"@backstage/config@backstage:^::backstage=1.53.0-next.1&npm=1.3.8, @backstage/config@npm:1.3.8, @backstage/config@npm:^1.3.6, @backstage/config@npm:^1.3.8":
   version: 1.3.8
   resolution: "@backstage/config@npm:1.3.8"
   dependencies:
@@ -2885,7 +2984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.53.0-next.0&npm=1.20.3-next.0, @backstage/core-app-api@npm:1.20.3-next.0, @backstage/core-app-api@npm:^1.20.3-next.0":
+"@backstage/core-app-api@backstage:^::backstage=1.53.0-next.1&npm=1.20.3-next.0, @backstage/core-app-api@npm:1.20.3-next.0, @backstage/core-app-api@npm:^1.20.3-next.0":
   version: 1.20.3-next.0
   resolution: "@backstage/core-app-api@npm:1.20.3-next.0"
   dependencies:
@@ -2914,7 +3013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.53.0-next.0&npm=0.5.13-next.0, @backstage/core-compat-api@npm:0.5.13-next.0, @backstage/core-compat-api@npm:^0.5.13-next.0":
+"@backstage/core-compat-api@backstage:^::backstage=1.53.0-next.1&npm=0.5.13-next.0, @backstage/core-compat-api@npm:0.5.13-next.0, @backstage/core-compat-api@npm:^0.5.13-next.0":
   version: 0.5.13-next.0
   resolution: "@backstage/core-compat-api@npm:0.5.13-next.0"
   dependencies:
@@ -2964,7 +3063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.53.0-next.0&npm=0.18.12-next.0, @backstage/core-components@npm:0.18.12-next.0, @backstage/core-components@npm:^0.18.12-next.0":
+"@backstage/core-components@backstage:^::backstage=1.53.0-next.1&npm=0.18.12-next.0, @backstage/core-components@npm:0.18.12-next.0, @backstage/core-components@npm:^0.18.12-next.0":
   version: 0.18.12-next.0
   resolution: "@backstage/core-components@npm:0.18.12-next.0"
   dependencies:
@@ -3080,7 +3179,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.53.0-next.0&npm=1.12.8-next.0, @backstage/core-plugin-api@npm:1.12.8-next.0, @backstage/core-plugin-api@npm:^1.12.8-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.53.0-next.1&npm=1.12.8-next.0, @backstage/core-plugin-api@npm:1.12.8-next.0, @backstage/core-plugin-api@npm:^1.12.8-next.0":
   version: 1.12.8-next.0
   resolution: "@backstage/core-plugin-api@npm:1.12.8-next.0"
   dependencies:
@@ -3126,7 +3225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.53.0-next.0&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.53.0-next.1&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
   version: 0.1.2
   resolution: "@backstage/e2e-test-utils@npm:0.1.2"
   dependencies:
@@ -3214,7 +3313,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.53.0-next.0&npm=0.5.4-next.0, @backstage/frontend-defaults@npm:0.5.4-next.0, @backstage/frontend-defaults@npm:^0.5.4-next.0":
+"@backstage/frontend-defaults@backstage:^::backstage=1.53.0-next.1&npm=0.5.4-next.0, @backstage/frontend-defaults@npm:0.5.4-next.0, @backstage/frontend-defaults@npm:^0.5.4-next.0":
   version: 0.5.4-next.0
   resolution: "@backstage/frontend-defaults@npm:0.5.4-next.0"
   dependencies:
@@ -3237,7 +3336,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.53.0-next.0&npm=0.17.3-next.0, @backstage/frontend-plugin-api@npm:0.17.3-next.0, @backstage/frontend-plugin-api@npm:^0.17.3-next.0":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.53.0-next.1&npm=0.17.3-next.1, @backstage/frontend-plugin-api@npm:0.17.3-next.1, @backstage/frontend-plugin-api@npm:^0.17.3-next.1":
+  version: 0.17.3-next.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.17.3-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/filter-predicates": "npm:0.1.4-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@standard-schema/spec": "npm:^1.1.0"
+    zod: "npm:^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/23acb22ec986a5e62ee30e2ba8cee7b1c0a7569b77f25ab37fd6c1b8a9e456520cd7f3bfe0272920c36ba9251594e07b14683f5b56b35284d5eee0488fe8699a
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:0.17.3-next.0":
   version: 0.17.3-next.0
   resolution: "@backstage/frontend-plugin-api@npm:0.17.3-next.0"
   dependencies:
@@ -3366,7 +3489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.53.0-next.0&npm=1.2.20-next.0, @backstage/integration-react@npm:1.2.20-next.0, @backstage/integration-react@npm:^1.2.20-next.0":
+"@backstage/integration-react@backstage:^::backstage=1.53.0-next.1&npm=1.2.20-next.0, @backstage/integration-react@npm:1.2.20-next.0, @backstage/integration-react@npm:^1.2.20-next.0":
   version: 1.2.20-next.0
   resolution: "@backstage/integration-react@npm:1.2.20-next.0"
   dependencies:
@@ -3452,7 +3575,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.53.0-next.0&npm=0.14.3-next.0, @backstage/plugin-api-docs@npm:^0.14.3-next.0":
+"@backstage/plugin-api-docs@backstage:^::backstage=1.53.0-next.1&npm=0.14.3-next.0, @backstage/plugin-api-docs@npm:^0.14.3-next.0":
   version: 0.14.3-next.0
   resolution: "@backstage/plugin-api-docs@npm:0.14.3-next.0"
   dependencies:
@@ -3487,7 +3610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.53.0-next.0&npm=0.5.16-next.0, @backstage/plugin-app-backend@npm:^0.5.16-next.0":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.53.0-next.1&npm=0.5.16-next.0, @backstage/plugin-app-backend@npm:^0.5.16-next.0":
   version: 0.5.16-next.0
   resolution: "@backstage/plugin-app-backend@npm:0.5.16-next.0"
   dependencies:
@@ -3523,7 +3646,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-react@backstage:^::backstage=1.53.0-next.0&npm=0.2.5-next.0, @backstage/plugin-app-react@npm:0.2.5-next.0, @backstage/plugin-app-react@npm:^0.2.5-next.0":
+"@backstage/plugin-app-react@backstage:^::backstage=1.53.0-next.1&npm=0.2.5-next.0, @backstage/plugin-app-react@npm:0.2.5-next.0, @backstage/plugin-app-react@npm:^0.2.5-next.0":
   version: 0.2.5-next.0
   resolution: "@backstage/plugin-app-react@npm:0.2.5-next.0"
   dependencies:
@@ -3561,7 +3684,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-visualizer@backstage:^::backstage=1.53.0-next.0&npm=0.2.6-next.0, @backstage/plugin-app-visualizer@npm:^0.2.6-next.0":
+"@backstage/plugin-app-visualizer@backstage:^::backstage=1.53.0-next.1&npm=0.2.6-next.0, @backstage/plugin-app-visualizer@npm:^0.2.6-next.0":
   version: 0.2.6-next.0
   resolution: "@backstage/plugin-app-visualizer@npm:0.2.6-next.0"
   dependencies:
@@ -3583,7 +3706,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@backstage:^::backstage=1.53.0-next.0&npm=0.5.1-next.0, @backstage/plugin-app@npm:0.5.1-next.0, @backstage/plugin-app@npm:^0.5.1-next.0":
+"@backstage/plugin-app@backstage:^::backstage=1.53.0-next.1&npm=0.5.1-next.1, @backstage/plugin-app@npm:^0.5.1-next.1":
+  version: 0.5.1-next.1
+  resolution: "@backstage/plugin-app@npm:0.5.1-next.1"
+  dependencies:
+    "@backstage/core-components": "npm:0.18.12-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.8-next.0"
+    "@backstage/filter-predicates": "npm:0.1.4-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.17.3-next.1"
+    "@backstage/integration-react": "npm:1.2.20-next.0"
+    "@backstage/plugin-app-react": "npm:0.2.5-next.0"
+    "@backstage/plugin-permission-react": "npm:0.5.3-next.0"
+    "@backstage/theme": "npm:0.7.3"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/ui": "npm:0.17.0-next.1"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@material-ui/core": "npm:^4.9.13"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:^4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    motion: "npm:^12.0.0"
+    react-aria: "npm:~3.48.0"
+    react-stately: "npm:~3.46.0"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/a3681f7ff1b5012c8924e729ed1472c5489ee68a77fbefb956a0b2cc424b882847b0300a5099dd7001ce4603caccaebba5f84121431f6739ab84ed8c4f5ec945
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-app@npm:0.5.1-next.0":
   version: 0.5.1-next.0
   resolution: "@backstage/plugin-app@npm:0.5.1-next.0"
   dependencies:
@@ -3621,7 +3782,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.53.0-next.0&npm=0.5.5-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.5-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.53.0-next.1&npm=0.5.5-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.5-next.0":
   version: 0.5.5-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.5.5-next.0"
   dependencies:
@@ -3633,7 +3794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.53.0-next.0&npm=0.2.21-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.21-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.53.0-next.1&npm=0.2.21-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.21-next.0":
   version: 0.2.21-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.21-next.0"
   dependencies:
@@ -3646,7 +3807,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.53.0-next.0&npm=0.29.2-next.0, @backstage/plugin-auth-backend@npm:^0.29.2-next.0":
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.53.0-next.1&npm=0.29.2-next.0, @backstage/plugin-auth-backend@npm:^0.29.2-next.0":
   version: 0.29.2-next.0
   resolution: "@backstage/plugin-auth-backend@npm:0.29.2-next.0"
   dependencies:
@@ -3744,7 +3905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth@backstage:^::backstage=1.53.0-next.0&npm=0.1.10-next.0, @backstage/plugin-auth@npm:^0.1.10-next.0":
+"@backstage/plugin-auth@backstage:^::backstage=1.53.0-next.1&npm=0.1.10-next.0, @backstage/plugin-auth@npm:^0.1.10-next.0":
   version: 0.1.10-next.0
   resolution: "@backstage/plugin-auth@npm:0.1.10-next.0"
   dependencies:
@@ -3766,7 +3927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.53.0-next.0&npm=0.5.16-next.0, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.16-next.0":
+"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.53.0-next.1&npm=0.5.16-next.0, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.16-next.0":
   version: 0.5.16-next.0
   resolution: "@backstage/plugin-catalog-backend-module-backstage-openapi@npm:0.5.16-next.0"
   dependencies:
@@ -3784,7 +3945,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.53.0-next.0&npm=0.13.4-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.13.4-next.0":
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.53.0-next.1&npm=0.13.4-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.13.4-next.0":
   version: 0.13.4-next.0
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.13.4-next.0"
   dependencies:
@@ -3812,7 +3973,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.53.0-next.0&npm=0.1.24-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.24-next.0":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.53.0-next.1&npm=0.1.24-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.24-next.0":
   version: 0.1.24-next.0
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.24-next.0"
   dependencies:
@@ -3823,7 +3984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.53.0-next.0&npm=0.2.22-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.22-next.0":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.53.0-next.1&npm=0.2.22-next.0, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.22-next.0":
   version: 0.2.22-next.0
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.22-next.0"
   dependencies:
@@ -3836,7 +3997,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.53.0-next.0&npm=3.8.1-next.0, @backstage/plugin-catalog-backend@npm:3.8.1-next.0, @backstage/plugin-catalog-backend@npm:^3.8.1-next.0":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.53.0-next.1&npm=3.8.1-next.0, @backstage/plugin-catalog-backend@npm:3.8.1-next.0, @backstage/plugin-catalog-backend@npm:^3.8.1-next.0":
   version: 3.8.1-next.0
   resolution: "@backstage/plugin-catalog-backend@npm:3.8.1-next.0"
   dependencies:
@@ -3878,7 +4039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.53.0-next.0&npm=1.1.10, @backstage/plugin-catalog-common@npm:1.1.10, @backstage/plugin-catalog-common@npm:^1.1.10, @backstage/plugin-catalog-common@npm:^1.1.9":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.53.0-next.1&npm=1.1.10, @backstage/plugin-catalog-common@npm:1.1.10, @backstage/plugin-catalog-common@npm:^1.1.10, @backstage/plugin-catalog-common@npm:^1.1.9":
   version: 1.1.10
   resolution: "@backstage/plugin-catalog-common@npm:1.1.10"
   dependencies:
@@ -3889,7 +4050,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.53.0-next.0&npm=0.6.6-next.0, @backstage/plugin-catalog-graph@npm:^0.6.6-next.0":
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.53.0-next.1&npm=0.6.6-next.0, @backstage/plugin-catalog-graph@npm:^0.6.6-next.0":
   version: 0.6.6-next.0
   resolution: "@backstage/plugin-catalog-graph@npm:0.6.6-next.0"
   dependencies:
@@ -3922,7 +4083,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.53.0-next.0&npm=2.2.3-next.0, @backstage/plugin-catalog-node@npm:2.2.3-next.0, @backstage/plugin-catalog-node@npm:^2.2.3-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.53.0-next.1&npm=2.2.3-next.0, @backstage/plugin-catalog-node@npm:2.2.3-next.0, @backstage/plugin-catalog-node@npm:^2.2.3-next.0":
   version: 2.2.3-next.0
   resolution: "@backstage/plugin-catalog-node@npm:2.2.3-next.0"
   dependencies:
@@ -3970,7 +4131,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.53.0-next.0&npm=3.2.0-next.0, @backstage/plugin-catalog-react@npm:3.2.0-next.0, @backstage/plugin-catalog-react@npm:^3.2.0-next.0":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.53.0-next.1&npm=3.2.0-next.0, @backstage/plugin-catalog-react@npm:3.2.0-next.0, @backstage/plugin-catalog-react@npm:^3.2.0-next.0":
   version: 3.2.0-next.0
   resolution: "@backstage/plugin-catalog-react@npm:3.2.0-next.0"
   dependencies:
@@ -4109,7 +4270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.53.0-next.0&npm=2.0.7-next.0, @backstage/plugin-catalog@npm:2.0.7-next.0, @backstage/plugin-catalog@npm:^2.0.7-next.0":
+"@backstage/plugin-catalog@backstage:^::backstage=1.53.0-next.1&npm=2.0.7-next.0, @backstage/plugin-catalog@npm:2.0.7-next.0, @backstage/plugin-catalog@npm:^2.0.7-next.0":
   version: 2.0.7-next.0
   resolution: "@backstage/plugin-catalog@npm:2.0.7-next.0"
   dependencies:
@@ -4158,7 +4319,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.53.0-next.0&npm=0.4.14-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.14-next.0":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.53.0-next.1&npm=0.4.14-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.14-next.0":
   version: 0.4.14-next.0
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.14-next.0"
   dependencies:
@@ -4175,7 +4336,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.53.0-next.0&npm=0.6.4-next.0, @backstage/plugin-events-backend@npm:^0.6.4-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.53.0-next.1&npm=0.6.4-next.0, @backstage/plugin-events-backend@npm:^0.6.4-next.0":
   version: 0.6.4-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.6.4-next.0"
   dependencies:
@@ -4228,7 +4389,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@backstage:^::backstage=1.53.0-next.0&npm=0.1.40-next.0, @backstage/plugin-home-react@npm:0.1.40-next.0, @backstage/plugin-home-react@npm:^0.1.40-next.0":
+"@backstage/plugin-home-react@backstage:^::backstage=1.53.0-next.1&npm=0.1.40-next.0, @backstage/plugin-home-react@npm:0.1.40-next.0, @backstage/plugin-home-react@npm:^0.1.40-next.0":
   version: 0.1.40-next.0
   resolution: "@backstage/plugin-home-react@npm:0.1.40-next.0"
   dependencies:
@@ -4251,7 +4412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.53.0-next.0&npm=0.9.8-next.0, @backstage/plugin-home@npm:^0.9.8-next.0":
+"@backstage/plugin-home@backstage:^::backstage=1.53.0-next.1&npm=0.9.8-next.0, @backstage/plugin-home@npm:^0.9.8-next.0":
   version: 0.9.8-next.0
   resolution: "@backstage/plugin-home@npm:0.9.8-next.0"
   dependencies:
@@ -4291,7 +4452,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.53.0-next.0&npm=0.21.6-next.0, @backstage/plugin-kubernetes-backend@npm:^0.21.6-next.0":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.53.0-next.1&npm=0.21.6-next.0, @backstage/plugin-kubernetes-backend@npm:^0.21.6-next.0":
   version: 0.21.6-next.0
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.6-next.0"
   dependencies:
@@ -4393,7 +4554,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.53.0-next.0&npm=0.12.21-next.0, @backstage/plugin-kubernetes@npm:^0.12.21-next.0":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.53.0-next.1&npm=0.12.21-next.0, @backstage/plugin-kubernetes@npm:^0.12.21-next.0":
   version: 0.12.21-next.0
   resolution: "@backstage/plugin-kubernetes@npm:0.12.21-next.0"
   dependencies:
@@ -4418,9 +4579,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.53.0-next.0&npm=0.1.15-next.0, @backstage/plugin-mcp-actions-backend@npm:^0.1.15-next.0":
-  version: 0.1.15-next.0
-  resolution: "@backstage/plugin-mcp-actions-backend@npm:0.1.15-next.0"
+"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.53.0-next.1&npm=0.2.0-next.1, @backstage/plugin-mcp-actions-backend@npm:^0.2.0-next.1":
+  version: 0.2.0-next.1
+  resolution: "@backstage/plugin-mcp-actions-backend@npm:0.2.0-next.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.9.3-next.0"
     "@backstage/catalog-client": "npm:1.16.1-next.0"
@@ -4434,11 +4595,11 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     minimatch: "npm:^10.2.1"
     zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10/6186890f5d4ff6536537364ea88081e768f9d12ccc4953670899bc64a1fec78ee3ea3f13677a7de0ca6412861cff8528f99e40fccdf4f83707dfe06bdd0b9683
+  checksum: 10/77ba7de18e189d6e8368b432dd918c8a2f96489fd4d6ac54e5931d78466603b3804751e815a93992e947409dab4e1f2b02489f2ed8e0448335588aa12bd3698c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.53.0-next.0&npm=0.2.9-next.0, @backstage/plugin-mui-to-bui@npm:^0.2.9-next.0":
+"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.53.0-next.1&npm=0.2.9-next.0, @backstage/plugin-mui-to-bui@npm:^0.2.9-next.0":
   version: 0.2.9-next.0
   resolution: "@backstage/plugin-mui-to-bui@npm:0.2.9-next.0"
   dependencies:
@@ -4460,7 +4621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.53.0-next.0&npm=0.6.7-next.0, @backstage/plugin-notifications-backend@npm:^0.6.7-next.0":
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.53.0-next.1&npm=0.6.7-next.0, @backstage/plugin-notifications-backend@npm:^0.6.7-next.0":
   version: 0.6.7-next.0
   resolution: "@backstage/plugin-notifications-backend@npm:0.6.7-next.0"
   dependencies:
@@ -4492,7 +4653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.53.0-next.0&npm=0.2.28-next.0, @backstage/plugin-notifications-node@npm:0.2.28-next.0, @backstage/plugin-notifications-node@npm:^0.2.28-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.53.0-next.1&npm=0.2.28-next.0, @backstage/plugin-notifications-node@npm:0.2.28-next.0, @backstage/plugin-notifications-node@npm:^0.2.28-next.0":
   version: 0.2.28-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.28-next.0"
   dependencies:
@@ -4502,7 +4663,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.53.0-next.0&npm=0.5.19-next.0, @backstage/plugin-notifications@npm:^0.5.19-next.0":
+"@backstage/plugin-notifications@backstage:^::backstage=1.53.0-next.1&npm=0.5.19-next.0, @backstage/plugin-notifications@npm:^0.5.19-next.0":
   version: 0.5.19-next.0
   resolution: "@backstage/plugin-notifications@npm:0.5.19-next.0"
   dependencies:
@@ -4532,7 +4693,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.53.0-next.0&npm=0.7.6-next.0, @backstage/plugin-org@npm:^0.7.6-next.0":
+"@backstage/plugin-org@backstage:^::backstage=1.53.0-next.1&npm=0.7.6-next.0, @backstage/plugin-org@npm:^0.7.6-next.0":
   version: 0.7.6-next.0
   resolution: "@backstage/plugin-org@npm:0.7.6-next.0"
   dependencies:
@@ -4653,7 +4814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.53.0-next.0&npm=0.6.15-next.0, @backstage/plugin-proxy-backend@npm:^0.6.15-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.53.0-next.1&npm=0.6.15-next.0, @backstage/plugin-proxy-backend@npm:^0.6.15-next.0":
   version: 0.6.15-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.15-next.0"
   dependencies:
@@ -4676,7 +4837,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.53.0-next.0&npm=0.9.11-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.11-next.0":
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.53.0-next.1&npm=0.9.11-next.0, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.11-next.0":
   version: 0.9.11-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.11-next.0"
   dependencies:
@@ -4700,7 +4861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.53.0-next.0&npm=0.1.24-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.24-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.53.0-next.1&npm=0.1.24-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.24-next.0":
   version: 0.1.24-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.24-next.0"
   dependencies:
@@ -4713,7 +4874,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.53.0-next.0&npm=4.0.2-next.0, @backstage/plugin-scaffolder-backend@npm:^4.0.2-next.0":
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.53.0-next.1&npm=4.0.2-next.0, @backstage/plugin-scaffolder-backend@npm:^4.0.2-next.0":
   version: 4.0.2-next.0
   resolution: "@backstage/plugin-scaffolder-backend@npm:4.0.2-next.0"
   dependencies:
@@ -4865,9 +5026,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.53.0-next.0&npm=1.38.1-next.0, @backstage/plugin-scaffolder@npm:^1.38.1-next.0":
-  version: 1.38.1-next.0
-  resolution: "@backstage/plugin-scaffolder@npm:1.38.1-next.0"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.53.0-next.1&npm=1.38.1-next.1, @backstage/plugin-scaffolder@npm:^1.38.1-next.1":
+  version: 1.38.1-next.1
+  resolution: "@backstage/plugin-scaffolder@npm:1.38.1-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1-next.0"
     "@backstage/catalog-model": "npm:1.9.0"
@@ -4875,7 +5036,7 @@ __metadata:
     "@backstage/core-plugin-api": "npm:1.12.8-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/filter-predicates": "npm:0.1.4-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.3-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.17.3-next.1"
     "@backstage/integration": "npm:2.0.3"
     "@backstage/integration-react": "npm:1.2.20-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.10"
@@ -4886,7 +5047,7 @@ __metadata:
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/plugin-techdocs-react": "npm:1.3.13-next.0"
     "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.17.0-next.0"
+    "@backstage/ui": "npm:0.17.0-next.1"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
     "@codemirror/view": "npm:^6.0.0"
@@ -4925,11 +5086,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a234ef3a643ba3a10265034137d3f0d3a4472070d3f0f6facf0651b10c6a951a0e34277121c89a9f6f728151c3a587b22effbfc0cdbe1f4872a926779ecca8a8
+  checksum: 10/227e9c77b6e286386ddf63117b750d22df409017cd0ab5206f77d7ee846904c5c8c80e778d93507158db1cb06dd779711ab31386716a5cb95349d063d2940346
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.53.0-next.0&npm=0.3.17-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.17-next.0":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.53.0-next.1&npm=0.3.17-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.17-next.0":
   version: 0.3.17-next.0
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.17-next.0"
   dependencies:
@@ -4981,7 +5142,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.53.0-next.0&npm=2.1.4-next.0, @backstage/plugin-search-backend@npm:^2.1.4-next.0":
+"@backstage/plugin-search-backend@backstage:^::backstage=1.53.0-next.1&npm=2.1.4-next.0, @backstage/plugin-search-backend@npm:^2.1.4-next.0":
   version: 2.1.4-next.0
   resolution: "@backstage/plugin-search-backend@npm:2.1.4-next.0"
   dependencies:
@@ -5013,7 +5174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.53.0-next.0&npm=1.11.6-next.0, @backstage/plugin-search-react@npm:1.11.6-next.0, @backstage/plugin-search-react@npm:^1.11.6-next.0":
+"@backstage/plugin-search-react@backstage:^::backstage=1.53.0-next.1&npm=1.11.6-next.0, @backstage/plugin-search-react@npm:1.11.6-next.0, @backstage/plugin-search-react@npm:^1.11.6-next.0":
   version: 1.11.6-next.0
   resolution: "@backstage/plugin-search-react@npm:1.11.6-next.0"
   dependencies:
@@ -5073,7 +5234,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.53.0-next.0&npm=1.7.6-next.0, @backstage/plugin-search@npm:^1.7.6-next.0":
+"@backstage/plugin-search@backstage:^::backstage=1.53.0-next.1&npm=1.7.6-next.0, @backstage/plugin-search@npm:^1.7.6-next.0":
   version: 1.7.6-next.0
   resolution: "@backstage/plugin-search@npm:1.7.6-next.0"
   dependencies:
@@ -5104,7 +5265,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.53.0-next.0&npm=0.3.17-next.0, @backstage/plugin-signals-backend@npm:^0.3.17-next.0":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.53.0-next.1&npm=0.3.17-next.0, @backstage/plugin-signals-backend@npm:^0.3.17-next.0":
   version: 0.3.17-next.0
   resolution: "@backstage/plugin-signals-backend@npm:0.3.17-next.0"
   dependencies:
@@ -5150,7 +5311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.53.0-next.0&npm=0.0.33-next.0, @backstage/plugin-signals@npm:^0.0.33-next.0":
+"@backstage/plugin-signals@backstage:^::backstage=1.53.0-next.1&npm=0.0.33-next.0, @backstage/plugin-signals@npm:^0.0.33-next.0":
   version: 0.0.33-next.0
   resolution: "@backstage/plugin-signals@npm:0.0.33-next.0"
   dependencies:
@@ -5174,7 +5335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.53.0-next.0&npm=2.2.2-next.0, @backstage/plugin-techdocs-backend@npm:^2.2.2-next.0":
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.53.0-next.1&npm=2.2.2-next.0, @backstage/plugin-techdocs-backend@npm:^2.2.2-next.0":
   version: 2.2.2-next.0
   resolution: "@backstage/plugin-techdocs-backend@npm:2.2.2-next.0"
   dependencies:
@@ -5204,7 +5365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.53.0-next.0&npm=1.1.38-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.38-next.0":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.53.0-next.1&npm=1.1.38-next.0, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.38-next.0":
   version: 1.1.38-next.0
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.38-next.0"
   dependencies:
@@ -5231,7 +5392,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.53.0-next.0&npm=1.15.2-next.0, @backstage/plugin-techdocs-node@npm:1.15.2-next.0, @backstage/plugin-techdocs-node@npm:^1.15.2-next.0":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.53.0-next.1&npm=1.15.2-next.0, @backstage/plugin-techdocs-node@npm:1.15.2-next.0, @backstage/plugin-techdocs-node@npm:^1.15.2-next.0":
   version: 1.15.2-next.0
   resolution: "@backstage/plugin-techdocs-node@npm:1.15.2-next.0"
   dependencies:
@@ -5268,7 +5429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.53.0-next.0&npm=1.3.13-next.0, @backstage/plugin-techdocs-react@npm:1.3.13-next.0, @backstage/plugin-techdocs-react@npm:^1.3.13-next.0":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.53.0-next.1&npm=1.3.13-next.0, @backstage/plugin-techdocs-react@npm:1.3.13-next.0, @backstage/plugin-techdocs-react@npm:^1.3.13-next.0":
   version: 1.3.13-next.0
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.13-next.0"
   dependencies:
@@ -5324,7 +5485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.53.0-next.0&npm=1.17.8-next.0, @backstage/plugin-techdocs@npm:^1.17.8-next.0":
+"@backstage/plugin-techdocs@backstage:^::backstage=1.53.0-next.1&npm=1.17.8-next.0, @backstage/plugin-techdocs@npm:^1.17.8-next.0":
   version: 1.17.8-next.0
   resolution: "@backstage/plugin-techdocs@npm:1.17.8-next.0"
   dependencies:
@@ -5378,7 +5539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.53.0-next.0&npm=0.9.5-next.0, @backstage/plugin-user-settings@npm:^0.9.5-next.0":
+"@backstage/plugin-user-settings@backstage:^::backstage=1.53.0-next.1&npm=0.9.5-next.0, @backstage/plugin-user-settings@npm:^0.9.5-next.0":
   version: 0.9.5-next.0
   resolution: "@backstage/plugin-user-settings@npm:0.9.5-next.0"
   dependencies:
@@ -5419,7 +5580,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.53.0-next.0&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.2, @backstage/theme@npm:^0.7.3":
+"@backstage/theme@backstage:^::backstage=1.53.0-next.1&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.2, @backstage/theme@npm:^0.7.3":
   version: 0.7.3
   resolution: "@backstage/theme@npm:0.7.3"
   dependencies:
@@ -5446,7 +5607,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.53.0-next.0&npm=0.17.0-next.0, @backstage/ui@npm:0.17.0-next.0, @backstage/ui@npm:^0.17.0-next.0":
+"@backstage/ui@backstage:^::backstage=1.53.0-next.1&npm=0.17.0-next.1, @backstage/ui@npm:0.17.0-next.1, @backstage/ui@npm:^0.17.0-next.1":
+  version: 0.17.0-next.1
+  resolution: "@backstage/ui@npm:0.17.0-next.1"
+  dependencies:
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@braintree/sanitize-url": "npm:^7.1.2"
+    "@internationalized/date": "npm:^3.12.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    "@tanstack/react-table": "npm:^8.21.3"
+    clsx: "npm:^2.1.1"
+    marked: "npm:^15.0.12"
+    react-aria: "npm:~3.48.0"
+    react-aria-components: "npm:~1.17.0"
+    react-stately: "npm:~3.46.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/4bf6848cee8151be93db8f0eca225185790ee87ea3dd5b5f6f148dfd212d98234b60147e4394f79d03cf51f1cd91a58409fa04bcf92b3511c97ee4a834b4d5e7
+  languageName: node
+  linkType: hard
+
+"@backstage/ui@npm:0.17.0-next.0":
   version: 0.17.0-next.0
   resolution: "@backstage/ui@npm:0.17.0-next.0"
   dependencies:


### PR DESCRIPTION
Backstage release v1.53.0-next.1 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.53.0-next.1](https://github.com/backstage/backstage/blob/master/docs/releases/v1.53.0-next.1-changelog.md)
- Upgrade Helper: [From 1.53.0-next.0 to 1.53.0-next.1](https://backstage.github.io/upgrade-helper/?from=1.53.0-next.0&to=1.53.0-next.1)
 
Created by [Version Bump 28677999802](https://github.com/backstage/demo/actions/runs/28677999802)
 