### PR TITLE
v1.54.0-next.3 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,6 +12,6 @@ npmPreapprovedPackages:
 plugins:
   - checksum: ae08ece83681cc6d217ebb53d9e00a06ea215383f34af0681a05da5720e018a6b0d98012112f9368e9fe2328b19919baba37ada25f46c4614b894765a9338db9
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.54.0-next.2/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.54.0-next.3/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.54.0-next.2"
+  "version": "1.54.0-next.3"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,7 +2067,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.54.0-next.2&npm=0.17.7-next.2, @backstage/backend-defaults@npm:^0.17.7-next.2":
+"@backstage/backend-defaults@backstage:^::backstage=1.54.0-next.3&npm=0.17.7-next.2, @backstage/backend-defaults@npm:^0.17.7-next.2":
   version: 0.17.7-next.2
   resolution: "@backstage/backend-defaults@npm:0.17.7-next.2"
   dependencies:
@@ -2300,7 +2300,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.54.0-next.2&npm=1.10.0-next.1, @backstage/backend-plugin-api@npm:1.10.0-next.1, @backstage/backend-plugin-api@npm:^1.10.0-next.1":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.54.0-next.3&npm=1.10.0-next.1, @backstage/backend-plugin-api@npm:1.10.0-next.1, @backstage/backend-plugin-api@npm:^1.10.0-next.1":
   version: 1.10.0-next.1
   resolution: "@backstage/backend-plugin-api@npm:1.10.0-next.1"
   dependencies:
@@ -2378,7 +2378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.54.0-next.2&npm=1.9.0, @backstage/catalog-model@npm:1.9.0, @backstage/catalog-model@npm:^1.9.0":
+"@backstage/catalog-model@backstage:^::backstage=1.54.0-next.3&npm=1.9.0, @backstage/catalog-model@npm:1.9.0, @backstage/catalog-model@npm:^1.9.0":
   version: 1.9.0
   resolution: "@backstage/catalog-model@npm:1.9.0"
   dependencies:
@@ -2402,7 +2402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-defaults@backstage:^::backstage=1.54.0-next.2&npm=0.1.5-next.0, @backstage/cli-defaults@npm:0.1.5-next.0, @backstage/cli-defaults@npm:^0.1.5-next.0":
+"@backstage/cli-defaults@backstage:^::backstage=1.54.0-next.3&npm=0.1.5-next.0, @backstage/cli-defaults@npm:0.1.5-next.0, @backstage/cli-defaults@npm:^0.1.5-next.0":
   version: 0.1.5-next.0
   resolution: "@backstage/cli-defaults@npm:0.1.5-next.0"
   dependencies:
@@ -2755,7 +2755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.54.0-next.2&npm=0.36.5-next.1, @backstage/cli@npm:^0.36.5-next.1":
+"@backstage/cli@backstage:^::backstage=1.54.0-next.3&npm=0.36.5-next.1, @backstage/cli@npm:^0.36.5-next.1":
   version: 0.36.5-next.1
   resolution: "@backstage/cli@npm:0.36.5-next.1"
   dependencies:
@@ -2856,7 +2856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.54.0-next.2&npm=1.3.8, @backstage/config@npm:1.3.8, @backstage/config@npm:^1.3.8":
+"@backstage/config@backstage:^::backstage=1.54.0-next.3&npm=1.3.8, @backstage/config@npm:1.3.8, @backstage/config@npm:^1.3.8":
   version: 1.3.8
   resolution: "@backstage/config@npm:1.3.8"
   dependencies:
@@ -2889,6 +2889,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/connections@npm:0.3.0-next.2":
+  version: 0.3.0-next.2
+  resolution: "@backstage/connections@npm:0.3.0-next.2"
+  dependencies:
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    zod: "npm:^4.0.0"
+  checksum: 10/a9aa54260e3cc39574babd3045d269769efa255e589adbac4643f5d4138a959f08786659441497d06723ce47f2a1768ef9d96cead4664d69721646a9198c801a
+  languageName: node
+  linkType: hard
+
 "@backstage/connections@npm:^0.2.0":
   version: 0.2.0
   resolution: "@backstage/connections@npm:0.2.0"
@@ -2902,7 +2913,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.54.0-next.2&npm=1.20.4-next.1, @backstage/core-app-api@npm:1.20.4-next.1, @backstage/core-app-api@npm:^1.20.4-next.1":
+"@backstage/core-app-api@backstage:^::backstage=1.54.0-next.3&npm=1.20.4-next.1, @backstage/core-app-api@npm:1.20.4-next.1, @backstage/core-app-api@npm:^1.20.4-next.1":
   version: 1.20.4-next.1
   resolution: "@backstage/core-app-api@npm:1.20.4-next.1"
   dependencies:
@@ -2931,7 +2942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.54.0-next.2&npm=0.5.14-next.1, @backstage/core-compat-api@npm:0.5.14-next.1, @backstage/core-compat-api@npm:^0.5.14-next.1":
+"@backstage/core-compat-api@backstage:^::backstage=1.54.0-next.3&npm=0.5.14-next.1, @backstage/core-compat-api@npm:0.5.14-next.1, @backstage/core-compat-api@npm:^0.5.14-next.1":
   version: 0.5.14-next.1
   resolution: "@backstage/core-compat-api@npm:0.5.14-next.1"
   dependencies:
