### PR TITLE
Disable Renovate lock file maintenance PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
   "postUpdateOptions": ["yarnDedupeHighest"],
   "rangeStrategy": "update-lockfile",
   "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor", "patch"],


### PR DESCRIPTION
## Summary

- Disables Renovate's lock file maintenance PRs

Lock file maintenance PRs touch a large number of dependencies at once, making them difficult to review meaningfully. Disabling them doesn't prevent dependency updates — individual package updates will still be created as normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)