### PR TITLE
v1.54.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,6 +12,6 @@ npmPreapprovedPackages:
 plugins:
   - checksum: ae08ece83681cc6d217ebb53d9e00a06ea215383f34af0681a05da5720e018a6b0d98012112f9368e9fe2328b19919baba37ada25f46c4614b894765a9338db9
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.54.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.54.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.54.0-next.1"
+  "version": "1.54.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,9 +2067,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.54.0-next.1&npm=0.17.6-next.1, @backstage/backend-defaults@npm:^0.17.6-next.1":
-  version: 0.17.6-next.1
-  resolution: "@backstage/backend-defaults@npm:0.17.6-next.1"
+"@backstage/backend-defaults@backstage:^::backstage=1.54.0-next.2&npm=0.17.7-next.2, @backstage/backend-defaults@npm:^0.17.7-next.2":
+  version: 0.17.7-next.2
+  resolution: "@backstage/backend-defaults@npm:0.17.7-next.2"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -2081,10 +2081,10 @@ __metadata:
     "@azure/storage-blob": "npm:^12.5.0"
     "@backstage/backend-app-api": "npm:1.7.3-next.0"
     "@backstage/backend-dev-utils": "npm:0.1.7"
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
     "@backstage/cli-node": "npm:0.3.4"
     "@backstage/config": "npm:1.3.8"
-    "@backstage/config-loader": "npm:1.11.0"
+    "@backstage/config-loader": "npm:1.11.2-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/integration": "npm:2.1.0-next.0"
     "@backstage/integration-aws-node": "npm:0.2.0"
@@ -2136,7 +2136,7 @@ __metadata:
     rate-limit-redis: "npm:^4.2.0"
     raw-body: "npm:^2.4.1"
     selfsigned: "npm:^2.0.0"
-    tar: "npm:^7.5.6"
+    tar: "npm:^7.5.21"
     triple-beam: "npm:^1.4.1"
     winston: "npm:^3.2.1"
     winston-transport: "npm:^4.5.0"
@@ -2152,7 +2152,7 @@ __metadata:
       optional: true
     better-sqlite3:
       optional: true
-  checksum: 10/b6eaa68f241c6b417f71c161d17803a8be9234d504066a5bed3682dde355e75a4f76835555b2511416c1bd247e62184e9426931f6acb641cb7bbd286cc059a8f
+  checksum: 10/3f42bd09afb5f981b8c3502761a147edbc841e1eda92b1276e32f16e24dc358924b7b8da98a80be97294073d64e25ef7a35c7f52209cf54b654636697617df8d
   languageName: node
   linkType: hard
 
@@ -2300,7 +2300,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.54.0-next.1&npm=1.10.0-next.0, @backstage/backend-plugin-api@npm:1.10.0-next.0, @backstage/backend-plugin-api@npm:^1.10.0-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.54.0-next.2&npm=1.10.0-next.1, @backstage/backend-plugin-api@npm:1.10.0-next.1, @backstage/backend-plugin-api@npm:^1.10.0-next.1":
+  version: 1.10.0-next.1
+  resolution: "@backstage/backend-plugin-api@npm:1.10.0-next.1"
+  dependencies:
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/plugin-auth-node": "npm:0.7.4-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9"
+    "@backstage/plugin-permission-node": "npm:0.11.3-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/json-schema": "npm:^7.0.6"
+    "@types/luxon": "npm:^3.0.0"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  checksum: 10/b56c483dd52efc643dbb11f61cb2b895327bd85e1b86930b30c821917df0093105b53e1445ad72929298ab669e2b7f760a937142d5dd37ad60bf7bf2f3806a0d
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-plugin-api@npm:1.10.0-next.0":
   version: 1.10.0-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.10.0-next.0"
   dependencies:
@@ -2357,7 +2378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.54.0-next.1&npm=1.9.0, @backstage/catalog-model@npm:1.9.0, @backstage/catalog-model@npm:^1.9.0":
+"@backstage/catalog-model@backstage:^::backstage=1.54.0-next.2&npm=1.9.0, @backstage/catalog-model@npm:1.9.0, @backstage/catalog-model@npm:^1.9.0":
   version: 1.9.0
   resolution: "@backstage/catalog-model@npm:1.9.0"
   dependencies:
@@ -2381,27 +2402,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-defaults@backstage:^::backstage=1.54.0-next.1&npm=0.1.4, @backstage/cli-defaults@npm:0.1.4, @backstage/cli-defaults@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@backstage/cli-defaults@npm:0.1.4"
+"@backstage/cli-defaults@backstage:^::backstage=1.54.0-next.2&npm=0.1.5-next.0, @backstage/cli-defaults@npm:0.1.5-next.0, @backstage/cli-defaults@npm:^0.1.5-next.0":
+  version: 0.1.5-next.0
+  resolution: "@backstage/cli-defaults@npm:0.1.5-next.0"
   dependencies:
-    "@backstage/cli-module-actions": "npm:^0.1.3"
-    "@backstage/cli-module-auth": "npm:^0.1.4"
-    "@backstage/cli-module-build": "npm:^0.1.5"
-    "@backstage/cli-module-config": "npm:^0.1.4"
-    "@backstage/cli-module-github": "npm:^0.1.4"
-    "@backstage/cli-module-info": "npm:^0.1.4"
-    "@backstage/cli-module-lint": "npm:^0.1.4"
-    "@backstage/cli-module-maintenance": "npm:^0.1.4"
-    "@backstage/cli-module-migrate": "npm:^0.2.0"
-    "@backstage/cli-module-new": "npm:^0.1.5"
-    "@backstage/cli-module-test-jest": "npm:^0.1.4"
-    "@backstage/cli-module-translations": "npm:^0.1.4"
-  checksum: 10/d74d4a2368ee325519aaa2294859502bda4351421d46f231fb6e22daa1f1da4c28b33314555b7e2959374aa15d9b666981ad947ebb35fc2de0860c60b7d520a6
+    "@backstage/cli-module-actions": "npm:0.1.3"
+    "@backstage/cli-module-auth": "npm:0.1.4"
+    "@backstage/cli-module-build": "npm:0.1.7-next.0"
+    "@backstage/cli-module-config": "npm:0.1.6-next.0"
+    "@backstage/cli-module-github": "npm:0.1.4"
+    "@backstage/cli-module-info": "npm:0.1.4"
+    "@backstage/cli-module-lint": "npm:0.1.5-next.0"
+    "@backstage/cli-module-maintenance": "npm:0.1.4"
+    "@backstage/cli-module-migrate": "npm:0.2.0"
+    "@backstage/cli-module-new": "npm:0.1.6-next.0"
+    "@backstage/cli-module-test-jest": "npm:0.1.5-next.0"
+    "@backstage/cli-module-translations": "npm:0.1.4"
+  checksum: 10/f8fc8911c8d7a85824f8ebf6654758ddddd610d2ba3bc55b5395c286d9e6c150ea99e8ff2ff106b3493262a61b984936ab649db0ce672d964493a09873fff5fa
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-actions@npm:^0.1.3":
+"@backstage/cli-module-actions@npm:0.1.3":
   version: 0.1.3
   resolution: "@backstage/cli-module-actions@npm:0.1.3"
   dependencies:
@@ -2419,7 +2440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-auth@npm:^0.1.4":
+"@backstage/cli-module-auth@npm:0.1.4":
   version: 0.1.4
   resolution: "@backstage/cli-module-auth@npm:0.1.4"
   dependencies:
@@ -2442,16 +2463,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-build@npm:0.1.5, @backstage/cli-module-build@npm:^0.1.5":
-  version: 0.1.5
-  resolution: "@backstage/cli-module-build@npm:0.1.5"
+"@backstage/cli-module-build@npm:0.1.7-next.0":
+  version: 0.1.7-next.0
+  resolution: "@backstage/cli-module-build@npm:0.1.7-next.0"
   dependencies:
-    "@backstage/cli-common": "npm:^0.3.0"
-    "@backstage/cli-node": "npm:^0.3.4"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/config-loader": "npm:^1.11.0"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/module-federation-common": "npm:^0.1.4"
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/cli-node": "npm:0.3.4"
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/config-loader": "npm:1.11.2-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/module-federation-common": "npm:0.1.4"
     "@manypkg/get-packages": "npm:^1.1.3"
     "@module-federation/enhanced": "npm:^2.3.3"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.6.0"
@@ -2495,10 +2516,10 @@ __metadata:
     rollup-plugin-esbuild: "npm:^6.1.1"
     rollup-plugin-postcss: "npm:^4.0.0"
     rollup-pluginutils: "npm:^2.8.2"
-    shell-quote: "npm:^1.8.1"
+    shell-quote: "npm:^1.9.0"
     style-loader: "npm:^3.3.1"
     swc-loader: "npm:^0.2.3"
-    tar: "npm:^7.5.6"
+    tar: "npm:^7.5.21"
     ts-checker-rspack-plugin: "npm:^1.1.5"
     ts-morph: "npm:^24.0.0"
     util: "npm:^0.12.3"
@@ -2514,19 +2535,19 @@ __metadata:
       optional: true
   bin:
     cli-module-build: bin/backstage-cli-module-build
-  checksum: 10/ddefd00326609d3303e087bc57e3297618ac35011942303ea46dea996a08c6e0feec0273a089dcfedcfc6ca0efa166f72593d6afcdd770547404a0ec707bfd47
+  checksum: 10/8175c75848fea5dd7b2854f1ac699a336f5c3ac965649e8c6a5a7c5ad2bc1e572984471b74e815c3d11adeaba30ef9ee7466ba6cbd905de3d3209dab9256638a
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-config@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@backstage/cli-module-config@npm:0.1.4"
+"@backstage/cli-module-config@npm:0.1.6-next.0":
+  version: 0.1.6-next.0
+  resolution: "@backstage/cli-module-config@npm:0.1.6-next.0"
   dependencies:
-    "@backstage/cli-common": "npm:^0.3.0"
-    "@backstage/cli-node": "npm:^0.3.4"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/config-loader": "npm:^1.11.0"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/cli-node": "npm:0.3.4"
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/config-loader": "npm:1.11.2-next.0"
+    "@backstage/types": "npm:1.2.2"
     "@manypkg/get-packages": "npm:^1.1.3"
     chalk: "npm:^4.0.0"
     cleye: "npm:^2.6.0"
@@ -2534,11 +2555,11 @@ __metadata:
     yaml: "npm:^2.0.0"
   bin:
     cli-module-config: bin/backstage-cli-module-config
-  checksum: 10/1770f0320029f1a2263471ebbaab30b14563471feafe70731e84e0489a04922087b343ebf8b999b8b495a2f0dbf1fe8ed3c3b808aa10ff8b13ff6f76dc1488ff
+  checksum: 10/169bd1447c64bbd50a1d1fd960f1f23bbb2b06a2374d221c8c058768d92b5e8ca091106bb35e5f66a802777cd1899917311855e730cca9cfec18fe18f611f715
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-github@npm:^0.1.4":
+"@backstage/cli-module-github@npm:0.1.4":
   version: 0.1.4
   resolution: "@backstage/cli-module-github@npm:0.1.4"
   dependencies:
@@ -2558,7 +2579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-info@npm:^0.1.4":
+"@backstage/cli-module-info@npm:0.1.4":
   version: 0.1.4
   resolution: "@backstage/cli-module-info@npm:0.1.4"
   dependencies:
@@ -2573,26 +2594,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-lint@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@backstage/cli-module-lint@npm:0.1.4"
+"@backstage/cli-module-lint@npm:0.1.5-next.0":
+  version: 0.1.5-next.0
+  resolution: "@backstage/cli-module-lint@npm:0.1.5-next.0"
   dependencies:
-    "@backstage/cli-common": "npm:^0.3.0"
-    "@backstage/cli-node": "npm:^0.3.4"
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/cli-node": "npm:0.3.4"
     chalk: "npm:^4.0.0"
     cleye: "npm:^2.6.0"
     eslint: "npm:^8.6.0"
     eslint-formatter-friendly: "npm:^7.0.0"
     fs-extra: "npm:^11.2.0"
     globby: "npm:^11.1.0"
-    shell-quote: "npm:^1.8.1"
+    shell-quote: "npm:^1.9.0"
   bin:
     cli-module-lint: bin/backstage-cli-module-lint