@@ -2981,7 +2992,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.54.0-next.2&npm=0.18.13-next.2, @backstage/core-components@npm:0.18.13-next.2, @backstage/core-components@npm:^0.18.13-next.2":
+"@backstage/core-components@backstage:^::backstage=1.54.0-next.3&npm=0.18.13-next.2, @backstage/core-components@npm:0.18.13-next.2, @backstage/core-components@npm:^0.18.13-next.2":
   version: 0.18.13-next.2
   resolution: "@backstage/core-components@npm:0.18.13-next.2"
   dependencies:
@@ -3099,7 +3110,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.54.0-next.2&npm=1.12.9-next.0, @backstage/core-plugin-api@npm:1.12.9-next.0, @backstage/core-plugin-api@npm:^1.12.9-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.54.0-next.3&npm=1.12.9-next.1, @backstage/core-plugin-api@npm:1.12.9-next.1, @backstage/core-plugin-api@npm:^1.12.9-next.1":
+  version: 1.12.9-next.1
+  resolution: "@backstage/core-plugin-api@npm:1.12.9-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    history: "npm:^5.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/27a9682248fb21985add69a4415a5f29066efca96bf397aad2e8f1492531f07af0316982afc540894a2a9e6899cd15d742f800623d393b52265e2d65edb0f7e4
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:1.12.9-next.0":
   version: 1.12.9-next.0
   resolution: "@backstage/core-plugin-api@npm:1.12.9-next.0"
   dependencies:
@@ -3145,7 +3179,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.54.0-next.2&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.54.0-next.3&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
   version: 0.1.2
   resolution: "@backstage/e2e-test-utils@npm:0.1.2"
   dependencies:
@@ -3219,7 +3253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.54.0-next.2&npm=0.5.5-next.1, @backstage/frontend-defaults@npm:0.5.5-next.1, @backstage/frontend-defaults@npm:^0.5.5-next.1":
+"@backstage/frontend-defaults@backstage:^::backstage=1.54.0-next.3&npm=0.5.5-next.1, @backstage/frontend-defaults@npm:0.5.5-next.1, @backstage/frontend-defaults@npm:^0.5.5-next.1":
   version: 0.5.5-next.1
   resolution: "@backstage/frontend-defaults@npm:0.5.5-next.1"
   dependencies:
@@ -3242,7 +3276,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.54.0-next.2&npm=0.18.0-next.0, @backstage/frontend-plugin-api@npm:0.18.0-next.0, @backstage/frontend-plugin-api@npm:^0.18.0-next.0":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.54.0-next.3&npm=0.18.0-next.0, @backstage/frontend-plugin-api@npm:0.18.0-next.0, @backstage/frontend-plugin-api@npm:^0.18.0-next.0":
   version: 0.18.0-next.0
   resolution: "@backstage/frontend-plugin-api@npm:0.18.0-next.0"
   dependencies:
@@ -3324,7 +3358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.54.0-next.2&npm=1.2.21-next.1, @backstage/integration-react@npm:1.2.21-next.1, @backstage/integration-react@npm:^1.2.21-next.1":
+"@backstage/integration-react@backstage:^::backstage=1.54.0-next.3&npm=1.2.21-next.1, @backstage/integration-react@npm:1.2.21-next.1, @backstage/integration-react@npm:^1.2.21-next.1":
   version: 1.2.21-next.1
   resolution: "@backstage/integration-react@npm:1.2.21-next.1"
   dependencies:
@@ -3405,6 +3439,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration@npm:2.1.0-next.1":
+  version: 2.1.0-next.1
+  resolution: "@backstage/integration@npm:2.1.0-next.1"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:1.3.8"
+    "@backstage/connections": "npm:0.3.0-next.2"
+    "@backstage/errors": "npm:1.3.1"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    p-throttle: "npm:^4.1.1"
+  checksum: 10/8b00dbd981bb25ec5bb7a984352000034eb8d87a870d47796dc0ca81048cda26ed1884dded52032326a139a9651fab07bbd34af0f91099fa52f064637235fb22
+  languageName: node
+  linkType: hard
+
 "@backstage/module-federation-common@npm:0.1.4":
   version: 0.1.4
   resolution: "@backstage/module-federation-common@npm:0.1.4"
@@ -3430,18 +3484,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.54.0-next.2&npm=0.14.4-next.1, @backstage/plugin-api-docs@npm:^0.14.4-next.1":
-  version: 0.14.4-next.1
-  resolution: "@backstage/plugin-api-docs@npm:0.14.4-next.1"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.54.0-next.3&npm=0.14.4-next.2, @backstage/plugin-api-docs@npm:^0.14.4-next.2":
+  version: 0.14.4-next.2
+  resolution: "@backstage/plugin-api-docs@npm:0.14.4-next.2"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/core-components": "npm:0.18.13-next.2"
-    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.1"
     "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
-    "@backstage/plugin-catalog": "npm:2.0.8-next.2"
+    "@backstage/plugin-catalog": "npm:2.0.8-next.3"
     "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.3"
     "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@graphiql/react": "npm:0.29.0"
@@ -3462,11 +3516,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/1e1d57271c7f90b145c57cb7d40fb7d26528617d5955d2ab306d626863c8e06957e1684869d2971601a8d21a7ad960c384dd3c7592b5d0a4222d490751be9136
+  checksum: 10/a6640d02697a303d7178ab15c1d9ec56557785a787419d94a4a4c79d76f393b83e7f5a9bf2c458ab54f02129074db9ed3e2aafa8191a5c3a8060fb072335a2d8
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.54.0-next.2&npm=0.5.17-next.1, @backstage/plugin-app-backend@npm:^0.5.17-next.1":
+"@backstage/plugin-app-backend@backstage:^::backstage=1.54.0-next.3&npm=0.5.17-next.1, @backstage/plugin-app-backend@npm:^0.5.17-next.1":
   version: 0.5.17-next.1
   resolution: "@backstage/plugin-app-backend@npm:0.5.17-next.1"
   dependencies:
@@ -3502,7 +3556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-react@backstage:^::backstage=1.54.0-next.2&npm=0.2.6-next.0, @backstage/plugin-app-react@npm:0.2.6-next.0, @backstage/plugin-app-react@npm:^0.2.6-next.0":
+"@backstage/plugin-app-react@backstage:^::backstage=1.54.0-next.3&npm=0.2.6-next.0, @backstage/plugin-app-react@npm:0.2.6-next.0, @backstage/plugin-app-react@npm:^0.2.6-next.0":
   version: 0.2.6-next.0
   resolution: "@backstage/plugin-app-react@npm:0.2.6-next.0"
   dependencies:
@@ -3540,7 +3594,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-visualizer@backstage:^::backstage=1.54.0-next.2&npm=0.2.7-next.1, @backstage/plugin-app-visualizer@npm:^0.2.7-next.1":
+"@backstage/plugin-app-visualizer@backstage:^::backstage=1.54.0-next.3&npm=0.2.7-next.1, @backstage/plugin-app-visualizer@npm:^0.2.7-next.1":
   version: 0.2.7-next.1
   resolution: "@backstage/plugin-app-visualizer@npm:0.2.7-next.1"
   dependencies:
@@ -3562,7 +3616,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@backstage:^::backstage=1.54.0-next.2&npm=0.5.2-next.2, @backstage/plugin-app@npm:0.5.2-next.2, @backstage/plugin-app@npm:^0.5.2-next.2":
+"@backstage/plugin-app@backstage:^::backstage=1.54.0-next.3&npm=0.5.2-next.2, @backstage/plugin-app@npm:0.5.2-next.2, @backstage/plugin-app@npm:^0.5.2-next.2":
   version: 0.5.2-next.2
   resolution: "@backstage/plugin-app@npm:0.5.2-next.2"
   dependencies:
@@ -3600,7 +3654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.54.0-next.2&npm=0.5.6-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.6-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.54.0-next.3&npm=0.5.6-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.6-next.0":
   version: 0.5.6-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.5.6-next.0"
   dependencies:
@@ -3612,7 +3666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.54.0-next.2&npm=0.2.22-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.22-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.54.0-next.3&npm=0.2.22-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.22-next.0":
   version: 0.2.22-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.22-next.0"
   dependencies:
@@ -3625,7 +3679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.54.0-next.2&npm=0.30.0-next.1, @backstage/plugin-auth-backend@npm:^0.30.0-next.1":
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.54.0-next.3&npm=0.30.0-next.1, @backstage/plugin-auth-backend@npm:^0.30.0-next.1":
   version: 0.30.0-next.1
   resolution: "@backstage/plugin-auth-backend@npm:0.30.0-next.1"
   dependencies:
@@ -3723,7 +3777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth@backstage:^::backstage=1.54.0-next.2&npm=0.1.11-next.1, @backstage/plugin-auth@npm:^0.1.11-next.1":
+"@backstage/plugin-auth@backstage:^::backstage=1.54.0-next.3&npm=0.1.11-next.1, @backstage/plugin-auth@npm:^0.1.11-next.1":
   version: 0.1.11-next.1
   resolution: "@backstage/plugin-auth@npm:0.1.11-next.1"
   dependencies:
@@ -3745,7 +3799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-ai-model@backstage:^::backstage=1.54.0-next.2&npm=0.1.3-next.0, @backstage/plugin-catalog-backend-module-ai-model@npm:^0.1.3-next.0":
+"@backstage/plugin-catalog-backend-module-ai-model@backstage:^::backstage=1.54.0-next.3&npm=0.1.3-next.0, @backstage/plugin-catalog-backend-module-ai-model@npm:^0.1.3-next.0":
   version: 0.1.3-next.0
   resolution: "@backstage/plugin-catalog-backend-module-ai-model@npm:0.1.3-next.0"
   dependencies:
@@ -3756,7 +3810,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.54.0-next.2&npm=0.5.17-next.0, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.17-next.0":
+"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.54.0-next.3&npm=0.5.17-next.0, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.17-next.0":
   version: 0.5.17-next.0
   resolution: "@backstage/plugin-catalog-backend-module-backstage-openapi@npm:0.5.17-next.0"
   dependencies:
@@ -3774,7 +3828,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.54.0-next.2&npm=0.13.5-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.13.5-next.1":
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.54.0-next.3&npm=0.13.5-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.13.5-next.1":
   version: 0.13.5-next.1
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.13.5-next.1"
   dependencies:
@@ -3802,7 +3856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.54.0-next.2&npm=0.1.25-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.25-next.1":
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.54.0-next.3&npm=0.1.25-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.25-next.1":
   version: 0.1.25-next.1
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.25-next.1"
   dependencies:
@@ -3813,7 +3867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.54.0-next.2&npm=0.2.23-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.23-next.1":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.54.0-next.3&npm=0.2.23-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.23-next.1":
   version: 0.2.23-next.1
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.23-next.1"
   dependencies:
@@ -3826,7 +3880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.54.0-next.2&npm=3.9.0-next.2, @backstage/plugin-catalog-backend@npm:3.9.0-next.2, @backstage/plugin-catalog-backend@npm:^3.9.0-next.2":
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.54.0-next.3&npm=3.9.0-next.2, @backstage/plugin-catalog-backend@npm:3.9.0-next.2, @backstage/plugin-catalog-backend@npm:^3.9.0-next.2":
   version: 3.9.0-next.2
   resolution: "@backstage/plugin-catalog-backend@npm:3.9.0-next.2"
   dependencies:
@@ -3868,7 +3922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.54.0-next.2&npm=1.1.10, @backstage/plugin-catalog-common@npm:1.1.10, @backstage/plugin-catalog-common@npm:^1.1.10":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.54.0-next.3&npm=1.1.10, @backstage/plugin-catalog-common@npm:1.1.10, @backstage/plugin-catalog-common@npm:^1.1.10":
   version: 1.1.10
   resolution: "@backstage/plugin-catalog-common@npm:1.1.10"
   dependencies:
@@ -3879,16 +3933,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.54.0-next.2&npm=0.6.7-next.1, @backstage/plugin-catalog-graph@npm:^0.6.7-next.1":
-  version: 0.6.7-next.1
-  resolution: "@backstage/plugin-catalog-graph@npm:0.6.7-next.1"
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.54.0-next.3&npm=0.6.7-next.2, @backstage/plugin-catalog-graph@npm:^0.6.7-next.2":
+  version: 0.6.7-next.2
+  resolution: "@backstage/plugin-catalog-graph@npm:0.6.7-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/core-components": "npm:0.18.13-next.2"
-    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.1"
     "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.3"
     "@backstage/types": "npm:1.2.2"
     "@backstage/ui": "npm:0.17.1-next.0"
     "@material-ui/core": "npm:^4.12.2"
@@ -3908,11 +3962,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6429691fc288a76e03b24394a8080c5a0a162ceda67650c0b30c91b4cc7e9485c2cc28d507b0e556f5fc9ef94430fecb7557790c31b032337e293ee91619ec97
+  checksum: 10/a98db2007f0f15ba9b20b5eeb5212af0a1d803e4c508c94f2916dcc3f7c7b7ec0c9d0e08c66c5abce4fa9c721cedff1b9fc78ffcbcc544b91a5349f03a626220
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.54.0-next.2&npm=2.2.4-next.0, @backstage/plugin-catalog-node@npm:2.2.4-next.0, @backstage/plugin-catalog-node@npm:^2.2.4-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.54.0-next.3&npm=2.2.4-next.0, @backstage/plugin-catalog-node@npm:2.2.4-next.0, @backstage/plugin-catalog-node@npm:^2.2.4-next.0":
   version: 2.2.4-next.0
   resolution: "@backstage/plugin-catalog-node@npm:2.2.4-next.0"
   dependencies:
@@ -3960,7 +4014,54 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.54.0-next.2&npm=3.2.1-next.2, @backstage/plugin-catalog-react@npm:3.2.1-next.2, @backstage/plugin-catalog-react@npm:^3.2.1-next.2":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.54.0-next.3&npm=3.2.1-next.3, @backstage/plugin-catalog-react@npm:3.2.1-next.3, @backstage/plugin-catalog-react@npm:^3.2.1-next.3":
+  version: 3.2.1-next.3
+  resolution: "@backstage/plugin-catalog-react@npm:3.2.1-next.3"
+  dependencies:
+    "@backstage/catalog-client": "npm:1.16.1"
+    "@backstage/catalog-model": "npm:1.9.0"
+    "@backstage/core-compat-api": "npm:0.5.14-next.1"
+    "@backstage/core-components": "npm:0.18.13-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.1"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/filter-predicates": "npm:0.1.4"
+    "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
+    "@backstage/integration-react": "npm:1.2.21-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.9"
+    "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/ui": "npm:0.17.1-next.0"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    classnames: "npm:^2.2.6"
+    lodash: "npm:^4.17.21"
+    material-ui-popup-state: "npm:^5.3.6"
+    qs: "npm:^6.15.2"
+    react-use: "npm:^17.2.4"
+    react-window: "npm:^1.8.10"
+    yaml: "npm:^2.0.0"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^4.0.0"
+  peerDependencies:
+    "@backstage/frontend-test-utils": 0.6.3-next.1
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@backstage/frontend-test-utils":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/15d464a187f8e38c5518cca55db082ddc025a50ce9a13e19e9894ddbb6f414780093e784f97765c3fd49d6231ca5e0eb393e34c2622840296572cfee687743d5
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-react@npm:3.2.1-next.2":
   version: 3.2.1-next.2
   resolution: "@backstage/plugin-catalog-react@npm:3.2.1-next.2"
   dependencies:
@@ -4053,20 +4154,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.54.0-next.2&npm=2.0.8-next.2, @backstage/plugin-catalog@npm:2.0.8-next.2, @backstage/plugin-catalog@npm:^2.0.8-next.2":
-  version: 2.0.8-next.2
-  resolution: "@backstage/plugin-catalog@npm:2.0.8-next.2"
+"@backstage/plugin-catalog@backstage:^::backstage=1.54.0-next.3&npm=2.0.8-next.3, @backstage/plugin-catalog@npm:2.0.8-next.3, @backstage/plugin-catalog@npm:^2.0.8-next.3":
+  version: 2.0.8-next.3
+  resolution: "@backstage/plugin-catalog@npm:2.0.8-next.3"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/core-compat-api": "npm:0.5.14-next.1"
     "@backstage/core-components": "npm:0.18.13-next.2"
-    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.1"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@backstage/integration-react": "npm:1.2.21-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.3"
     "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@backstage/plugin-scaffolder-common": "npm:2.2.2-next.0"
     "@backstage/plugin-search-common": "npm:1.2.24"
@@ -4098,11 +4199,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/ceed68dfb482396d4c7b93d6e7845e9daf66129c1386353615ba27dc95ce607fddfabfca745664ef44f856910036eb46f034d766c87cee9df73197b69769ec38
+  checksum: 10/401aa19c726051b2d4203a52c49e4906d3da6aa92db8f25e153b3807d31c685fe890c72c8a2c2eddf046c2dbea4028df5b1baac408d80692bd29cd37855963a9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.54.0-next.2&npm=0.4.15-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.15-next.1":
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.54.0-next.3&npm=0.4.15-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.15-next.1":
   version: 0.4.15-next.1
   resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.15-next.1"
   dependencies:
@@ -4119,7 +4220,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.54.0-next.2&npm=0.6.5-next.0, @backstage/plugin-events-backend@npm:^0.6.5-next.0":
+"@backstage/plugin-events-backend@backstage:^::backstage=1.54.0-next.3&npm=0.6.5-next.0, @backstage/plugin-events-backend@npm:^0.6.5-next.0":
   version: 0.6.5-next.0
   resolution: "@backstage/plugin-events-backend@npm:0.6.5-next.0"
   dependencies:
@@ -4172,13 +4273,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@backstage:^::backstage=1.54.0-next.2&npm=0.1.41-next.1, @backstage/plugin-home-react@npm:0.1.41-next.1, @backstage/plugin-home-react@npm:^0.1.41-next.1":
-  version: 0.1.41-next.1
-  resolution: "@backstage/plugin-home-react@npm:0.1.41-next.1"
+"@backstage/plugin-home-react@backstage:^::backstage=1.54.0-next.3&npm=0.1.41-next.2, @backstage/plugin-home-react@npm:0.1.41-next.2, @backstage/plugin-home-react@npm:^0.1.41-next.2":
+  version: 0.1.41-next.2
+  resolution: "@backstage/plugin-home-react@npm:0.1.41-next.2"
   dependencies:
     "@backstage/core-compat-api": "npm:0.5.14-next.1"
     "@backstage/core-components": "npm:0.18.13-next.2"
-    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.1"
     "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4191,13 +4292,13 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/bd08d6eed3927e973571e7fc081386681c722ac6679234b6eece09b17caaef5e4a4595db2b887759e1c7eef8cf4fc31a962bff36baee1d64cb71bc80ee167d13
+  checksum: 10/e57cf6fc32deef89e2f63394180b1b92227787bebd1ac7b49b64af0e30f350600e0aa729830d8cf16d20ade2da07d7f4a5480f9bc0cc9dead18e21cbf251474d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.54.0-next.2&npm=0.9.9-next.1, @backstage/plugin-home@npm:^0.9.9-next.1":
-  version: 0.9.9-next.1
-  resolution: "@backstage/plugin-home@npm:0.9.9-next.1"
+"@backstage/plugin-home@backstage:^::backstage=1.54.0-next.3&npm=0.9.9-next.2, @backstage/plugin-home@npm:^0.9.9-next.2":
+  version: 0.9.9-next.2
+  resolution: "@backstage/plugin-home@npm:0.9.9-next.2"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
@@ -4205,10 +4306,10 @@ __metadata:
     "@backstage/core-app-api": "npm:1.20.4-next.1"
     "@backstage/core-compat-api": "npm:0.5.14-next.1"
     "@backstage/core-components": "npm:0.18.13-next.2"
-    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.1"
     "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
-    "@backstage/plugin-home-react": "npm:0.1.41-next.1"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.3"
+    "@backstage/plugin-home-react": "npm:0.1.41-next.2"
     "@backstage/theme": "npm:0.7.3"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4231,11 +4332,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7b215af8a97a3a72a7ff3805b86945dfe0af675675bda534b5fb659bdde8d13ccf461eff080e3db645c0dabf3a8411896c6d472b7971ddf8b9ec90bde9902a5d