-  checksum: 10/5354b2e8a9e85a595deaf69cddf69670313204cc47e40c783cf44fe7b9a736b6fe9a0ad72c6bf25451831c5f7ed80bb64647239ef6fd466b6bca853ea4b1349f
+  checksum: 10/7bb73fd269853c002963aef0ca15b4f5abb4fa16baa1728d365667db32d620406410bd9f6ef1934de97f833b4a7e33208569d2be8f5700550c58c5c8de9668bc
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-maintenance@npm:^0.1.4":
+"@backstage/cli-module-maintenance@npm:0.1.4":
   version: 0.1.4
   resolution: "@backstage/cli-module-maintenance@npm:0.1.4"
   dependencies:
@@ -2608,7 +2629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-migrate@npm:^0.2.0":
+"@backstage/cli-module-migrate@npm:0.2.0":
   version: 0.2.0
   resolution: "@backstage/cli-module-migrate@npm:0.2.0"
   dependencies:
@@ -2630,13 +2651,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-new@npm:^0.1.5":
-  version: 0.1.5
-  resolution: "@backstage/cli-module-new@npm:0.1.5"
+"@backstage/cli-module-new@npm:0.1.6-next.0":
+  version: 0.1.6-next.0
+  resolution: "@backstage/cli-module-new@npm:0.1.6-next.0"
   dependencies:
-    "@backstage/cli-common": "npm:^0.3.0"
-    "@backstage/cli-node": "npm:^0.3.4"
-    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/cli-node": "npm:0.3.4"
+    "@backstage/errors": "npm:1.3.1"
     chalk: "npm:^4.0.0"
     cleye: "npm:^2.6.0"
     fs-extra: "npm:^11.2.0"
@@ -2651,16 +2672,16 @@ __metadata:
     zod-validation-error: "npm:^5.0.0"
   bin:
     cli-module-new: bin/backstage-cli-module-new
-  checksum: 10/72ad4e357e4fd340ce6fc118675ffc77a8c6bb87d20bd9c4ee594a90b8861b1ea90241f4659024b345406043ddec76cfa0c14062a358f6563950674badf0320d
+  checksum: 10/f1b69c7f16b57e160435a73124b1c8b4c4d2d21659ccfd5cdf66a1770b649781aab170a689d5eb9bb6cf1d6f7fb5dc317775134dcdf5d81d0b9cfb8d1dc500ea
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-test-jest@npm:0.1.4, @backstage/cli-module-test-jest@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@backstage/cli-module-test-jest@npm:0.1.4"
+"@backstage/cli-module-test-jest@npm:0.1.5-next.0":
+  version: 0.1.5-next.0
+  resolution: "@backstage/cli-module-test-jest@npm:0.1.5-next.0"
   dependencies:
-    "@backstage/cli-common": "npm:^0.3.0"
-    "@backstage/cli-node": "npm:^0.3.4"
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/cli-node": "npm:0.3.4"
     "@swc/core": "npm:^1.15.6"
     "@swc/jest": "npm:^0.2.39"
     cleye: "npm:^2.6.0"
@@ -2684,11 +2705,11 @@ __metadata:
       optional: true
   bin:
     cli-module-test-jest: bin/backstage-cli-module-test-jest
-  checksum: 10/88f87463e3c2b8a78028ea5b11d8ff228aea1a1189db495b88b866a6b647e7ccb42c8ac0ad1e3e7fab72cf5866264b6333d2300b100dc499eac84563560b7ec0
+  checksum: 10/4f3d16bafa025ac71e1e4dc31afd2fe67c45bdaef04ca795ce830da7ba5fcc4687606769fc8396a718d3cec807e2d9cc5a088de99420cdc22fb353496eccff59
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-translations@npm:^0.1.4":
+"@backstage/cli-module-translations@npm:0.1.4":
   version: 0.1.4
   resolution: "@backstage/cli-module-translations@npm:0.1.4"
   dependencies:
@@ -2734,14 +2755,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.54.0-next.1&npm=0.36.5-next.0, @backstage/cli@npm:^0.36.5-next.0":
-  version: 0.36.5-next.0
-  resolution: "@backstage/cli@npm:0.36.5-next.0"
+"@backstage/cli@backstage:^::backstage=1.54.0-next.2&npm=0.36.5-next.1, @backstage/cli@npm:^0.36.5-next.1":
+  version: 0.36.5-next.1
+  resolution: "@backstage/cli@npm:0.36.5-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.3.0"
-    "@backstage/cli-defaults": "npm:0.1.4"
-    "@backstage/cli-module-build": "npm:0.1.5"
-    "@backstage/cli-module-test-jest": "npm:0.1.4"
+    "@backstage/cli-defaults": "npm:0.1.5-next.0"
+    "@backstage/cli-module-build": "npm:0.1.7-next.0"
+    "@backstage/cli-module-test-jest": "npm:0.1.5-next.0"
     "@backstage/cli-node": "npm:0.3.4"
     "@backstage/eslint-plugin": "npm:0.3.2-next.0"
     "@manypkg/get-packages": "npm:^1.1.3"
@@ -2785,11 +2806,34 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/8706def94548bd34697cbee32b56c120c9485180f62950ce30964b25039d09655601c9000b3ba0555c84e59d63c50114a621694d6e645144537921ca11ada2c8
+  checksum: 10/004867254ecfec025e9a8c16d8eefae5b13cc3ac855765858ad31edcf03acfa715ee2c0a3d3a003af26a4f06b3fbec615f00f27278fb5b3c890570b6c84ead3a
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:1.11.0, @backstage/config-loader@npm:^1.11.0":
+"@backstage/config-loader@npm:1.11.2-next.0":
+  version: 1.11.2-next.0
+  resolution: "@backstage/config-loader@npm:1.11.2-next.0"
+  dependencies:
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    "@types/json-schema": "npm:^7.0.6"
+    ajv: "npm:^8.10.0"
+    chokidar: "npm:^3.5.2"
+    fs-extra: "npm:^11.2.0"
+    json-schema-merge-allof: "npm:^0.8.1"
+    json-schema-traverse: "npm:^1.0.0"
+    lodash: "npm:^4.17.21"
+    minimist: "npm:^1.2.5"
+    ts-json-schema-generator: "npm:^2.9.0"
+    typescript: "npm:^5.9.3"
+    yaml: "npm:^2.0.0"
+  checksum: 10/961ffe80d28015b9b1a63f59baea351453c015a7402c4fc6bf560386d517018e04de59657cf222810bdd4327354bf14efb2ea004992e5976ade9a9a94d671504
+  languageName: node
+  linkType: hard
+
+"@backstage/config-loader@npm:^1.11.0":
   version: 1.11.0
   resolution: "@backstage/config-loader@npm:1.11.0"
   dependencies:
@@ -2812,7 +2856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.54.0-next.1&npm=1.3.8, @backstage/config@npm:1.3.8, @backstage/config@npm:^1.3.8":
+"@backstage/config@backstage:^::backstage=1.54.0-next.2&npm=1.3.8, @backstage/config@npm:1.3.8, @backstage/config@npm:^1.3.8":
   version: 1.3.8
   resolution: "@backstage/config@npm:1.3.8"
   dependencies:
@@ -2858,12 +2902,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.54.0-next.1&npm=1.20.4-next.0, @backstage/core-app-api@npm:1.20.4-next.0, @backstage/core-app-api@npm:^1.20.4-next.0":
-  version: 1.20.4-next.0
-  resolution: "@backstage/core-app-api@npm:1.20.4-next.0"
+"@backstage/core-app-api@backstage:^::backstage=1.54.0-next.2&npm=1.20.4-next.1, @backstage/core-app-api@npm:1.20.4-next.1, @backstage/core-app-api@npm:^1.20.4-next.1":
+  version: 1.20.4-next.1
+  resolution: "@backstage/core-app-api@npm:1.20.4-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.8"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@backstage/version-bridge": "npm:1.0.12"
@@ -2883,20 +2927,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/deda3e9f5e2fdbebe70f4a89703f6d78ec13b74263446ae3363e90d3ebd9ea7b71972eba56b041a3f1dc36b4e5e5e57f912a0eb60840eefc110afe1767ce3cfc
+  checksum: 10/218a83012e99fb91466501b54f47670f0e318fb89d585f24bea28f49e39ce70430992a4261bbc236d07f607059c37db65659c62e0eb84bb1415c4d4a6528de9b
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.54.0-next.1&npm=0.5.14-next.0, @backstage/core-compat-api@npm:0.5.14-next.0, @backstage/core-compat-api@npm:^0.5.14-next.0":
-  version: 0.5.14-next.0
-  resolution: "@backstage/core-compat-api@npm:0.5.14-next.0"
+"@backstage/core-compat-api@backstage:^::backstage=1.54.0-next.2&npm=0.5.14-next.1, @backstage/core-compat-api@npm:0.5.14-next.1, @backstage/core-compat-api@npm:^0.5.14-next.1":
+  version: 0.5.14-next.1
+  resolution: "@backstage/core-compat-api@npm:0.5.14-next.1"
   dependencies:
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/filter-predicates": "npm:0.1.4"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-app-react": "npm:0.2.5"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-app-react": "npm:0.2.6-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.12"
     lodash: "npm:^4.17.21"
@@ -2908,7 +2952,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fe266ccb008ec735070e2faa0056de0a228d1cf40d88d3ef621378d1dcf8f3779f7f789e463e3766092717cf3744512d69f1e3ce3de38b097e2d340c23a58a62
+  checksum: 10/458dbfabf1089c9bd071973eaa934e0e5148a0c1602c7ebec0077fff1964e42b9b2e5b116fa4620fa442374fa3af586cda771f5410c9404b3bb5efdf21c59a29
   languageName: node
   linkType: hard
 
@@ -2937,12 +2981,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.54.0-next.1&npm=0.18.13-next.1, @backstage/core-components@npm:0.18.13-next.1, @backstage/core-components@npm:^0.18.13-next.1":
-  version: 0.18.13-next.1
-  resolution: "@backstage/core-components@npm:0.18.13-next.1"
+"@backstage/core-components@backstage:^::backstage=1.54.0-next.2&npm=0.18.13-next.2, @backstage/core-components@npm:0.18.13-next.2, @backstage/core-components@npm:^0.18.13-next.2":
+  version: 0.18.13-next.2
+  resolution: "@backstage/core-components@npm:0.18.13-next.2"
   dependencies:
     "@backstage/config": "npm:1.3.8"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/ui": "npm:0.17.1-next.0"
@@ -2992,66 +3036,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/fa254792e985c52144c1a07686a4e9c41fe8442c92c5cccdc1f86e71c1289f1a21f0386847f277555fa4081ec0c6e4d849d87804ab937c4e5f6904d7f48302e4
-  languageName: node
-  linkType: hard
-
-"@backstage/core-components@npm:0.18.13-next.0":
-  version: 0.18.13-next.0
-  resolution: "@backstage/core-components@npm:0.18.13-next.0"
-  dependencies:
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/errors": "npm:1.3.1"
-    "@backstage/theme": "npm:0.7.3"
-    "@backstage/ui": "npm:0.17.1-next.0"
-    "@backstage/version-bridge": "npm:1.0.12"
-    "@dagrejs/dagre": "npm:^1.1.4"
-    "@date-io/core": "npm:^1.3.13"
-    "@material-table/core": "npm:^3.1.0"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@react-hookz/web": "npm:^24.0.0"
-    "@testing-library/react": "npm:^16.0.0"
-    "@types/react-sparklines": "npm:^1.7.0"
-    ansi-regex: "npm:^6.0.1"
-    classnames: "npm:^2.2.6"
-    csstype: "npm:^3.0.2"
-    d3-selection: "npm:^3.0.0"
-    d3-shape: "npm:^3.0.0"
-    d3-zoom: "npm:^3.0.0"
-    js-yaml: "npm:^4.3.0"
-    linkify-react: "npm:4.3.2"
-    linkifyjs: "npm:4.3.2"
-    lodash: "npm:^4.17.21"
-    parse5: "npm:^6.0.0"
-    qs: "npm:^6.15.2"
-    rc-progress: "npm:3.5.1"
-    react-full-screen: "npm:^1.1.1"
-    react-helmet: "npm:6.1.0"
-    react-hook-form: "npm:^7.12.2"
-    react-idle-timer: "npm:5.7.2"
-    react-markdown: "npm:^8.0.0"
-    react-sparklines: "npm:^1.7.0"
-    react-syntax-highlighter: "npm:^15.4.5"
-    react-use: "npm:^17.3.2"
-    react-virtualized-auto-sizer: "npm:^1.0.11"
-    react-window: "npm:^1.8.6"
-    rehype-raw: "npm:^6.0.0"
-    rehype-sanitize: "npm:^5.0.0"
-    remark-gfm: "npm:^3.0.1"
-    zen-observable: "npm:^0.10.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.30.2
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10/fb59c9623c325aed397226e7ad4668aa7b2908d2fbbcd2a8c0445470615d3d20697cd12620421ef14eb25b557580ad6b8f5e18416910e82736cbd2ac41f93b31
+  checksum: 10/785c5d5b314eab9c7f22053bd2f60109ce30875943394b5891ee404ab36201548133b6f3e0eafbe8dfc73d01162fc5c3f6dd4115fe5488fb427edd9375f9b0be
   languageName: node
   linkType: hard
 