+  checksum: 10/eff7674926655406389934c147e459f45b0e6e53db5b858bf388619732eb5dfaeb823b661b0917f4a249f701f830c7576489623c3158baefce9a677f876cc4e5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.54.0-next.2&npm=0.21.7-next.1, @backstage/plugin-kubernetes-backend@npm:^0.21.7-next.1":
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.54.0-next.3&npm=0.21.7-next.1, @backstage/plugin-kubernetes-backend@npm:^0.21.7-next.1":
   version: 0.21.7-next.1
   resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.7-next.1"
   dependencies:
@@ -4337,7 +4438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.54.0-next.2&npm=0.12.22-next.1, @backstage/plugin-kubernetes@npm:^0.12.22-next.1":
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.54.0-next.3&npm=0.12.22-next.1, @backstage/plugin-kubernetes@npm:^0.12.22-next.1":
   version: 0.12.22-next.1
   resolution: "@backstage/plugin-kubernetes@npm:0.12.22-next.1"
   dependencies:
@@ -4362,9 +4463,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.54.0-next.2&npm=0.2.1-next.1, @backstage/plugin-mcp-actions-backend@npm:^0.2.1-next.1":
-  version: 0.2.1-next.1
-  resolution: "@backstage/plugin-mcp-actions-backend@npm:0.2.1-next.1"
+"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.54.0-next.3&npm=0.2.1-next.2, @backstage/plugin-mcp-actions-backend@npm:^0.2.1-next.2":
+  version: 0.2.1-next.2
+  resolution: "@backstage/plugin-mcp-actions-backend@npm:0.2.1-next.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:1.10.0-next.1"
     "@backstage/catalog-client": "npm:1.16.1"
@@ -4378,11 +4479,11 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     minimatch: "npm:^10.2.1"
     zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10/5704e7728406e0161853b5f20dae5287a0a4f39bb4293b36381c0988e980cfa4562d2c0771c5c65a4c195b8eb0f8b8508bb67f43d2df3d0e6411ae5a3affb1b6
+  checksum: 10/e844a7e79c7ba369076c903fb4b9ac350a1b61a9b283b64368611ee208b17262f152b6019a423284b7eedfe073c553a04692ea7691a7557d9754b1c65f6ea061
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.54.0-next.2&npm=0.2.10-next.1, @backstage/plugin-mui-to-bui@npm:^0.2.10-next.1":
+"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.54.0-next.3&npm=0.2.10-next.1, @backstage/plugin-mui-to-bui@npm:^0.2.10-next.1":
   version: 0.2.10-next.1
   resolution: "@backstage/plugin-mui-to-bui@npm:0.2.10-next.1"
   dependencies:
@@ -4404,7 +4505,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.54.0-next.2&npm=0.6.8-next.1, @backstage/plugin-notifications-backend@npm:^0.6.8-next.1":
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.54.0-next.3&npm=0.6.8-next.1, @backstage/plugin-notifications-backend@npm:^0.6.8-next.1":
   version: 0.6.8-next.1
   resolution: "@backstage/plugin-notifications-backend@npm:0.6.8-next.1"
   dependencies:
@@ -4436,7 +4537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.54.0-next.2&npm=0.2.29-next.0, @backstage/plugin-notifications-node@npm:0.2.29-next.0, @backstage/plugin-notifications-node@npm:^0.2.29-next.0":
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.54.0-next.3&npm=0.2.29-next.0, @backstage/plugin-notifications-node@npm:0.2.29-next.0, @backstage/plugin-notifications-node@npm:^0.2.29-next.0":
   version: 0.2.29-next.0
   resolution: "@backstage/plugin-notifications-node@npm:0.2.29-next.0"
   dependencies:
@@ -4446,7 +4547,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.54.0-next.2&npm=0.5.20-next.1, @backstage/plugin-notifications@npm:^0.5.20-next.1":
+"@backstage/plugin-notifications@backstage:^::backstage=1.54.0-next.3&npm=0.5.20-next.1, @backstage/plugin-notifications@npm:^0.5.20-next.1":
   version: 0.5.20-next.1
   resolution: "@backstage/plugin-notifications@npm:0.5.20-next.1"
   dependencies:
@@ -4476,7 +4577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.54.0-next.2&npm=0.7.7-next.1, @backstage/plugin-org@npm:^0.7.7-next.1":
+"@backstage/plugin-org@backstage:^::backstage=1.54.0-next.3&npm=0.7.7-next.1, @backstage/plugin-org@npm:^0.7.7-next.1":
   version: 0.7.7-next.1
   resolution: "@backstage/plugin-org@npm:0.7.7-next.1"
   dependencies:
@@ -4597,7 +4698,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.54.0-next.2&npm=0.6.16-next.0, @backstage/plugin-proxy-backend@npm:^0.6.16-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.54.0-next.3&npm=0.6.16-next.0, @backstage/plugin-proxy-backend@npm:^0.6.16-next.0":
   version: 0.6.16-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.16-next.0"
   dependencies:
@@ -4620,7 +4721,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.54.0-next.2&npm=0.9.12-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.12-next.1":
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.54.0-next.3&npm=0.9.12-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.12-next.1":
   version: 0.9.12-next.1
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.12-next.1"
   dependencies:
@@ -4644,7 +4745,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.54.0-next.2&npm=0.1.25-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.25-next.0":
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.54.0-next.3&npm=0.1.25-next.0, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.25-next.0":
   version: 0.1.25-next.0
   resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.25-next.0"
   dependencies:
@@ -4657,7 +4758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.54.0-next.2&npm=4.0.3-next.2, @backstage/plugin-scaffolder-backend@npm:^4.0.3-next.2":
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.54.0-next.3&npm=4.0.3-next.2, @backstage/plugin-scaffolder-backend@npm:^4.0.3-next.2":
   version: 4.0.3-next.2
   resolution: "@backstage/plugin-scaffolder-backend@npm:4.0.3-next.2"
   dependencies:
@@ -4894,21 +4995,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.54.0-next.2&npm=1.38.2-next.2, @backstage/plugin-scaffolder@npm:^1.38.2-next.2":
-  version: 1.38.2-next.2
-  resolution: "@backstage/plugin-scaffolder@npm:1.38.2-next.2"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.54.0-next.3&npm=1.38.2-next.3, @backstage/plugin-scaffolder@npm:^1.38.2-next.3":
+  version: 1.38.2-next.3
+  resolution: "@backstage/plugin-scaffolder@npm:1.38.2-next.3"
   dependencies:
     "@backstage/catalog-client": "npm:1.16.1"
     "@backstage/catalog-model": "npm:1.9.0"
     "@backstage/core-components": "npm:0.18.13-next.2"
-    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.1"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/filter-predicates": "npm:0.1.4"
     "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
-    "@backstage/integration": "npm:2.1.0-next.0"
+    "@backstage/integration": "npm:2.1.0-next.1"
     "@backstage/integration-react": "npm:1.2.21-next.1"
     "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.3"
     "@backstage/plugin-permission-react": "npm:0.5.4-next.0"
     "@backstage/plugin-scaffolder-common": "npm:2.2.2-next.0"
     "@backstage/plugin-scaffolder-react": "npm:2.0.3-next.2"
@@ -4954,11 +5055,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5fe4b4312e77eaa22575353c07ee7ac601165683222221f496c52681495f2b4f555286f0a66351eefb2d30d7151b4c515eed060ce294aab42610fcfaf24eaad4
+  checksum: 10/67c320d6ca92c83a8ea4e93f970273079d3d679806ced49463f2e3cded070a9d0c67e57d1fb4e213177b015ce10ac1804c2de844168e5a042b25873c9af84d11
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.54.0-next.2&npm=0.3.18-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.18-next.0":
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.54.0-next.3&npm=0.3.18-next.0, @backstage/plugin-search-backend-module-catalog@npm:^0.3.18-next.0":
   version: 0.3.18-next.0
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.18-next.0"
   dependencies:
@@ -5010,7 +5111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.54.0-next.2&npm=2.1.5-next.0, @backstage/plugin-search-backend@npm:^2.1.5-next.0":
+"@backstage/plugin-search-backend@backstage:^::backstage=1.54.0-next.3&npm=2.1.5-next.0, @backstage/plugin-search-backend@npm:^2.1.5-next.0":
   version: 2.1.5-next.0
   resolution: "@backstage/plugin-search-backend@npm:2.1.5-next.0"
   dependencies:
@@ -5042,7 +5143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.54.0-next.2&npm=1.11.7-next.1, @backstage/plugin-search-react@npm:1.11.7-next.1, @backstage/plugin-search-react@npm:^1.11.7-next.1":
+"@backstage/plugin-search-react@backstage:^::backstage=1.54.0-next.3&npm=1.11.7-next.1, @backstage/plugin-search-react@npm:1.11.7-next.1, @backstage/plugin-search-react@npm:^1.11.7-next.1":
   version: 1.11.7-next.1
   resolution: "@backstage/plugin-search-react@npm:1.11.7-next.1"
   dependencies:
@@ -5102,15 +5203,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.54.0-next.2&npm=1.7.7-next.1, @backstage/plugin-search@npm:^1.7.7-next.1":
-  version: 1.7.7-next.1
-  resolution: "@backstage/plugin-search@npm:1.7.7-next.1"
+"@backstage/plugin-search@backstage:^::backstage=1.54.0-next.3&npm=1.7.7-next.2, @backstage/plugin-search@npm:^1.7.7-next.2":
+  version: 1.7.7-next.2
+  resolution: "@backstage/plugin-search@npm:1.7.7-next.2"
   dependencies:
     "@backstage/core-components": "npm:0.18.13-next.2"
-    "@backstage/core-plugin-api": "npm:1.12.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.9-next.1"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/frontend-plugin-api": "npm:0.18.0-next.0"
-    "@backstage/plugin-catalog-react": "npm:3.2.1-next.2"
+    "@backstage/plugin-catalog-react": "npm:3.2.1-next.3"
+    "@backstage/plugin-home-react": "npm:0.1.41-next.2"
     "@backstage/plugin-search-common": "npm:1.2.24"
     "@backstage/plugin-search-react": "npm:1.11.7-next.1"
     "@backstage/types": "npm:1.2.2"