@@ -3114,7 +3099,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.54.0-next.1&npm=1.12.8, @backstage/core-plugin-api@npm:1.12.8, @backstage/core-plugin-api@npm:^1.12.2, @backstage/core-plugin-api@npm:^1.12.7, @backstage/core-plugin-api@npm:^1.12.8":
+"@backstage/core-plugin-api@backstage:^::backstage=1.54.0-next.2&npm=1.12.9-next.0, @backstage/core-plugin-api@npm:1.12.9-next.0, @backstage/core-plugin-api@npm:^1.12.9-next.0":
+  version: 1.12.9-next.0
+  resolution: "@backstage/core-plugin-api@npm:1.12.9-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    history: "npm:^5.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/27155ed4a28f4cab4e666cfd88b8df7bd088bbc58211d9b07eab87cbd704ef0e63945c4d21e5f9eb24b2f69559cfe71939d35747223edcf9a2b98fcd72b0cdd1
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:^1.12.2, @backstage/core-plugin-api@npm:^1.12.7, @backstage/core-plugin-api@npm:^1.12.8":
   version: 1.12.8
   resolution: "@backstage/core-plugin-api@npm:1.12.8"
   dependencies:
@@ -3137,7 +3145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.54.0-next.1&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.54.0-next.2&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
   version: 0.1.2
   resolution: "@backstage/e2e-test-utils@npm:0.1.2"
   dependencies:
@@ -3185,21 +3193,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-app-api@npm:0.16.7-next.0":
-  version: 0.16.7-next.0
-  resolution: "@backstage/frontend-app-api@npm:0.16.7-next.0"
+"@backstage/frontend-app-api@npm:0.16.7-next.1":
+  version: 0.16.7-next.1
+  resolution: "@backstage/frontend-app-api@npm:0.16.7-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.8"
-    "@backstage/core-app-api": "npm:1.20.4-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-app-api": "npm:1.20.4-next.1"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/filter-predicates": "npm:0.1.4"
-    "@backstage/frontend-defaults": "npm:0.5.5-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/frontend-defaults": "npm:0.5.5-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.12"
     lodash: "npm:^4.17.21"
-    zod: "npm:^3.25.76 || ^4.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
@@ -3208,20 +3215,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e4d6900a225162762b72e86b71d30123a2f0f899d093dbb8a89a621e1a10952846cbd8aca56da10e989606c61c532a6bace2786cb6c0d7336a18539827a3e21e
+  checksum: 10/44b5849623a846f96defb285a8a0001cd040ffda829fe602f48ee84178076c326b1bed964e801079bd1a896d4cccede1057dd34a40f22a96f73dbc89400fa832
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.54.0-next.1&npm=0.5.5-next.0, @backstage/frontend-defaults@npm:0.5.5-next.0, @backstage/frontend-defaults@npm:^0.5.5-next.0":
-  version: 0.5.5-next.0
-  resolution: "@backstage/frontend-defaults@npm:0.5.5-next.0"
+"@backstage/frontend-defaults@backstage:^::backstage=1.54.0-next.2&npm=0.5.5-next.1, @backstage/frontend-defaults@npm:0.5.5-next.1, @backstage/frontend-defaults@npm:^0.5.5-next.1":
+  version: 0.5.5-next.1
+  resolution: "@backstage/frontend-defaults@npm:0.5.5-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.8"
-    "@backstage/core-components": "npm:0.18.13-next.0"
+    "@backstage/core-components": "npm:0.18.13-next.2"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-app-api": "npm:0.16.7-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-app": "npm:0.5.2-next.0"
+    "@backstage/frontend-app-api": "npm:0.16.7-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-app": "npm:0.5.2-next.2"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -3231,22 +3238,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e155114c15ca952b149215c42d9c18e10e9ce2751bb9dfbce44dc9cc59fab0a8a2c6d6f4bd4250d3773e7ba2b5764b1522bd3b0e3a89a6eb5d0bd6cb9e6b8533
+  checksum: 10/88e26a0d2233bd45be199ea8de83a08a9e3f3795b06904660634094bc95e17325dbf75fda20ef3c7829f8fee9e126259fdf07687c170c0d7b6fdd0ea777e5531
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.54.0-next.1&npm=0.17.3, @backstage/frontend-plugin-api@npm:0.17.3, @backstage/frontend-plugin-api@npm:^0.17.2, @backstage/frontend-plugin-api@npm:^0.17.3":
-  version: 0.17.3
-  resolution: "@backstage/frontend-plugin-api@npm:0.17.3"
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.54.0-next.2&npm=0.18.0-next.0, @backstage/frontend-plugin-api@npm:0.18.0-next.0, @backstage/frontend-plugin-api@npm:^0.18.0-next.0":
+  version: 0.18.0-next.0
+  resolution: "@backstage/frontend-plugin-api@npm:0.18.0-next.0"
   dependencies:
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/filter-predicates": "npm:^0.1.4"
-    "@backstage/types": "npm:^1.2.2"
-    "@backstage/version-bridge": "npm:^1.0.12"
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/filter-predicates": "npm:0.1.4"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.12"
     "@standard-schema/spec": "npm:^1.1.0"
-    zod: "npm:^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
@@ -3255,7 +3260,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/16da36c4d922b0ac0d5a146476ad00bc82bb1033a164be5f5f9d282a144c06a5ea7d3a093993133521bbcf865f543194d065079660137931d0f7d5a263bd8472
+  checksum: 10/7ec49d6ed40663194e9e5ed9b0eae6889a0d2b1aee122fb2b2ef073d95a1978974b638ca2d35904e4fdad111946bfa012ebbebc9f3eb4871c12c4ca679f7c4d5
   languageName: node
   linkType: hard
 
@@ -3280,6 +3285,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-plugin-api@npm:^0.17.2, @backstage/frontend-plugin-api@npm:^0.17.3":
+  version: 0.17.3
+  resolution: "@backstage/frontend-plugin-api@npm:0.17.3"
+  dependencies:
+    "@backstage/config": "npm:^1.3.8"
+    "@backstage/errors": "npm:^1.3.1"
+    "@backstage/filter-predicates": "npm:^0.1.4"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@standard-schema/spec": "npm:^1.1.0"
+    zod: "npm:^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/16da36c4d922b0ac0d5a146476ad00bc82bb1033a164be5f5f9d282a144c06a5ea7d3a093993133521bbcf865f543194d065079660137931d0f7d5a263bd8472
+  languageName: node
+  linkType: hard
+
 "@backstage/integration-aws-node@npm:0.2.0, @backstage/integration-aws-node@npm:^0.2.0":
   version: 0.2.0
   resolution: "@backstage/integration-aws-node@npm:0.2.0"
@@ -3295,12 +3324,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.54.0-next.1&npm=1.2.21-next.0, @backstage/integration-react@npm:1.2.21-next.0, @backstage/integration-react@npm:^1.2.21-next.0":
-  version: 1.2.21-next.0
-  resolution: "@backstage/integration-react@npm:1.2.21-next.0"
+"@backstage/integration-react@backstage:^::backstage=1.54.0-next.2&npm=1.2.21-next.1, @backstage/integration-react@npm:1.2.21-next.1, @backstage/integration-react@npm:^1.2.21-next.1":
+  version: 1.2.21-next.1
+  resolution: "@backstage/integration-react@npm:1.2.21-next.1"
   dependencies:
     "@backstage/config": "npm:1.3.8"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/integration": "npm:2.1.0-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -3312,11 +3341,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1cc06acef5d956c9a91e11a410d923c8fadedcab3cdb76ae324ee6a4b77aba165a815020fbbcbd2c476249065e03edbd4744528f58483143c7d44e6a26b98368
+  checksum: 10/11a213f25a58983b6255c75ffdc4a902d2a56a3be0b98e9a5cbf640e37f43495e048e9ba43f09301487d67ec39165ce7d33539bfbbcf02de5a42d01dda790b6d
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@npm:1.2.20, @backstage/integration-react@npm:^1.2.20":
+"@backstage/integration-react@npm:^1.2.20":
   version: 1.2.20
   resolution: "@backstage/integration-react@npm:1.2.20"
   dependencies:
@@ -3376,7 +3405,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/module-federation-common@npm:^0.1.4":
+"@backstage/module-federation-common@npm:0.1.4":
   version: 0.1.4
   resolution: "@backstage/module-federation-common@npm:0.1.4"
   dependencies:
@@ -3401,19 +3430,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.54.0-next.1&npm=0.14.4-next.0, @backstage/plugin-api-docs@npm:^0.14.4-next.0":
-  version: 0.14.4-next.0
-  resolution: "@backstage/plugin-api-docs@npm:0.14.4-next.0"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.54.0-next.2&npm=0.14.4-next.1, @backstage/plugin-api-docs@npm:^0.14.4-next.1":
+  version: 0.14.4-next.1
+  resolution: "@backstage/plugin-api-docs@npm:0.14.4-next.1"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-catalog": "npm:2.0.8-next.0"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-catalog": "npm:2.0.8-next.2"
     "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.0"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@graphiql/react": "npm:0.29.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -3424,6 +3453,7 @@ __metadata:
     graphql: "npm:^16.0.0"
     graphql-ws: "npm:^5.4.1"
     swagger-ui-react: "npm:^5.27.1"
+    zod: "npm:^4.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
@@ -3432,19 +3462,19 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8d6386a509f3452f16ad72740c0cf20c5008abb3acfd31bfaf39b2ad280538654d1486bb08053ca0882c1a57905c41cd0138bcc4b4f9eca4240445bcf04341a9
+  checksum: 10/1e1d57271c7f90b145c57cb7d40fb7d26528617d5955d2ab306d626863c8e06957e1684869d2971601a8d21a7ad960c384dd3c7592b5d0a4222d490751be9136
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.54.0-next.1&npm=0.5.17-next.0, @backstage/plugin-app-backend@npm:^0.5.17-next.0":
-  version: 0.5.17-next.0
-  resolution: "@backstage/plugin-app-backend@npm:0.5.17-next.0"
+"@backstage/plugin-app-backend@backstage:^::backstage=1.54.0-next.2&npm=0.5.17-next.1, @backstage/plugin-app-backend@npm:^0.5.17-next.1":
+  version: 0.5.17-next.1
+  resolution: "@backstage/plugin-app-backend@npm:0.5.17-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
     "@backstage/config": "npm:1.3.8"
-    "@backstage/config-loader": "npm:1.11.0"
+    "@backstage/config-loader": "npm:1.11.2-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-app-node": "npm:0.1.48-next.0"
+    "@backstage/plugin-app-node": "npm:0.1.48-next.1"
     "@backstage/plugin-auth-node": "npm:0.7.4-next.0"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.22.0"
@@ -3455,24 +3485,43 @@ __metadata:
     knex: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-  checksum: 10/dc3c809da6e774ace25be62fd3a223306e6d738b3f26789f3e0a1d0b4a18f396b89a90735f1f14e7ef16d5d67ac403c0843ee109f5be3ce1f05fa8cbf2c17c1e
+  checksum: 10/79f30bd6634d9b1b15ef68c1a4d92c18aba9a15f5cbf866f2ae0a8a1c728075c3d6b2910f242f1c2d5335e488d0fa62971f234862283430f6cb3b52dc0337eec
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-node@npm:0.1.48-next.0":
-  version: 0.1.48-next.0
-  resolution: "@backstage/plugin-app-node@npm:0.1.48-next.0"
+"@backstage/plugin-app-node@npm:0.1.48-next.1":
+  version: 0.1.48-next.1
+  resolution: "@backstage/plugin-app-node@npm:0.1.48-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
-    "@backstage/config-loader": "npm:1.11.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
+    "@backstage/config-loader": "npm:1.11.2-next.0"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
-  checksum: 10/20ea2613078de36b6a1e7e229f22641e70a36f0f9fcc32f8f1d809dcb8d3f5d313c6fd3ae632d30cbdbe6a084d83294e6bb74315dc9f7981e8da7b01f0fcc0c7
+  checksum: 10/645bb058f412fdd898e86fd650b5c05a56b44974b33d024b221569116be0abb7ba5d456837960297b6a864abc7f783cdabb7288603556bbef908a68851a6dda1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-react@backstage:^::backstage=1.54.0-next.1&npm=0.2.5, @backstage/plugin-app-react@npm:0.2.5, @backstage/plugin-app-react@npm:^0.2.5":
+"@backstage/plugin-app-react@backstage:^::backstage=1.54.0-next.2&npm=0.2.6-next.0, @backstage/plugin-app-react@npm:0.2.6-next.0, @backstage/plugin-app-react@npm:^0.2.6-next.0":
+  version: 0.2.6-next.0
+  resolution: "@backstage/plugin-app-react@npm:0.2.6-next.0"
+  dependencies:
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@material-ui/core": "npm:^4.9.13"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/e5682a34fec0a103b19326ba523dcfae2824df7da505fc40505e0248c75bae6c86095f4687ea2c08c9281627f97c4b5a1779d31021d5269cc63ea14f6f530ff5
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-app-react@npm:^0.2.5":
   version: 0.2.5
   resolution: "@backstage/plugin-app-react@npm:0.2.5"
   dependencies:
@@ -3491,13 +3540,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-visualizer@backstage:^::backstage=1.54.0-next.1&npm=0.2.7-next.0, @backstage/plugin-app-visualizer@npm:^0.2.7-next.0":
-  version: 0.2.7-next.0
-  resolution: "@backstage/plugin-app-visualizer@npm:0.2.7-next.0"
+"@backstage/plugin-app-visualizer@backstage:^::backstage=1.54.0-next.2&npm=0.2.7-next.1, @backstage/plugin-app-visualizer@npm:^0.2.7-next.1":
+  version: 0.2.7-next.1
+  resolution: "@backstage/plugin-app-visualizer@npm:0.2.7-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     react-aria-components: "npm:~1.17.0"
@@ -3509,21 +3558,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d4a73df3a9f5d494ccb9924d64cf18c67781a99ff9afed94e126fccb127711ea67b1350c457dcfba363361aeae19a11eae5a2c0408bd096eed04eea1e4aafc90
+  checksum: 10/5cc13601db090773c1a2cc655563d5b6facf52e7ad5be04fac3e532e179f0899d31481d639bfdd05f5c62a380a9231bfd2072aea602a7527eb6f3778cd3659b6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@backstage:^::backstage=1.54.0-next.1&npm=0.5.2-next.1, @backstage/plugin-app@npm:^0.5.2-next.1":
-  version: 0.5.2-next.1
-  resolution: "@backstage/plugin-app@npm:0.5.2-next.1"
+"@backstage/plugin-app@backstage:^::backstage=1.54.0-next.2&npm=0.5.2-next.2, @backstage/plugin-app@npm:0.5.2-next.2, @backstage/plugin-app@npm:^0.5.2-next.2":
+  version: 0.5.2-next.2
+  resolution: "@backstage/plugin-app@npm:0.5.2-next.2"
   dependencies:
-    "@backstage/core-components": "npm:0.18.13-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/filter-predicates": "npm:0.1.4"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/integration-react": "npm:1.2.21-next.0"
-    "@backstage/plugin-app-react": "npm:0.2.5"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/integration-react": "npm:1.2.21-next.1"
+    "@backstage/plugin-app-react": "npm:0.2.6-next.0"
+    "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/types": "npm:1.2.2"
     "@backstage/ui": "npm:0.17.1-next.0"
@@ -3547,49 +3596,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/19bedbadeeafb9c2d23c90d469f5653dfa35381d3c045d18575783efde2061806cc5477db12be738615127af67ab3501e435a2a1a888369766db0d6c122b7b1b
+  checksum: 10/7821dfe6f6a8a28ea930d85660c7c550dde976a42661954446740034a1404abb6b9f82e0aaf7af8717d15386ef79ccd362f3597bac9f8567d8f2ea44ecbdc6d1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@npm:0.5.2-next.0":
-  version: 0.5.2-next.0
-  resolution: "@backstage/plugin-app@npm:0.5.2-next.0"
-  dependencies:
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/filter-predicates": "npm:0.1.4"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/integration-react": "npm:1.2.20"
-    "@backstage/plugin-app-react": "npm:0.2.5"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
-    "@backstage/theme": "npm:0.7.3"
-    "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.17.1-next.0"
-    "@backstage/version-bridge": "npm:1.0.12"
-    "@material-ui/core": "npm:^4.9.13"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:^4.0.0-alpha.61"
-    "@react-hookz/web": "npm:^24.0.0"
-    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
-    motion: "npm:^12.0.0"
-    react-aria: "npm:~3.48.0"
-    react-stately: "npm:~3.46.0"
-    react-use: "npm:^17.2.4"
-    zen-observable: "npm:^0.10.0"
-    zod: "npm:^4.0.0"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.30.2
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10/2107ffca832f0fb15cff68ad15634e96424260ece4599c738af2f03b884b9faac97ab151968d2a5731347598e3a8518e2137bbe2e30cca501b5bbeeb727bf9d3
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.54.0-next.1&npm=0.5.6-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.6-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.54.0-next.2&npm=0.5.6-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.6-next.0":
   version: 0.5.6-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.5.6-next.0"
   dependencies:
@@ -3601,7 +3612,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.54.0-next.1&npm=0.2.22-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.22-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.54.0-next.2&npm=0.2.22-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.22-next.0":
   version: 0.2.22-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.22-next.0"
   dependencies:
@@ -3614,11 +3625,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.54.0-next.1&npm=0.30.0-next.0, @backstage/plugin-auth-backend@npm:^0.30.0-next.0":
-  version: 0.30.0-next.0
-  resolution: "@backstage/plugin-auth-backend@npm:0.30.0-next.0"
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.54.0-next.2&npm=0.30.0-next.1, @backstage/plugin-auth-backend@npm:^0.30.0-next.1":
+  version: 0.30.0-next.1
+  resolution: "@backstage/plugin-auth-backend@npm:0.30.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/config": "npm:1.3.8"
     "@backstage/errors": "npm:1.3.1"
@@ -3641,7 +3652,7 @@ __metadata:
     passport: "npm:^0.7.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-validation-error: "npm:^5.0.0"
-  checksum: 10/34fd257e28a7354516af9997f51731bd295af51ffe9b3484e1f708a4668781409d5c12c7f098aed645331404e68c79ad67a55671c20785f7c0932ac9cafc5568
+  checksum: 10/a45d2742cc75542dd7cea24c5857e663b53480fea06b390c045c60eb10350909efab7e657eb8f5ea5ecd3ffe315af4dff10e6f48e4528ff8714e054c0e6dc9a2
   languageName: node
   linkType: hard
 
@@ -3691,12 +3702,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-react@npm:0.1.30-next.0":
-  version: 0.1.30-next.0
-  resolution: "@backstage/plugin-auth-react@npm:0.1.30-next.0"
+"@backstage/plugin-auth-react@npm:0.1.30-next.1":
+  version: 0.1.30-next.1
+  resolution: "@backstage/plugin-auth-react@npm:0.1.30-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@material-ui/core": "npm:^4.9.13"
     "@react-hookz/web": "npm:^24.0.0"
@@ -3708,16 +3719,16 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5376b7ec45e30b508b27f73d72ad7fdbfa775802030d0aefcdd4e22c05008c1b041482a7ae69a292f78d6fe2188f2d7449f6aa93cb707efb18fc1744ecb82259
+  checksum: 10/e7437f036c60520667c6292d77094bd7003ba942480fe78f3f8380af9e03810e8fccf5a27736378f3a4b83421ccebd7d42584850b5de4b49be3408a62d63cbd5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth@backstage:^::backstage=1.54.0-next.1&npm=0.1.11-next.0, @backstage/plugin-auth@npm:^0.1.11-next.0":
-  version: 0.1.11-next.0
-  resolution: "@backstage/plugin-auth@npm:0.1.11-next.0"
+"@backstage/plugin-auth@backstage:^::backstage=1.54.0-next.2&npm=0.1.11-next.1, @backstage/plugin-auth@npm:^0.1.11-next.1":
+  version: 0.1.11-next.1
+  resolution: "@backstage/plugin-auth@npm:0.1.11-next.1"
   dependencies:
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@remixicon/react": "npm:>=4.6.0 <4.9.0"
@@ -3730,11 +3741,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/522d979f9d7bf5e0f928fb3183704c2cbb416be30d2e23980eee6195de51f006225496506ccb110830e1e1812637aebb21c0b85e79bbac0ead77977b403788fd
+  checksum: 10/afd52837427daffec056b90d184b3e1ce6f180e4686e82b92d4309b5bf40c8410d6e34105b7ed375bb238e08dd8c652d83b63357584f4322ea6dc2e9a1ecd661
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-ai-model@backstage:^::backstage=1.54.0-next.1&npm=0.1.3-next.0, @backstage/plugin-catalog-backend-module-ai-model@npm:^0.1.3-next.0":
+"@backstage/plugin-catalog-backend-module-ai-model@backstage:^::backstage=1.54.0-next.2&npm=0.1.3-next.0, @backstage/plugin-catalog-backend-module-ai-model@npm:^0.1.3-next.0":
   version: 0.1.3-next.0
   resolution: "@backstage/plugin-catalog-backend-module-ai-model@npm:0.1.3-next.0"
   dependencies:
@@ -3745,7 +3756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.54.0-next.1&npm=0.5.17-next.0, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.17-next.0":
+"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.54.0-next.2&npm=0.5.17-next.0, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.17-next.0":
   version: 0.5.17-next.0
   resolution: "@backstage/plugin-catalog-backend-module-backstage-openapi@npm:0.5.17-next.0"
   dependencies:
@@ -3763,7 +3774,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.54.0-next.1&npm=0.13.5-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.13.5-next.1":
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.54.0-next.2&npm=0.13.5-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.13.5-next.1":
   version: 0.13.5-next.1
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.13.5-next.1"
   dependencies:
@@ -3791,18 +3802,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.54.0-next.1&npm=0.1.25-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.25-next.0":
-  version: 0.1.25-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.25-next.0"
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.54.0-next.2&npm=0.1.25-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.25-next.1":
+  version: 0.1.25-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.25-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
-    "@backstage/plugin-catalog-backend": "npm:3.8.2-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
+    "@backstage/plugin-catalog-backend": "npm:3.9.0-next.2"
     "@backstage/plugin-events-node": "npm:0.4.25-next.0"
-  checksum: 10/77d2d5c44f608cdbff4d8293df246be93cf4119d1d821fe4040566948ab88c6ba1047913002d41a529803bba35b71c92521bb8cd80e470aa89b18aee5c98e82e
+  checksum: 10/d32e97385317dae2d4aebbeba6beae0f3f27e3f64f21d6c9e6c4f01942512659c522322f0daa6f832f7603aaa5e8b1b319b3772ee20e449298a23068a9b7a078
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.54.0-next.1&npm=0.2.23-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.23-next.1":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.54.0-next.2&npm=0.2.23-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.23-next.1":
   version: 0.2.23-next.1
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.23-next.1"
   dependencies:
@@ -3815,12 +3826,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.54.0-next.1&npm=3.8.2-next.1, @backstage/plugin-catalog-backend@npm:^3.8.2-next.1":
-  version: 3.8.2-next.1
-  resolution: "@backstage/plugin-catalog-backend@npm:3.8.2-next.1"
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.54.0-next.2&npm=3.9.0-next.2, @backstage/plugin-catalog-backend@npm:3.9.0-next.2, @backstage/plugin-catalog-backend@npm:^3.9.0-next.2":
+  version: 3.9.0-next.2
+  resolution: "@backstage/plugin-catalog-backend@npm:3.9.0-next.2"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.7.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/config": "npm:1.3.8"
@@ -3853,53 +3864,11 @@ __metadata:
     yn: "npm:^4.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-validation-error: "npm:^5.0.0"