@@ -5129,11 +5231,11 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/5c96c63f490506b495c85f3e7ece64f2534c93f4920d36315a0fc83bcbd3ad99f0f2c35051dafaa31235006881a23857f3fdac597981a08e51172b0a8d345a38
+  checksum: 10/4e99dc5e21510f0f2e3ffb79129cf52c8e296690713c8c05b6d0909eb745f2c109a6dde854eb84f3fef560aca8c8dbf252fc297889af2a32ccd5f459fa269941
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.54.0-next.2&npm=0.3.18-next.0, @backstage/plugin-signals-backend@npm:^0.3.18-next.0":
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.54.0-next.3&npm=0.3.18-next.0, @backstage/plugin-signals-backend@npm:^0.3.18-next.0":
   version: 0.3.18-next.0
   resolution: "@backstage/plugin-signals-backend@npm:0.3.18-next.0"
   dependencies:
@@ -5179,7 +5281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.54.0-next.2&npm=0.0.34-next.1, @backstage/plugin-signals@npm:^0.0.34-next.1":
+"@backstage/plugin-signals@backstage:^::backstage=1.54.0-next.3&npm=0.0.34-next.1, @backstage/plugin-signals@npm:^0.0.34-next.1":
   version: 0.0.34-next.1
   resolution: "@backstage/plugin-signals@npm:0.0.34-next.1"
   dependencies:
@@ -5203,7 +5305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.54.0-next.2&npm=2.2.3-next.1, @backstage/plugin-techdocs-backend@npm:^2.2.3-next.1":
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.54.0-next.3&npm=2.2.3-next.1, @backstage/plugin-techdocs-backend@npm:^2.2.3-next.1":
   version: 2.2.3-next.1
   resolution: "@backstage/plugin-techdocs-backend@npm:2.2.3-next.1"
   dependencies:
@@ -5233,7 +5335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.54.0-next.2&npm=1.1.39-next.2, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.39-next.2":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.54.0-next.3&npm=1.1.39-next.2, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.39-next.2":
   version: 1.1.39-next.2
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.39-next.2"
   dependencies:
@@ -5260,7 +5362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.54.0-next.2&npm=1.15.3-next.1, @backstage/plugin-techdocs-node@npm:1.15.3-next.1, @backstage/plugin-techdocs-node@npm:^1.15.3-next.1":
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.54.0-next.3&npm=1.15.3-next.1, @backstage/plugin-techdocs-node@npm:1.15.3-next.1, @backstage/plugin-techdocs-node@npm:^1.15.3-next.1":
   version: 1.15.3-next.1
   resolution: "@backstage/plugin-techdocs-node@npm:1.15.3-next.1"
   dependencies:
@@ -5297,7 +5399,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.54.0-next.2&npm=1.3.14-next.1, @backstage/plugin-techdocs-react@npm:1.3.14-next.1, @backstage/plugin-techdocs-react@npm:^1.3.14-next.1":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.54.0-next.3&npm=1.3.14-next.1, @backstage/plugin-techdocs-react@npm:1.3.14-next.1, @backstage/plugin-techdocs-react@npm:^1.3.14-next.1":
   version: 1.3.14-next.1
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.14-next.1"
   dependencies:
@@ -5353,7 +5455,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.54.0-next.2&npm=1.18.0-next.2, @backstage/plugin-techdocs@npm:^1.18.0-next.2":
+"@backstage/plugin-techdocs@backstage:^::backstage=1.54.0-next.3&npm=1.18.0-next.2, @backstage/plugin-techdocs@npm:^1.18.0-next.2":
   version: 1.18.0-next.2
   resolution: "@backstage/plugin-techdocs@npm:1.18.0-next.2"
   dependencies:
@@ -5407,7 +5509,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.54.0-next.2&npm=0.9.6-next.1, @backstage/plugin-user-settings@npm:^0.9.6-next.1":
+"@backstage/plugin-user-settings@backstage:^::backstage=1.54.0-next.3&npm=0.9.6-next.1, @backstage/plugin-user-settings@npm:^0.9.6-next.1":
   version: 0.9.6-next.1
   resolution: "@backstage/plugin-user-settings@npm:0.9.6-next.1"
   dependencies:
@@ -5448,7 +5550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.54.0-next.2&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.3":
+"@backstage/theme@backstage:^::backstage=1.54.0-next.3&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.3":
   version: 0.7.3
   resolution: "@backstage/theme@npm:0.7.3"
   dependencies:
@@ -5475,7 +5577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.54.0-next.2&npm=0.17.1-next.0, @backstage/ui@npm:0.17.1-next.0, @backstage/ui@npm:^0.17.1-next.0":
+"@backstage/ui@backstage:^::backstage=1.54.0-next.3&npm=0.17.1-next.0, @backstage/ui@npm:0.17.1-next.0, @backstage/ui@npm:^0.17.1-next.0":
   version: 0.17.1-next.0
   resolution: "@backstage/ui@npm:0.17.1-next.0"
   dependencies:


### PR DESCRIPTION
Backstage release v1.54.0-next.3 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.54.0-next.3](https://github.com/backstage/backstage/blob/master/docs/releases/v1.54.0-next.3-changelog.md)
- Upgrade Helper: [From 1.54.0-next.2 to 1.54.0-next.3](https://backstage.github.io/upgrade-helper/?from=1.54.0-next.2&to=1.54.0-next.3)
 
Created by [Version Bump 31587257837](https://github.com/backstage/demo/actions/runs/31587257837)
 