-  checksum: 10/ab4462848bac9e39719978ccf735654d7862bea1099bc069386b6c45d488f23f44a2410146e347272e503eb8d57cefedb2d8172bdfb7224cb4c2902bde5bdde2
+  checksum: 10/9a36cf056deeab087f3f290f2a44106a307e6d2c1180bb063fd86ef7af0d436dc859a79217671c864373c810ae1054a4a0a03fe7987b7de24d58511d419e7ca1
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@npm:3.8.2-next.0":
-  version: 3.8.2-next.0
-  resolution: "@backstage/plugin-catalog-backend@npm:3.8.2-next.0"
-  dependencies:
-    "@backstage/backend-openapi-utils": "npm:0.7.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
-    "@backstage/catalog-client": "npm:1.16.1"
-    "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/errors": "npm:1.3.1"
-    "@backstage/filter-predicates": "npm:0.1.4"
-    "@backstage/integration": "npm:2.0.3"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-node": "npm:2.2.4-next.0"
-    "@backstage/plugin-events-node": "npm:0.4.25-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.9"
-    "@backstage/plugin-permission-node": "npm:0.11.3-next.0"
-    "@backstage/types": "npm:1.2.2"
-    "@opentelemetry/api": "npm:^1.9.0"
-    ajv: "npm:^8.10.0"
-    ajv-errors: "npm:^3.0.0"
-    codeowners-utils: "npm:^1.0.2"
-    core-js: "npm:^3.6.5"
-    express: "npm:^4.22.0"
-    fast-json-stable-stringify: "npm:^2.1.0"
-    fs-extra: "npm:^11.2.0"
-    git-url-parse: "npm:^15.0.0"
-    glob: "npm:^13.0.0"
-    knex: "npm:^3.0.0"
-    lodash: "npm:^4.17.21"
-    luxon: "npm:^3.0.0"
-    minimatch: "npm:^10.2.1"
-    p-limit: "npm:^3.0.2"
-    prom-client: "npm:^15.0.0"
-    yaml: "npm:^2.0.0"
-    yn: "npm:^4.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-validation-error: "npm:^5.0.0"
-  checksum: 10/791798d987b93b0bb0d22d470b6c004d1b6b62e9d7c25c763681063df1a5c1cd1244657f4fe2de57018738771cc6d350366e485441ed734750468028cf066873
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.54.0-next.1&npm=1.1.10, @backstage/plugin-catalog-common@npm:1.1.10, @backstage/plugin-catalog-common@npm:^1.1.10":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.54.0-next.2&npm=1.1.10, @backstage/plugin-catalog-common@npm:1.1.10, @backstage/plugin-catalog-common@npm:^1.1.10":
   version: 1.1.10
   resolution: "@backstage/plugin-catalog-common@npm:1.1.10"
   dependencies:
@@ -3910,16 +3879,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.54.0-next.1&npm=0.6.7-next.0, @backstage/plugin-catalog-graph@npm:^0.6.7-next.0":
-  version: 0.6.7-next.0
-  resolution: "@backstage/plugin-catalog-graph@npm:0.6.7-next.0"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.54.0-next.2&npm=0.6.7-next.1, @backstage/plugin-catalog-graph@npm:^0.6.7-next.1":
+  version: 0.6.7-next.1
+  resolution: "@backstage/plugin-catalog-graph@npm:0.6.7-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.0"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
     "@backstage/types": "npm:1.2.2"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -3939,11 +3908,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d55b60a91e314d5f20d6ab31606b8d5544521df8596a73b41fbb2035c54a5aa3055185565261979cf8c83146ef1c7da8921ecb3923e77549eeeab91774f91f5d
+  checksum: 10/6429691fc288a76e03b24394a8080c5a0a162ceda67650c0b30c91b4cc7e9485c2cc28d507b0e556f5fc9ef94430fecb7557790c31b032337e293ee91619ec97
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.54.0-next.1&npm=2.2.4-next.0, @backstage/plugin-catalog-node@npm:2.2.4-next.0, @backstage/plugin-catalog-node@npm:^2.2.4-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.54.0-next.2&npm=2.2.4-next.0, @backstage/plugin-catalog-node@npm:2.2.4-next.0, @backstage/plugin-catalog-node@npm:^2.2.4-next.0":
   version: 2.2.4-next.0
   resolution: "@backstage/plugin-catalog-node@npm:2.2.4-next.0"
   dependencies:
@@ -3991,21 +3960,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.54.0-next.1&npm=3.2.1-next.1, @backstage/plugin-catalog-react@npm:3.2.1-next.1, @backstage/plugin-catalog-react@npm:^3.2.1-next.1":
-  version: 3.2.1-next.1
-  resolution: "@backstage/plugin-catalog-react@npm:3.2.1-next.1"
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.54.0-next.2&npm=3.2.1-next.2, @backstage/plugin-catalog-react@npm:3.2.1-next.2, @backstage/plugin-catalog-react@npm:^3.2.1-next.2":
+  version: 3.2.1-next.2
+  resolution: "@backstage/plugin-catalog-react@npm:3.2.1-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-compat-api": "npm:0.5.14-next.0"
-    "@backstage/core-components": "npm:0.18.13-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-compat-api": "npm:0.5.14-next.1"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/filter-predicates": "npm:0.1.4"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/integration-react": "npm:1.2.21-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/integration-react": "npm:1.2.21-next.1"
     "@backstage/plugin-permission-common": "npm:0.9.9"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
+    "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@backstage/types": "npm:1.2.2"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@backstage/version-bridge": "npm:1.0.12"
@@ -4024,7 +3993,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^4.0.0"
   peerDependencies:
-    "@backstage/frontend-test-utils": 0.6.3-next.0
+    "@backstage/frontend-test-utils": 0.6.3-next.1
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -4034,53 +4003,7 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 10/9280ee7f5b453d83153bc71a96550485078e5fc1a08e1f6810ba9252a3936bd1e8d7a859edee0ec64386c1d2e1a3b039967a939157d6980a7b468ab3f9bf81a2
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-catalog-react@npm:3.2.1-next.0":
-  version: 3.2.1-next.0
-  resolution: "@backstage/plugin-catalog-react@npm:3.2.1-next.0"
-  dependencies:
-    "@backstage/catalog-client": "npm:1.16.1"
-    "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-compat-api": "npm:0.5.14-next.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/errors": "npm:1.3.1"
-    "@backstage/filter-predicates": "npm:0.1.4"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/integration-react": "npm:1.2.20"
-    "@backstage/plugin-permission-common": "npm:0.9.9"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
-    "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.17.1-next.0"
-    "@backstage/version-bridge": "npm:1.0.12"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@react-hookz/web": "npm:^24.0.0"
-    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
-    classnames: "npm:^2.2.6"
-    lodash: "npm:^4.17.21"
-    material-ui-popup-state: "npm:^5.3.6"
-    qs: "npm:^6.15.2"
-    react-use: "npm:^17.2.4"
-    yaml: "npm:^2.0.0"
-    zen-observable: "npm:^0.10.0"
-    zod: "npm:^4.0.0"
-  peerDependencies:
-    "@backstage/frontend-test-utils": 0.6.3-next.0
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.30.2
-  peerDependenciesMeta:
-    "@backstage/frontend-test-utils":
-      optional: true
-    "@types/react":
-      optional: true
-  checksum: 10/7895c1e0463f37bac2d5bc17a460cd6be42f51501cb0df9f454fc07d201530c1c85b4ffbf41dcb007b07d1e0e92aec3dc859cba75aa79202e0c58a47bff77175
+  checksum: 10/3aed6bc7fd7644f28003271d7855c06d21d61e6087abc20beb91e0144c5d5fe3d70cf74565b1115b972707bc77073ae5c3f77471f294aa0f81e5140d9b779905
   languageName: node
   linkType: hard
 
@@ -4130,26 +4053,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.54.0-next.1&npm=2.0.8-next.1, @backstage/plugin-catalog@npm:^2.0.8-next.1":
-  version: 2.0.8-next.1
-  resolution: "@backstage/plugin-catalog@npm:2.0.8-next.1"
+"@backstage/plugin-catalog@backstage:^::backstage=1.54.0-next.2&npm=2.0.8-next.2, @backstage/plugin-catalog@npm:2.0.8-next.2, @backstage/plugin-catalog@npm:^2.0.8-next.2":
+  version: 2.0.8-next.2
+  resolution: "@backstage/plugin-catalog@npm:2.0.8-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-compat-api": "npm:0.5.14-next.0"
-    "@backstage/core-components": "npm:0.18.13-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-compat-api": "npm:0.5.14-next.1"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/integration-react": "npm:1.2.21-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/integration-react": "npm:1.2.21-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.1"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@backstage/plugin-scaffolder-common": "npm:2.2.2-next.0"
     "@backstage/plugin-search-common": "npm:1.2.24"
-    "@backstage/plugin-search-react": "npm:1.11.7-next.0"
+    "@backstage/plugin-search-react": "npm:1.11.7-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.14-next.0"
+    "@backstage/plugin-techdocs-react": "npm:1.3.14-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@backstage/version-bridge": "npm:1.0.12"
@@ -4175,60 +4098,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/e7906daa9c867ec2e7bb930ad20e528e6ade241d1a420a2991c926fb105fe53a4ef013b62bfc5c8d73f05157f0e3b4805fdddcaa0de956852f2f695227befa46
+  checksum: 10/ceed68dfb482396d4c7b93d6e7845e9daf66129c1386353615ba27dc95ce607fddfabfca745664ef44f856910036eb46f034d766c87cee9df73197b69769ec38
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@npm:2.0.8-next.0":
-  version: 2.0.8-next.0
-  resolution: "@backstage/plugin-catalog@npm:2.0.8-next.0"
-  dependencies:
-    "@backstage/catalog-client": "npm:1.16.1"
-    "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-compat-api": "npm:0.5.14-next.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/integration-react": "npm:1.2.20"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.0"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
-    "@backstage/plugin-scaffolder-common": "npm:2.2.1"
-    "@backstage/plugin-search-common": "npm:1.2.24"
-    "@backstage/plugin-search-react": "npm:1.11.7-next.0"
-    "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.14-next.0"
-    "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.17.1-next.0"
-    "@backstage/version-bridge": "npm:1.0.12"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@mui/utils": "npm:^5.14.15"
-    "@remixicon/react": "npm:^4.6.0"
-    classnames: "npm:^2.3.1"
-    csv-stringify: "npm:^5.6.5"
-    dataloader: "npm:^2.0.0"
-    lodash: "npm:^4.17.21"
-    pluralize: "npm:^8.0.0"
-    react-helmet: "npm:6.1.0"
-    react-use: "npm:^17.2.4"
-    zen-observable: "npm:^0.10.0"
-    zod: "npm:^4.0.0"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.30.2
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10/786dfc9754f1874c7d2a8237abb0126b46d0f54c9392df061a80bd09087389bf2df996b9abc6ada4b89dd5cfd02e6cd1f0752674df40191a0c97506cfe4dbd92
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.54.0-next.1&npm=0.4.15-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.15-next.1":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.54.0-next.2&npm=0.4.15-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.15-next.1":
   version: 0.4.15-next.1
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.15-next.1"
   dependencies:
@@ -4245,7 +4119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.54.0-next.1&npm=0.6.5-next.0, @backstage/plugin-events-backend@npm:^0.6.5-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.54.0-next.2&npm=0.6.5-next.0, @backstage/plugin-events-backend@npm:^0.6.5-next.0":
   version: 0.6.5-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.6.5-next.0"
   dependencies:
@@ -4298,14 +4172,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@backstage:^::backstage=1.54.0-next.1&npm=0.1.41-next.0, @backstage/plugin-home-react@npm:0.1.41-next.0, @backstage/plugin-home-react@npm:^0.1.41-next.0":
-  version: 0.1.41-next.0
-  resolution: "@backstage/plugin-home-react@npm:0.1.41-next.0"
+"@backstage/plugin-home-react@backstage:^::backstage=1.54.0-next.2&npm=0.1.41-next.1, @backstage/plugin-home-react@npm:0.1.41-next.1, @backstage/plugin-home-react@npm:^0.1.41-next.1":
+  version: 0.1.41-next.1
+  resolution: "@backstage/plugin-home-react@npm:0.1.41-next.1"
   dependencies:
-    "@backstage/core-compat-api": "npm:0.5.14-next.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/core-compat-api": "npm:0.5.14-next.1"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@rjsf/utils": "npm:5.24.13"
@@ -4317,24 +4191,24 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/514c067450f4fba3212fb32855623fe983d60f1657e1b5c4c90528fa5c00e2e55412857d085e50385669e1dd0d02e649228d0f3be095a3585945e4497433da99
+  checksum: 10/bd08d6eed3927e973571e7fc081386681c722ac6679234b6eece09b17caaef5e4a4595db2b887759e1c7eef8cf4fc31a962bff36baee1d64cb71bc80ee167d13
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.54.0-next.1&npm=0.9.9-next.0, @backstage/plugin-home@npm:^0.9.9-next.0":
-  version: 0.9.9-next.0
-  resolution: "@backstage/plugin-home@npm:0.9.9-next.0"
+"@backstage/plugin-home@backstage:^::backstage=1.54.0-next.2&npm=0.9.9-next.1, @backstage/plugin-home@npm:^0.9.9-next.1":
+  version: 0.9.9-next.1
+  resolution: "@backstage/plugin-home@npm:0.9.9-next.1"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/config": "npm:1.3.8"
-    "@backstage/core-app-api": "npm:1.20.4-next.0"
-    "@backstage/core-compat-api": "npm:0.5.14-next.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.0"
-    "@backstage/plugin-home-react": "npm:0.1.41-next.0"
+    "@backstage/core-app-api": "npm:1.20.4-next.1"
+    "@backstage/core-compat-api": "npm:0.5.14-next.1"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-home-react": "npm:0.1.41-next.1"
     "@backstage/theme": "npm:0.7.3"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4357,18 +4231,18 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/219d073969f539fdd64d6e6ac6a867bdd58320a7e328984c68c1f8156c8ccfe3fcff453c7817011d9d8470b0bdec55787c839fb8c0fb8b4d6a65c1ac7cbe56b0
+  checksum: 10/7b215af8a97a3a72a7ff3805b86945dfe0af675675bda534b5fb659bdde8d13ccf461eff080e3db645c0dabf3a8411896c6d472b7971ddf8b9ec90bde9902a5d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.54.0-next.1&npm=0.22.0-next.1, @backstage/plugin-kubernetes-backend@npm:^0.22.0-next.1":
-  version: 0.22.0-next.1
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.22.0-next.1"
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.54.0-next.2&npm=0.21.7-next.1, @backstage/plugin-kubernetes-backend@npm:^0.21.7-next.1":
+  version: 0.21.7-next.1
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.7-next.1"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@azure/identity": "npm:^4.0.0"
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/config": "npm:1.3.8"
@@ -4392,7 +4266,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     node-fetch: "npm:^2.7.0"
-  checksum: 10/cb101ef3e1266dc51280705bb756ff215c88cc66f8c25d42fb609b190a6cc10ad17e1082e7f9ab8a9ecd78b2f67696f552d1051f3e2d0165707b72d554a3625c
+  checksum: 10/a21b7a8b2fb6f80548e04338c73e8b5bbd451cb298cb4d6100f5113121f2353dbc6237946a743a6a240e766c57138804518b020d9c48c62c76adc183595968d9
   languageName: node
   linkType: hard
 
@@ -4426,13 +4300,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-react@npm:0.5.23-next.0":
-  version: 0.5.23-next.0
-  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.23-next.0"
+"@backstage/plugin-kubernetes-react@npm:0.5.23-next.1":
+  version: 0.5.23-next.1
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.23-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/plugin-kubernetes-common": "npm:0.9.12"
     "@backstage/types": "npm:1.2.2"
@@ -4459,22 +4333,22 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/f3b1f3454b1e1cf08821aa9d014881a0f10017b22325bf5ffe7a1c15eab20d82016a16c0836f352d9d23b4f63a4dac528e11c721541536ec5c957141f978e414
+  checksum: 10/f8b6ac938c431a537e27f0f85327d10000d24a8ff686321d900928c317838166eb18aff575ea9f8181bc66fb46620b116469b883389b7bb630cdee8dcc490263
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.54.0-next.1&npm=0.12.22-next.0, @backstage/plugin-kubernetes@npm:^0.12.22-next.0":
-  version: 0.12.22-next.0
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.22-next.0"
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.54.0-next.2&npm=0.12.22-next.1, @backstage/plugin-kubernetes@npm:^0.12.22-next.1":
+  version: 0.12.22-next.1
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.22-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.0"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
     "@backstage/plugin-kubernetes-common": "npm:0.9.12"
-    "@backstage/plugin-kubernetes-react": "npm:0.5.23-next.0"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
+    "@backstage/plugin-kubernetes-react": "npm:0.5.23-next.1"
+    "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@material-ui/core": "npm:^4.12.2"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -4484,15 +4358,15 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/327c7ab5dbb389db5d446d2a9606bee3e85ba4a74aef717c7faf9e75e2ee495af6bc353474636d5920e6d6a2516f20afca1ec7014b216934f17e860e1383fc86
+  checksum: 10/51b67167abf650c0968435cc18ba2811dff2e3e77c380cc2457b776f2d058c4ae09b9a5c4275f2f5489f3172cda4008a8a4b18c72a4a7ed0fcfae2d8597908be
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.54.0-next.1&npm=0.2.1-next.0, @backstage/plugin-mcp-actions-backend@npm:^0.2.1-next.0":
-  version: 0.2.1-next.0
-  resolution: "@backstage/plugin-mcp-actions-backend@npm:0.2.1-next.0"
+"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.54.0-next.2&npm=0.2.1-next.1, @backstage/plugin-mcp-actions-backend@npm:^0.2.1-next.1":
+  version: 0.2.1-next.1
+  resolution: "@backstage/plugin-mcp-actions-backend@npm:0.2.1-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/config": "npm:1.3.8"
     "@backstage/errors": "npm:1.3.1"
@@ -4504,16 +4378,16 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     minimatch: "npm:^10.2.1"
     zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10/41eda6ed3f099d3895ed91960ab4e66a6675c764d6a0b163ceba0fd09eaecfa03c27e1b9199f97f30804e557f6ad7d2a05704f9dee821839106ffd2e6974d335
+  checksum: 10/5704e7728406e0161853b5f20dae5287a0a4f39bb4293b36381c0988e980cfa4562d2c0771c5c65a4c195b8eb0f8b8508bb67f43d2df3d0e6411ae5a3affb1b6
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.54.0-next.1&npm=0.2.10-next.0, @backstage/plugin-mui-to-bui@npm:^0.2.10-next.0":
-  version: 0.2.10-next.0
-  resolution: "@backstage/plugin-mui-to-bui@npm:0.2.10-next.0"
+"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.54.0-next.2&npm=0.2.10-next.1, @backstage/plugin-mui-to-bui@npm:^0.2.10-next.1":
+  version: 0.2.10-next.1
+  resolution: "@backstage/plugin-mui-to-bui@npm:0.2.10-next.1"
   dependencies:
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@mui/material": "npm:^5.12.2"
@@ -4526,16 +4400,16 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/854180f2cff70d3af77b638a7aa783a5be0b95354808991502a2994ef9a0783eb4fbd2e9251976f27cd31a62fe5551add25fd45118d27e24d2775bbcb71ec9fb
+  checksum: 10/787d438daefc5f08bce5cc6101d603737a3c3acd8b235dbacdc4d837879f03d7dd11b6eb8bf4daeb583d6aeda8995bfe921f825b71808b303e0648805da88665
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.54.0-next.1&npm=0.6.8-next.0, @backstage/plugin-notifications-backend@npm:^0.6.8-next.0":
-  version: 0.6.8-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.6.8-next.0"
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.54.0-next.2&npm=0.6.8-next.1, @backstage/plugin-notifications-backend@npm:^0.6.8-next.1":
+  version: 0.6.8-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.6.8-next.1"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.7.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/config": "npm:1.3.8"
     "@backstage/errors": "npm:1.3.1"
@@ -4548,7 +4422,7 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     p-throttle: "npm:^4.1.1"
-  checksum: 10/5f9eae25feef9a769accd849a0884b263b6f8db023cc90630e6dc726ade054ed404ddea0ed335688ef2e9519f77a5fcd4f6601086856bc4368a3468741067c29
+  checksum: 10/0f0ef903105e5c6aa77d7114651afe9fbe3d38282b7f33dceed4878e5f56543678685bdedb9b21658104953110c175d852e56796b37d4a42b91e30ef317cadc1
   languageName: node
   linkType: hard
 
@@ -4562,7 +4436,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.54.0-next.1&npm=0.2.29-next.0, @backstage/plugin-notifications-node@npm:0.2.29-next.0, @backstage/plugin-notifications-node@npm:^0.2.29-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.54.0-next.2&npm=0.2.29-next.0, @backstage/plugin-notifications-node@npm:0.2.29-next.0, @backstage/plugin-notifications-node@npm:^0.2.29-next.0":
   version: 0.2.29-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.29-next.0"
   dependencies:
@@ -4572,16 +4446,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.54.0-next.1&npm=0.5.20-next.0, @backstage/plugin-notifications@npm:^0.5.20-next.0":
-  version: 0.5.20-next.0
-  resolution: "@backstage/plugin-notifications@npm:0.5.20-next.0"
+"@backstage/plugin-notifications@backstage:^::backstage=1.54.0-next.2&npm=0.5.20-next.1, @backstage/plugin-notifications@npm:^0.5.20-next.1":
+  version: 0.5.20-next.1
+  resolution: "@backstage/plugin-notifications@npm:0.5.20-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/plugin-notifications-common": "npm:0.2.3"
-    "@backstage/plugin-signals-react": "npm:0.0.24"
+    "@backstage/plugin-signals-react": "npm:0.0.25-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@remixicon/react": "npm:>=4.6.0 <4.9.0"
@@ -4598,20 +4472,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/cceecdab222dfbefcdd6ca109ee58bd7d892e9b350ca91ef6450d709dea0c3d8442d574e6ac8f76dae66bf9a0ea565fd91a21d34f4f9c058bd502ee14493c142
+  checksum: 10/d5bec3bffb251112170403c043c79b4cfab53cd8c022443c46032d3db041cc7ae35566c2c8b6fbfa17efcf9a474c397c8d940718efc3a3ba72d93b6d0989a4ab
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.54.0-next.1&npm=0.7.7-next.0, @backstage/plugin-org@npm:^0.7.7-next.0":
-  version: 0.7.7-next.0
-  resolution: "@backstage/plugin-org@npm:0.7.7-next.0"
+"@backstage/plugin-org@backstage:^::backstage=1.54.0-next.2&npm=0.7.7-next.1, @backstage/plugin-org@npm:^0.7.7-next.1":
+  version: 0.7.7-next.1
+  resolution: "@backstage/plugin-org@npm:0.7.7-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4631,7 +4505,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/83e38153de9c6b25d04a68f1e75f6ba121f4dae889be107d608b35c2057c35170320f8b57c001a24f745197c2f0d4a6d132a2c73e9dff72d9d669bb041e44bcd
+  checksum: 10/097d785d04a481cbe9aabf943fe7d9c1206d182012496dc89dec0a400e138590270f3a88f3ecc6c9a18533c50da665a7f63b7ac48f55f27415dd0ee6a870084f
   languageName: node
   linkType: hard
 
@@ -4683,7 +4557,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-react@npm:0.5.3, @backstage/plugin-permission-react@npm:^0.5.3":
+"@backstage/plugin-permission-react@npm:0.5.4-next.0":
+  version: 0.5.4-next.0
+  resolution: "@backstage/plugin-permission-react@npm:0.5.4-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9"
+    dataloader: "npm:^2.0.0"
+    swr: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/7d285a6d29806560b5b8cb0d4226b944c21cfbf5aff3416a39eb44ed042f693789cfd57357702230601f03c5984f2ad10d6c57548b1de4423a567090ef4ed133
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-react@npm:^0.5.3":
   version: 0.5.3
   resolution: "@backstage/plugin-permission-react@npm:0.5.3"
   dependencies:
@@ -4703,7 +4597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.54.0-next.1&npm=0.6.16-next.0, @backstage/plugin-proxy-backend@npm:^0.6.16-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.54.0-next.2&npm=0.6.16-next.0, @backstage/plugin-proxy-backend@npm:^0.6.16-next.0":
   version: 0.6.16-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.16-next.0"
   dependencies:
@@ -4726,7 +4620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.54.0-next.1&npm=0.9.12-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.12-next.1":
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.54.0-next.2&npm=0.9.12-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.12-next.1":
   version: 0.9.12-next.1
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.12-next.1"
   dependencies:
@@ -4750,7 +4644,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.54.0-next.1&npm=0.1.25-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.25-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.54.0-next.2&npm=0.1.25-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.25-next.0":
   version: 0.1.25-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.25-next.0"
   dependencies:
@@ -4763,12 +4657,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.54.0-next.1&npm=4.0.3-next.1, @backstage/plugin-scaffolder-backend@npm:^4.0.3-next.1":
-  version: 4.0.3-next.1
-  resolution: "@backstage/plugin-scaffolder-backend@npm:4.0.3-next.1"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.54.0-next.2&npm=4.0.3-next.2, @backstage/plugin-scaffolder-backend@npm:^4.0.3-next.2":
+  version: 4.0.3-next.2
+  resolution: "@backstage/plugin-scaffolder-backend@npm:4.0.3-next.2"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.7.1-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.0-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/config": "npm:1.3.8"
     "@backstage/errors": "npm:1.3.1"
@@ -4778,20 +4672,19 @@ __metadata:
     "@backstage/plugin-permission-common": "npm:0.9.9"
     "@backstage/plugin-permission-node": "npm:0.11.3-next.0"
     "@backstage/plugin-scaffolder-common": "npm:2.2.2-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.13.6-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.13.6-next.2"
     "@backstage/types": "npm:1.2.2"
     "@types/luxon": "npm:^3.0.0"
     express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
     globby: "npm:^11.0.0"
     isbinaryfile: "npm:^5.0.0"
-    isolated-vm: "npm:^6.0.1"
     jsonschema: "npm:^1.5.0"
     knex: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
     logform: "npm:^2.3.2"
     luxon: "npm:^3.0.0"
-    nunjucks: "npm:^3.2.3"
+    nunjitsu: "npm:^0.5.0"
     p-queue: "npm:^6.6.2"
     prom-client: "npm:^15.0.0"
     triple-beam: "npm:^1.4.1"
@@ -4801,7 +4694,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10/f476619a4456a57aef5ff8f6e335908692d443a54d7f6a2a419ee8c0f69378401d53b35fb28a1a405f71a96c4c385cd0699ad42b05d5f0b9574126ba2395fe6a
+  checksum: 10/a1e999f3b7d83de9aa7ecfcca5ee8c89c7c6119fc49cf33314ec36dd28e11f571816711da357d7741278fcfc72d8b4dd0bde67f149aae1ed85fb1fa747c6884a
   languageName: node
   linkType: hard
 
@@ -4909,17 +4802,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-react@npm:2.0.3-next.1":
-  version: 2.0.3-next.1
-  resolution: "@backstage/plugin-scaffolder-react@npm:2.0.3-next.1"
+"@backstage/plugin-scaffolder-node@npm:0.13.6-next.2":
+  version: 0.13.6-next.2
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.13.6-next.2"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
+    "@backstage/catalog-model": "npm:1.9.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/integration": "npm:2.1.0-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.9"
+    "@backstage/plugin-permission-node": "npm:0.11.3-next.0"
+    "@backstage/plugin-scaffolder-common": "npm:2.2.2-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
+    concat-stream: "npm:^2.0.0"
+    fs-extra: "npm:^11.2.0"
+    globby: "npm:^11.0.0"
+    isomorphic-git: "npm:^1.23.0"
+    jsonschema: "npm:^1.5.0"
+    lodash: "npm:^4.17.21"
+    p-limit: "npm:^3.1.0"
+    tar: "npm:^7.5.21"
+    winston: "npm:^3.2.1"
+    winston-transport: "npm:^4.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@backstage/backend-test-utils": 1.11.6-next.1
+  peerDependenciesMeta:
+    "@backstage/backend-test-utils":
+      optional: true
+  checksum: 10/06112f17391944ee2b1c03b2af02ebbb03065de789feb10509009934cdf46a1b654f8fca6f352556ae40862b65afcbbe086e47c64bb9cd02be1a8893c4aeed56
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-react@npm:2.0.3-next.2":
+  version: 2.0.3-next.2
+  resolution: "@backstage/plugin-scaffolder-react@npm:2.0.3-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-components": "npm:0.18.13-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.1"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@backstage/plugin-scaffolder-common": "npm:2.2.2-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/types": "npm:1.2.2"
@@ -4952,7 +4879,7 @@ __metadata:
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   peerDependencies:
-    "@backstage/frontend-test-utils": 0.6.3-next.0
+    "@backstage/frontend-test-utils": 0.6.3-next.1
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -4963,30 +4890,30 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 10/1f7d90770b003217c95dd0cbedaa94d158cd9cc516daecd549a0d7fe9cc1706570d2878fb89ade1130baad0de312dfeabe216e264725ace786b282c8300fe248
+  checksum: 10/48f78f5a4f657bcf0e586bdc32f1a1c3cbab5972fed414b207acdd030a860dea98f67781906d4642121af57bb0e2c1dda294dc4ac5c979a0c91bc3df96c71a04
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.54.0-next.1&npm=1.38.2-next.1, @backstage/plugin-scaffolder@npm:^1.38.2-next.1":
-  version: 1.38.2-next.1
-  resolution: "@backstage/plugin-scaffolder@npm:1.38.2-next.1"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.54.0-next.2&npm=1.38.2-next.2, @backstage/plugin-scaffolder@npm:^1.38.2-next.2":
+  version: 1.38.2-next.2
+  resolution: "@backstage/plugin-scaffolder@npm:1.38.2-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-components": "npm:0.18.13-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/filter-predicates": "npm:0.1.4"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/integration": "npm:2.1.0-next.0"
-    "@backstage/integration-react": "npm:1.2.21-next.0"
+    "@backstage/integration-react": "npm:1.2.21-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.1"
-    "@backstage/plugin-permission-react": "npm:0.5.3"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@backstage/plugin-scaffolder-common": "npm:2.2.2-next.0"
-    "@backstage/plugin-scaffolder-react": "npm:2.0.3-next.1"
+    "@backstage/plugin-scaffolder-react": "npm:2.0.3-next.2"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.14-next.0"
+    "@backstage/plugin-techdocs-react": "npm:1.3.14-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@codemirror/language": "npm:^6.0.0"
@@ -5027,11 +4954,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1cb9d056b5784c31e4e237e1f7add310f96b1d9feded8c6ffab93ef3308bc3b0b328b87d75231e9795e54fa51d25b7f98eb4f7a831943286227afd83606499ee
+  checksum: 10/5fe4b4312e77eaa22575353c07ee7ac601165683222221f496c52681495f2b4f555286f0a66351eefb2d30d7151b4c515eed060ce294aab42610fcfaf24eaad4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.54.0-next.1&npm=0.3.18-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.18-next.0":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.54.0-next.2&npm=0.3.18-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.18-next.0":
   version: 0.3.18-next.0
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.18-next.0"
   dependencies:
@@ -5083,7 +5010,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.54.0-next.1&npm=2.1.5-next.0, @backstage/plugin-search-backend@npm:^2.1.5-next.0":
+"@backstage/plugin-search-backend@backstage:^::backstage=1.54.0-next.2&npm=2.1.5-next.0, @backstage/plugin-search-backend@npm:^2.1.5-next.0":
   version: 2.1.5-next.0
   resolution: "@backstage/plugin-search-backend@npm:2.1.5-next.0"
   dependencies:
@@ -5115,13 +5042,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.54.0-next.1&npm=1.11.7-next.0, @backstage/plugin-search-react@npm:1.11.7-next.0, @backstage/plugin-search-react@npm:^1.11.7-next.0":
-  version: 1.11.7-next.0
-  resolution: "@backstage/plugin-search-react@npm:1.11.7-next.0"
+"@backstage/plugin-search-react@backstage:^::backstage=1.54.0-next.2&npm=1.11.7-next.1, @backstage/plugin-search-react@npm:1.11.7-next.1, @backstage/plugin-search-react@npm:^1.11.7-next.1":
+  version: 1.11.7-next.1
+  resolution: "@backstage/plugin-search-react@npm:1.11.7-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/plugin-search-common": "npm:1.2.24"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/types": "npm:1.2.2"
@@ -5141,7 +5068,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/f50bbcc35cf410bf2888d9390cab2bd9019ecb3236c5f09d0278468a8d240e1bcd725f538f28c7946d7b90f3fc43fef0a601c812cf02619da3d7e39658415f6a
+  checksum: 10/fa7b4b36817db9018264adf45f10a5cd789984686317abb8249f9c3adc9234ca7e6094f14e9e9e398eb1b6e17fe576851b1742593f058b14eabde288ba487d21
   languageName: node
   linkType: hard
 
@@ -5175,17 +5102,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.54.0-next.1&npm=1.7.7-next.0, @backstage/plugin-search@npm:^1.7.7-next.0":
-  version: 1.7.7-next.0
-  resolution: "@backstage/plugin-search@npm:1.7.7-next.0"
+"@backstage/plugin-search@backstage:^::backstage=1.54.0-next.2&npm=1.7.7-next.1, @backstage/plugin-search@npm:^1.7.7-next.1":
+  version: 1.7.7-next.1
+  resolution: "@backstage/plugin-search@npm:1.7.7-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
     "@backstage/plugin-search-common": "npm:1.2.24"
-    "@backstage/plugin-search-react": "npm:1.11.7-next.0"
+    "@backstage/plugin-search-react": "npm:1.11.7-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@backstage/version-bridge": "npm:1.0.12"
@@ -5202,11 +5129,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a29f09f6da072be7fb3501e29668c6718c61a8c19c1bcdb48dbcff0fe01c0ce3568a80ac3c5b7eda0f4c65d8796935ea32894bf1adf703e7ef014d24df27fdba
+  checksum: 10/5c96c63f490506b495c85f3e7ece64f2534c93f4920d36315a0fc83bcbd3ad99f0f2c35051dafaa31235006881a23857f3fdac597981a08e51172b0a8d345a38
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.54.0-next.1&npm=0.3.18-next.0, @backstage/plugin-signals-backend@npm:^0.3.18-next.0":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.54.0-next.2&npm=0.3.18-next.0, @backstage/plugin-signals-backend@npm:^0.3.18-next.0":
   version: 0.3.18-next.0
   resolution: "@backstage/plugin-signals-backend@npm:0.3.18-next.0"
   dependencies:
@@ -5233,12 +5160,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-react@npm:0.0.24":
-  version: 0.0.24
-  resolution: "@backstage/plugin-signals-react@npm:0.0.24"
+"@backstage/plugin-signals-react@npm:0.0.25-next.0":
+  version: 0.0.25-next.0
+  resolution: "@backstage/plugin-signals-react@npm:0.0.25-next.0"
   dependencies:
-    "@backstage/core-plugin-api": "npm:^1.12.8"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.4"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -5248,18 +5175,18 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/af48d11101fef90774f63266ca1326168fef5a68e5b6b536a575051ac44c4b4cd8a6d36e4dd237aba8ca2b00ec01d0ad7a5ce0b1df41742636313d5b3e0245df
+  checksum: 10/881dc6394892da13db38b953644e2b9d5d26949560074a7e7bae9fbdc4a9f22f0f4b236a520e55aed2d6a207405e3a71a9f8085a87586ccb58b9607271c96e52
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.54.0-next.1&npm=0.0.34-next.0, @backstage/plugin-signals@npm:^0.0.34-next.0":
-  version: 0.0.34-next.0
-  resolution: "@backstage/plugin-signals@npm:0.0.34-next.0"
+"@backstage/plugin-signals@backstage:^::backstage=1.54.0-next.2&npm=0.0.34-next.1, @backstage/plugin-signals@npm:^0.0.34-next.1":
+  version: 0.0.34-next.1
+  resolution: "@backstage/plugin-signals@npm:0.0.34-next.1"
   dependencies:
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-signals-react": "npm:0.0.24"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-signals-react": "npm:0.0.25-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/types": "npm:1.2.2"
     "@material-ui/core": "npm:^4.12.4"
@@ -5272,11 +5199,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/86297510b117867c462c2e72eb236ce9cb6b1aab7129da977d4179a038cd4dfbfc1bd38eafd1c68ac63125ec1e6365296cb8d3ffa3895e216bbe699ac58e8d3d
+  checksum: 10/23cb3f2d8de8245746d511fb2bd88f4caa64e0d5ae1a326ef6682b51a66bf1d488df72b85844aaaf0324ce6616703d9294762bf3a6bbca3c2b1fb881b9ffa806
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.54.0-next.1&npm=2.2.3-next.1, @backstage/plugin-techdocs-backend@npm:^2.2.3-next.1":
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.54.0-next.2&npm=2.2.3-next.1, @backstage/plugin-techdocs-backend@npm:^2.2.3-next.1":
   version: 2.2.3-next.1
   resolution: "@backstage/plugin-techdocs-backend@npm:2.2.3-next.1"
   dependencies:
@@ -5306,16 +5233,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.54.0-next.1&npm=1.1.39-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.39-next.1":
-  version: 1.1.39-next.1
-  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.39-next.1"
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.54.0-next.2&npm=1.1.39-next.2, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.39-next.2":
+  version: 1.1.39-next.2
+  resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.39-next.2"
   dependencies:
-    "@backstage/core-components": "npm:0.18.13-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/integration": "npm:2.1.0-next.0"
-    "@backstage/integration-react": "npm:1.2.21-next.0"
-    "@backstage/plugin-techdocs-react": "npm:1.3.14-next.0"
+    "@backstage/integration-react": "npm:1.2.21-next.1"
+    "@backstage/plugin-techdocs-react": "npm:1.3.14-next.1"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@react-hookz/web": "npm:^24.0.0"
@@ -5329,11 +5256,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/eec441d79d3e8f8800d08b9e71f93e29f1f965d7b66fb8130f1877d684f24d787cfbdbb2dc5743b31383cba92e8134a79289f2e1da4565fb4b0bd615ff3bbab5
+  checksum: 10/3eddc297a9803810fcc1485b24f57406947d4475adf11f4a2bb6e8bb6255e5ecc34269daa992ac46c7496eb95c636a5d6a47c59a5d70b6e5a5d866ce3b5c9e45
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.54.0-next.1&npm=1.15.3-next.1, @backstage/plugin-techdocs-node@npm:1.15.3-next.1, @backstage/plugin-techdocs-node@npm:^1.15.3-next.1":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.54.0-next.2&npm=1.15.3-next.1, @backstage/plugin-techdocs-node@npm:1.15.3-next.1, @backstage/plugin-techdocs-node@npm:^1.15.3-next.1":
   version: 1.15.3-next.1
   resolution: "@backstage/plugin-techdocs-node@npm:1.15.3-next.1"
   dependencies:
@@ -5370,15 +5297,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.54.0-next.1&npm=1.3.14-next.0, @backstage/plugin-techdocs-react@npm:1.3.14-next.0, @backstage/plugin-techdocs-react@npm:^1.3.14-next.0":
-  version: 1.3.14-next.0
-  resolution: "@backstage/plugin-techdocs-react@npm:1.3.14-next.0"
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.54.0-next.2&npm=1.3.14-next.1, @backstage/plugin-techdocs-react@npm:1.3.14-next.1, @backstage/plugin-techdocs-react@npm:^1.3.14-next.1":
+  version: 1.3.14-next.1
+  resolution: "@backstage/plugin-techdocs-react@npm:1.3.14-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/config": "npm:1.3.8"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@backstage/version-bridge": "npm:1.0.12"
     "@material-ui/core": "npm:^4.12.2"
@@ -5394,7 +5321,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a41f882fef03a00c0803260bc775721bb752522e25d1b0db44aff97d5ae6843c751890823d1a1f05ff237e709c84b40d2e9cede918854dc53fb7eaff9fdf92bf
+  checksum: 10/69e161e2b57093d9c6aaba8cab2cb981d45b467d4196378b60a9826a85da0167004222db3bf7f2fd4c9cb6f86612fea3431f13eeb5edbf92ab6b66c0e47d548b
   languageName: node
   linkType: hard
 
@@ -5426,25 +5353,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.54.0-next.1&npm=1.18.0-next.1, @backstage/plugin-techdocs@npm:^1.18.0-next.1":
-  version: 1.18.0-next.1
-  resolution: "@backstage/plugin-techdocs@npm:1.18.0-next.1"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.54.0-next.2&npm=1.18.0-next.2, @backstage/plugin-techdocs@npm:^1.18.0-next.2":
+  version: 1.18.0-next.2
+  resolution: "@backstage/plugin-techdocs@npm:1.18.0-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/config": "npm:1.3.8"
-    "@backstage/core-components": "npm:0.18.13-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/integration": "npm:2.1.0-next.0"
-    "@backstage/integration-react": "npm:1.2.21-next.0"
-    "@backstage/plugin-auth-react": "npm:0.1.30-next.0"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.1"
+    "@backstage/integration-react": "npm:1.2.21-next.1"
+    "@backstage/plugin-auth-react": "npm:0.1.30-next.1"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
     "@backstage/plugin-search-common": "npm:1.2.24"
-    "@backstage/plugin-search-react": "npm:1.11.7-next.0"
+    "@backstage/plugin-search-react": "npm:1.11.7-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.14-next.0"
+    "@backstage/plugin-techdocs-react": "npm:1.3.14-next.1"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -5467,7 +5394,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/2d0289367760e00cfecc9f742875cf1ef7466af8d69f13c71becc66bbe033c36105613c9fe668f3839b5365e01b205b2b5ccd7b75af444c92e05a09196db804c
+  checksum: 10/4e7fb77aaa85371d93651a7be6cf940862d62608427e73fda1d3b59e6351b3f62874eaa1f40e578001a2bb7255a7de646ab8ff175c4286a18513cdbb32f2e8e6
   languageName: node
   linkType: hard
 
@@ -5480,18 +5407,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.54.0-next.1&npm=0.9.6-next.0, @backstage/plugin-user-settings@npm:^0.9.6-next.0":
-  version: 0.9.6-next.0
-  resolution: "@backstage/plugin-user-settings@npm:0.9.6-next.0"
+"@backstage/plugin-user-settings@backstage:^::backstage=1.54.0-next.2&npm=0.9.6-next.1, @backstage/plugin-user-settings@npm:^0.9.6-next.1":
+  version: 0.9.6-next.1
+  resolution: "@backstage/plugin-user-settings@npm:0.9.6-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.9.0"
-    "@backstage/core-app-api": "npm:1.20.4-next.0"
-    "@backstage/core-components": "npm:0.18.13-next.0"
-    "@backstage/core-plugin-api": "npm:1.12.8"
+    "@backstage/core-app-api": "npm:1.20.4-next.1"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.17.3"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.0"
-    "@backstage/plugin-signals-react": "npm:0.0.24"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-signals-react": "npm:0.0.25-next.0"
     "@backstage/plugin-user-settings-common": "npm:0.1.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/types": "npm:1.2.2"
@@ -5510,7 +5437,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8504c8432d8234e87a08aab5c6a7e982785d0941b22b1b85c1788cfb2cfb4939f1037c7045b13ae05209cf46af319c08fe07e5220fccf01a945c8cfa8f11e71a
+  checksum: 10/d5865fe65565559e7210f8c82be0ae7a9ad37cf19136bdf4ef91277a281c7b700ab1b3ae800bb8208ced86a82e3883e481d94cd4b6b567721a9e8583f771d9a6
   languageName: node
   linkType: hard
 
@@ -5521,7 +5448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.54.0-next.1&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.3":
+"@backstage/theme@backstage:^::backstage=1.54.0-next.2&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.3":
   version: 0.7.3
   resolution: "@backstage/theme@npm:0.7.3"
   dependencies:
@@ -5548,7 +5475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.54.0-next.1&npm=0.17.1-next.0, @backstage/ui@npm:0.17.1-next.0, @backstage/ui@npm:^0.17.1-next.0":
+"@backstage/ui@backstage:^::backstage=1.54.0-next.2&npm=0.17.1-next.0, @backstage/ui@npm:0.17.1-next.0, @backstage/ui@npm:^0.17.1-next.0":
   version: 0.17.1-next.0
   resolution: "@backstage/ui@npm:0.17.1-next.0"
   dependencies:
@@ -16199,13 +16126,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"a-sync-waterfall@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "a-sync-waterfall@npm:1.0.1"
-  checksum: 10/6069080aff936c88fc32f798cc172a8b541e35b993dc5d2e43b74b6f37c522744eec107e1d475d2c624825c6cb7d2ec9ec020dbe4520578afcae74f11902daa2
-  languageName: node
-  linkType: hard
-
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -16851,13 +16771,6 @@ __metadata:
   version: 2.0.1
   resolution: "arrify@npm:2.0.1"
   checksum: 10/067c4c1afd182806a82e4c1cb8acee16ab8b5284fbca1ce29408e6e91281c36bb5b612f6ddfbd40a0f7a7e0c75bf2696eb94c027f6e328d6e9c52465c98e4209
-  languageName: node
-  linkType: hard
-
-"asap@npm:^2.0.3":
-  version: 2.0.6
-  resolution: "asap@npm:2.0.6"
-  checksum: 10/b244c0458c571945e4b3be0b14eb001bea5596f9868cc50cc711dc03d58a7e953517d3f0dad81ccde3ff37d1f074701fa76a6f07d41aaa992d7204a37b915dda
   languageName: node
   linkType: hard
 
@@ -18636,13 +18549,6 @@ __metadata:
   version: 4.1.1
   resolution: "commander@npm:4.1.1"
   checksum: 10/3b2dc4125f387dab73b3294dbcb0ab2a862f9c0ad748ee2b27e3544d25325b7a8cdfbcc228d103a98a716960b14478114a5206b5415bd48cdafa38797891562c
-  languageName: node
-  linkType: hard
-
-"commander@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "commander@npm:5.1.0"
-  checksum: 10/3e2ef5c003c5179250161e42ce6d48e0e69a54af970c65b7f985c70095240c260fd647453efd4c2c5a31b30ce468f373dc70f769c2f54a2c014abc4792aaca28
   languageName: node
   linkType: hard
 
@@ -24755,16 +24661,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isolated-vm@npm:^6.0.1":
-  version: 6.1.2
-  resolution: "isolated-vm@npm:6.1.2"
-  dependencies:
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.8.4"
-  checksum: 10/705c93375a6342d54d2381efebba45d965147d5a6e534dc5c1e622b625ad02ee8878cacd03a8fd09f9929a3fc2d039b26a900d976632b14a51a94005371ec1d9
-  languageName: node
-  linkType: hard
-
 "isomorphic-dompurify@npm:^2.14.0":
   version: 2.36.0
   resolution: "isomorphic-dompurify@npm:2.36.0"
@@ -28460,21 +28356,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nunjucks@npm:^3.2.3":
-  version: 3.2.4
-  resolution: "nunjucks@npm:3.2.4"
-  dependencies:
-    a-sync-waterfall: "npm:^1.0.0"
-    asap: "npm:^2.0.3"
-    commander: "npm:^5.1.0"
-  peerDependencies:
-    chokidar: ^3.3.0
-  peerDependenciesMeta:
-    chokidar:
-      optional: true
-  bin:
-    nunjucks-precompile: bin/precompile
-  checksum: 10/8decb8bb762501aa1a44366acff50ab9d4ff9e57034455e62056b4ac117da40140e1f34f2270c38884f1a5b84b7d97c4afcb2e8c789ddd09f4dcfe71ce7b56bf
+"nunjitsu@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "nunjitsu@npm:0.5.0"
+  checksum: 10/7482355dbb7c8921ce84e1d634bf627dd4704b9f69315660dd98ff0328f91f3e9d295adad04e629c2254de00348720059d7ec306d0edea2af71614473041f9b6
   languageName: node
   linkType: hard
 
@@ -32850,7 +32735,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1, shell-quote@npm:^1.8.4":
+"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.4, shell-quote@npm:^1.9.0":
   version: 1.10.0
   resolution: "shell-quote@npm:1.10.0"
   checksum: 10/d4a22aeefe64919290af753ac6098239d7ffee52a5db62c20edef69794bd10b5f86e298f68be26af9606ac435e890dd391994a5405a90bb8aebef1ff1dde839b
@@ -34001,7 +33886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.4, tar@npm:^7.5.6":
+"tar@npm:^7.5.21, tar@npm:^7.5.4, tar@npm:^7.5.6":
   version: 7.5.22
   resolution: "tar@npm:7.5.22"
   dependencies:


### PR DESCRIPTION
Backstage release v1.54.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.54.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.54.0-next.2-changelog.md)
- Upgrade Helper: [From 1.54.0-next.1 to 1.54.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.54.0-next.1&to=1.54.0-next.2)
 
Created by [Version Bump 30999114790](https://github.com/backstage/demo/actions/runs/30999114790)
 