### PR TITLE
v1.55.0-next.2 version bump

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,6 +15,6 @@ npmPreapprovedPackages:
 plugins:
   - checksum: ae08ece83681cc6d217ebb53d9e00a06ea215383f34af0681a05da5720e018a6b0d98012112f9368e9fe2328b19919baba37ada25f46c4614b894765a9338db9
     path: .yarn/plugins/@yarnpkg/plugin-backstage.cjs
-    spec: 'https://versions.backstage.io/v1/releases/1.55.0-next.1/yarn-plugin'
+    spec: 'https://versions.backstage.io/v1/releases/1.55.0-next.2/yarn-plugin'
 
 yarnPath: .yarn/releases/yarn-4.18.0.cjs

--- a/backstage.json
+++ b/backstage.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.55.0-next.1"
+  "version": "1.55.0-next.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2050,17 +2050,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-app-api@npm:1.7.4-next.0":
-  version: 1.7.4-next.0
-  resolution: "@backstage/backend-app-api@npm:1.7.4-next.0"
+"@backstage/backend-app-api@npm:1.7.4-next.1":
+  version: 1.7.4-next.1
+  resolution: "@backstage/backend-app-api@npm:1.7.4-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/connections": "npm:0.3.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/connections": "npm:0.4.0-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/types": "npm:1.2.2"
     zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10/2572c5ee1ec4e8794cb643251680c9190892c5dc7cdd733900a4eeeb3dcf6345d1d766894fece7a4c5b0230ae9ab430651bda10c7effd3049db46b150f617046
+  checksum: 10/bb211546abba79ecf3c54583813aafab24590051034d8e76b9a79de1b495247b18da220976cc15f5797fc3d3502c52c7f0fe4cf9fb787cdab7fd7fe7dd4356c5
   languageName: node
   linkType: hard
 
@@ -2078,9 +2078,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@backstage:^::backstage=1.55.0-next.1&npm=0.17.9-next.0, @backstage/backend-defaults@npm:^0.17.9-next.0":
-  version: 0.17.9-next.0
-  resolution: "@backstage/backend-defaults@npm:0.17.9-next.0"
+"@backstage/backend-defaults@backstage:^::backstage=1.55.0-next.2&npm=0.17.9-next.1, @backstage/backend-defaults@npm:^0.17.9-next.1":
+  version: 0.17.9-next.1
+  resolution: "@backstage/backend-defaults@npm:0.17.9-next.1"
   dependencies:
     "@aws-sdk/abort-controller": "npm:^3.347.0"
     "@aws-sdk/client-codecommit": "npm:^3.350.0"
@@ -2090,19 +2090,19 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-app-api": "npm:1.7.4-next.0"
+    "@backstage/backend-app-api": "npm:1.7.4-next.1"
     "@backstage/backend-dev-utils": "npm:0.1.7"
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/cli-node": "npm:0.3.4"
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/config-loader": "npm:1.11.2"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/config-loader": "npm:1.11.3-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/integration-aws-node": "npm:0.2.1"
-    "@backstage/plugin-auth-node": "npm:0.7.5-next.0"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/integration-aws-node": "npm:0.2.2-next.0"
+    "@backstage/plugin-auth-node": "npm:0.7.5-next.1"
     "@backstage/plugin-events-node": "npm:0.4.26-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.10"
-    "@backstage/plugin-permission-node": "npm:0.11.4-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-permission-node": "npm:0.11.4-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/storage": "npm:^7.0.0"
     "@keyv/memcache": "npm:^2.0.1"
@@ -2163,7 +2163,7 @@ __metadata:
       optional: true
     better-sqlite3:
       optional: true
-  checksum: 10/d0f8834a7c196f48be827a7fa0b530c49ea6efd253f3512928b41240c294c2d42aef3089458560801dd26c930b8b17bc5277b5d3847b782eec75ea3480947429
+  checksum: 10/cbae480d6eb485c8783581ffdbf737a3bd06f7fa7a43dd8b9b32852ebfcaa6f9a0dbfb67a1caa0bcbd5a65eba991efe272a97bdd1dd57dbafe3da9287159534a
   languageName: node
   linkType: hard
 
@@ -2312,7 +2312,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@backstage:^::backstage=1.55.0-next.1&npm=1.10.1-next.0, @backstage/backend-plugin-api@npm:1.10.1-next.0, @backstage/backend-plugin-api@npm:^1.10.1-next.0":
+"@backstage/backend-plugin-api@backstage:^::backstage=1.55.0-next.2&npm=1.10.1-next.1, @backstage/backend-plugin-api@npm:1.10.1-next.1, @backstage/backend-plugin-api@npm:^1.10.1-next.1":
+  version: 1.10.1-next.1
+  resolution: "@backstage/backend-plugin-api@npm:1.10.1-next.1"
+  dependencies:
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/plugin-auth-node": "npm:0.7.5-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-permission-node": "npm:0.11.4-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/json-schema": "npm:^7.0.6"
+    "@types/luxon": "npm:^3.0.0"
+    knex: "npm:^3.0.0"
+    luxon: "npm:^3.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  checksum: 10/c00b9f5325783fa5bce566a0865faab453fc4db377ebd2103066456a05c1937920d46fe663ec851f7646ce5017bd99872cf2dea1c28d301c24f8c12eee79d7aa
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-plugin-api@npm:1.10.1-next.0":
   version: 1.10.1-next.0
   resolution: "@backstage/backend-plugin-api@npm:1.10.1-next.0"
   dependencies:
@@ -2369,6 +2390,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-client@npm:1.16.2-next.1":
+  version: 1.16.2-next.1
+  resolution: "@backstage/catalog-client@npm:1.16.2-next.1"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.10.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/filter-predicates": "npm:0.1.5-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    cross-fetch: "npm:^4.0.0"
+    lodash: "npm:^4.17.21"
+    uri-template: "npm:^2.0.0"
+  checksum: 10/0d6187012324bc44819734fd4eb1211bb5ddfee59c2c3127cacddff32cca60305f3a477a6161ec7b66de66ff058b0a63cf110074b017ccaebf02f71110b51100
+  languageName: node
+  linkType: hard
+
 "@backstage/catalog-client@npm:^1.16.0, @backstage/catalog-client@npm:^1.16.1":
   version: 1.16.1
   resolution: "@backstage/catalog-client@npm:1.16.1"
@@ -2384,7 +2420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-model@backstage:^::backstage=1.55.0-next.1&npm=1.10.0, @backstage/catalog-model@npm:1.10.0, @backstage/catalog-model@npm:^1.10.0, @backstage/catalog-model@npm:^1.9.0":
+"@backstage/catalog-model@backstage:^::backstage=1.55.0-next.2&npm=1.10.0, @backstage/catalog-model@npm:1.10.0, @backstage/catalog-model@npm:^1.10.0, @backstage/catalog-model@npm:^1.9.0":
   version: 1.10.0
   resolution: "@backstage/catalog-model@npm:1.10.0"
   dependencies:
@@ -2408,44 +2444,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-defaults@backstage:^::backstage=1.55.0-next.1&npm=0.1.6-next.1, @backstage/cli-defaults@npm:^0.1.6-next.1":
-  version: 0.1.6-next.1
-  resolution: "@backstage/cli-defaults@npm:0.1.6-next.1"
+"@backstage/cli-defaults@backstage:^::backstage=1.55.0-next.2&npm=0.1.6-next.2, @backstage/cli-defaults@npm:0.1.6-next.2, @backstage/cli-defaults@npm:^0.1.6-next.2":
+  version: 0.1.6-next.2
+  resolution: "@backstage/cli-defaults@npm:0.1.6-next.2"
   dependencies:
     "@backstage/cli-module-actions": "npm:0.1.3"
     "@backstage/cli-module-auth": "npm:0.1.4"
-    "@backstage/cli-module-build": "npm:0.1.8-next.1"
-    "@backstage/cli-module-config": "npm:0.1.6"
+    "@backstage/cli-module-build": "npm:0.1.8-next.2"
+    "@backstage/cli-module-config": "npm:0.1.7-next.0"
     "@backstage/cli-module-github": "npm:0.1.4"
     "@backstage/cli-module-info": "npm:0.1.4"
     "@backstage/cli-module-lint": "npm:0.1.5"
-    "@backstage/cli-module-maintenance": "npm:0.1.4"
+    "@backstage/cli-module-maintenance": "npm:0.1.5-next.0"
     "@backstage/cli-module-migrate": "npm:0.2.1"
     "@backstage/cli-module-new": "npm:0.1.7-next.0"
-    "@backstage/cli-module-package-manager-yarn": "npm:0.1.1-next.0"
+    "@backstage/cli-module-package-manager-yarn": "npm:0.1.1-next.1"
     "@backstage/cli-module-test-jest": "npm:0.1.5"
     "@backstage/cli-module-translations": "npm:0.1.4"
-  checksum: 10/54fb011c150f22e36cf5c166bfdeef7d54770d8f1e57595d7b485f28cac5a3b1916d7185ae602acb98509081076c5666c6b6c4f8853a33a68dc0a0297d4a1552
-  languageName: node
-  linkType: hard
-
-"@backstage/cli-defaults@npm:0.1.6-next.0":
-  version: 0.1.6-next.0
-  resolution: "@backstage/cli-defaults@npm:0.1.6-next.0"
-  dependencies:
-    "@backstage/cli-module-actions": "npm:0.1.3"
-    "@backstage/cli-module-auth": "npm:0.1.4"
-    "@backstage/cli-module-build": "npm:0.1.8-next.0"
-    "@backstage/cli-module-config": "npm:0.1.6"
-    "@backstage/cli-module-github": "npm:0.1.4"
-    "@backstage/cli-module-info": "npm:0.1.4"
-    "@backstage/cli-module-lint": "npm:0.1.5"
-    "@backstage/cli-module-maintenance": "npm:0.1.4"
-    "@backstage/cli-module-migrate": "npm:0.2.1"
-    "@backstage/cli-module-new": "npm:0.1.7-next.0"
-    "@backstage/cli-module-test-jest": "npm:0.1.5"
-    "@backstage/cli-module-translations": "npm:0.1.4"
-  checksum: 10/31c22488d7529e97656ca586686a7ea9ad4fcfcaab766c175f784b81be60be37f1f100699d8b9c18362c1e0525855ad38fc13c684228485ef298293cd8a2db66
+  checksum: 10/4d8acae39bd76acbdd97e2610804896915e40e47e82d258d0ea989e93c7a63d6bd1bdd4fefe262c55c47734f21390ca12de2f7d72a3ab42819d5e7c335260b65
   languageName: node
   linkType: hard
 
@@ -2490,18 +2506,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-build@npm:0.1.8-next.0":
-  version: 0.1.8-next.0
-  resolution: "@backstage/cli-module-build@npm:0.1.8-next.0"
+"@backstage/cli-module-build@npm:0.1.8-next.2":
+  version: 0.1.8-next.2
+  resolution: "@backstage/cli-module-build@npm:0.1.8-next.2"
   dependencies:
     "@backstage/cli-common": "npm:0.3.0"
     "@backstage/cli-node": "npm:0.3.4"
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/config-loader": "npm:1.11.2"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/config-loader": "npm:1.11.3-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/module-federation-common": "npm:0.1.4"
+    "@backstage/module-federation-common": "npm:0.1.5-next.0"
     "@manypkg/get-packages": "npm:^1.1.3"
-    "@module-federation/enhanced": "npm:^2.3.3"
+    "@module-federation/enhanced": "npm:~2.8.2"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.6.0"
     "@rollup/plugin-commonjs": "npm:^26.0.0"
     "@rollup/plugin-json": "npm:^6.0.0"
@@ -2562,95 +2578,19 @@ __metadata:
       optional: true
   bin:
     cli-module-build: bin/backstage-cli-module-build
-  checksum: 10/45a2642099a75a5a6f6a713c4de7f1f7247f3611a93c2b4cc791f48c1886b1eb2d45d3158c1eb04095edc6c27e7d8e0deb2ab8dfc2df77d161ff3b227d18155e
+  checksum: 10/708f2bf6eb92dfc5a7e799b530e8aded6adf90002c7f987660b0df3a12786c898b639de1c4fce99639565a856d6498c9f95d645930bae21101e45acd715b42c6
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-build@npm:0.1.8-next.1":
-  version: 0.1.8-next.1
-  resolution: "@backstage/cli-module-build@npm:0.1.8-next.1"
+"@backstage/cli-module-config@npm:0.1.7-next.0":
+  version: 0.1.7-next.0
+  resolution: "@backstage/cli-module-config@npm:0.1.7-next.0"
   dependencies:
     "@backstage/cli-common": "npm:0.3.0"
     "@backstage/cli-node": "npm:0.3.4"
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/config-loader": "npm:1.11.2"
-    "@backstage/errors": "npm:1.3.1"
-    "@backstage/module-federation-common": "npm:0.1.4"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    "@module-federation/enhanced": "npm:^2.3.3"
-    "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.6.0"
-    "@rollup/plugin-commonjs": "npm:^26.0.0"
-    "@rollup/plugin-json": "npm:^6.0.0"
-    "@rollup/plugin-node-resolve": "npm:^15.0.0"
-    "@rollup/plugin-yaml": "npm:^4.0.0"
-    "@rspack/core": "npm:^1.4.11"
-    "@rspack/dev-server": "npm:^1.1.4"
-    "@rspack/plugin-react-refresh": "npm:^1.4.3"
-    "@swc/core": "npm:^1.15.6"
-    bfj: "npm:^9.0.2"
-    buffer: "npm:^6.0.3"
-    chalk: "npm:^4.0.0"
-    chokidar: "npm:^3.3.1"
-    cleye: "npm:^2.6.0"
-    cross-spawn: "npm:^7.0.3"
-    css-loader: "npm:^6.5.1"
-    ctrlc-windows: "npm:^2.1.0"
-    esbuild-loader: "npm:^4.0.0"
-    eslint-rspack-plugin: "npm:^4.2.1"
-    eslint-webpack-plugin: "npm:^4.2.0"
-    fork-ts-checker-webpack-plugin: "npm:^9.0.0"
-    fs-extra: "npm:^11.2.0"
-    glob: "npm:^13.0.0"
-    html-webpack-plugin: "npm:^5.6.3"
-    lodash: "npm:^4.17.21"
-    mini-css-extract-plugin: "npm:^2.4.2"
-    node-stdlib-browser: "npm:^1.3.1"
-    npm-packlist: "npm:^5.0.0"
-    p-queue: "npm:^6.6.2"
-    portfinder: "npm:^1.0.32"
-    postcss: "npm:^8.1.0"
-    postcss-import: "npm:^16.1.0"
-    process: "npm:^0.11.10"
-    raw-loader: "npm:^4.0.2"
-    react-dev-utils: "npm:^12.0.0-next.60"
-    react-refresh: "npm:^0.18.0"
-    rollup: "npm:^4.59.0"
-    rollup-plugin-dts: "npm:^6.1.0"
-    rollup-plugin-esbuild: "npm:^6.1.1"
-    rollup-plugin-postcss: "npm:^4.0.0"
-    rollup-pluginutils: "npm:^2.8.2"
-    shell-quote: "npm:^1.9.0"
-    style-loader: "npm:^3.3.1"
-    swc-loader: "npm:^0.2.3"
-    tar: "npm:^7.5.21"
-    ts-checker-rspack-plugin: "npm:^1.1.5"
-    ts-morph: "npm:^24.0.0"
-    util: "npm:^0.12.3"
-    webpack: "npm:~5.105.0"
-    webpack-dev-server: "npm:^5.0.0"
-    yml-loader: "npm:^2.1.0"
-    yn: "npm:^4.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-  peerDependencies:
-    embedded-postgres: ^18.3.0-beta.16
-  peerDependenciesMeta:
-    embedded-postgres:
-      optional: true
-  bin:
-    cli-module-build: bin/backstage-cli-module-build
-  checksum: 10/b5cdd1ff65ab09122cf429eccc8c94b8de50eb4144279ce1c7e88d2c9c4fd0c73891308c08bddd06745f87223625ee98e2bc418f63082720d1755e365c925f01
-  languageName: node
-  linkType: hard
-
-"@backstage/cli-module-config@npm:0.1.6":
-  version: 0.1.6
-  resolution: "@backstage/cli-module-config@npm:0.1.6"
-  dependencies:
-    "@backstage/cli-common": "npm:^0.3.0"
-    "@backstage/cli-node": "npm:^0.3.4"
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/config-loader": "npm:^1.11.2"
-    "@backstage/types": "npm:^1.2.2"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/config-loader": "npm:1.11.3-next.0"
+    "@backstage/types": "npm:1.2.2"
     "@manypkg/get-packages": "npm:^1.1.3"
     chalk: "npm:^4.0.0"
     cleye: "npm:^2.6.0"
@@ -2658,7 +2598,7 @@ __metadata:
     yaml: "npm:^2.0.0"
   bin:
     cli-module-config: bin/backstage-cli-module-config
-  checksum: 10/73385d0805e209c855996ec78ce7208fd9cc86d1941c3f6011e588028e87a89cd16ac06faee21c645b89a8dc3bcb15bed23c53926485bc05541dedff50f93ae6
+  checksum: 10/9869692a9c7b9df268f281f4405c674752fa90d80a3bfdbe3d7f386464ce1032c1658b13f9f787ef962134b089f4a122cc6037ce752e49c43fd655403eddbecb
   languageName: node
   linkType: hard
 
@@ -2716,19 +2656,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-maintenance@npm:0.1.4":
-  version: 0.1.4
-  resolution: "@backstage/cli-module-maintenance@npm:0.1.4"
+"@backstage/cli-module-maintenance@npm:0.1.5-next.0":
+  version: 0.1.5-next.0
+  resolution: "@backstage/cli-module-maintenance@npm:0.1.5-next.0"
   dependencies:
-    "@backstage/cli-common": "npm:^0.3.0"
-    "@backstage/cli-node": "npm:^0.3.4"
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/cli-node": "npm:0.3.4"
+    "@typescript-eslint/eslint-plugin": "npm:^8.17.0"
     chalk: "npm:^4.0.0"
     cleye: "npm:^2.6.0"
     eslint: "npm:^8.6.0"
     fs-extra: "npm:^11.2.0"
   bin:
     cli-module-maintenance: bin/backstage-cli-module-maintenance
-  checksum: 10/5e5b66396b187b15907cbcc51aa25308f02d40b624cdf4e6a2cd290f8ad4e5a2083cc2caf452ae1e8db37015952c3e95bb0a8b985a8f085451edce0df1161d4f
+  checksum: 10/8bee02bbb29af57ab9f083f7468615839c0a93e4dea95297f05d89079fd611e52e064bbe158d58c6421b302000f195befdbbbf5e2cd4b61293257cda17a78ca3
   languageName: node
   linkType: hard
 
@@ -2779,21 +2720,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-module-package-manager-yarn@npm:0.1.1-next.0":
-  version: 0.1.1-next.0
-  resolution: "@backstage/cli-module-package-manager-yarn@npm:0.1.1-next.0"
+"@backstage/cli-module-package-manager-yarn@npm:0.1.1-next.1":
+  version: 0.1.1-next.1
+  resolution: "@backstage/cli-module-package-manager-yarn@npm:0.1.1-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.3.0"
     "@backstage/cli-node": "npm:0.3.4"
     "@backstage/release-manifests": "npm:0.0.14"
-    "@yarnpkg/core": "npm:^4.4.1"
+    "@yarnpkg/core": "npm:^4.9.1"
     "@yarnpkg/fslib": "npm:^3.1.2"
     "@yarnpkg/parsers": "npm:^3.0.0"
     "@yarnpkg/plugin-patch": "npm:^4.0.2"
     cleye: "npm:^2.6.0"
   bin:
     cli-module-package-manager-yarn: bin/backstage-cli-module-package-manager-yarn
-  checksum: 10/170ef1e15210237f1168779e385d72148c5e03a54b223713fa1bced7756df6a91354380c65a24b13bfb7d17a3c7c40d33bcd9517f1ed7791bd2731c59da93bf0
+  checksum: 10/14770d0dfdfcade9b3fc54023ceb936d27fabd71a5ac9e52df37668e3a31839fcd2495a8c8b7d993b1303bef48cd996200dea46eb98c9ad41ee2f99bfc56adfa
   languageName: node
   linkType: hard
 
@@ -2876,13 +2817,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli@backstage:^::backstage=1.55.0-next.1&npm=0.36.6-next.0, @backstage/cli@npm:^0.36.6-next.0":
-  version: 0.36.6-next.0
-  resolution: "@backstage/cli@npm:0.36.6-next.0"
+"@backstage/cli@backstage:^::backstage=1.55.0-next.2&npm=0.36.6-next.1, @backstage/cli@npm:^0.36.6-next.1":
+  version: 0.36.6-next.1
+  resolution: "@backstage/cli@npm:0.36.6-next.1"
   dependencies:
     "@backstage/cli-common": "npm:0.3.0"
-    "@backstage/cli-defaults": "npm:0.1.6-next.0"
-    "@backstage/cli-module-build": "npm:0.1.8-next.0"
+    "@backstage/cli-defaults": "npm:0.1.6-next.2"
+    "@backstage/cli-module-build": "npm:0.1.8-next.2"
     "@backstage/cli-module-test-jest": "npm:0.1.5"
     "@backstage/cli-node": "npm:0.3.4"
     "@backstage/eslint-plugin": "npm:0.3.2"
@@ -2899,7 +2840,6 @@ __metadata:
     cross-fetch: "npm:^4.0.0"
     eslint: "npm:^8.6.0"
     eslint-config-prettier: "npm:^9.0.0"
-    eslint-plugin-deprecation: "npm:^3.0.0"
     eslint-plugin-import: "npm:^2.31.0"
     eslint-plugin-jest: "npm:^28.9.0"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
@@ -2927,11 +2867,34 @@ __metadata:
       optional: true
   bin:
     backstage-cli: bin/backstage-cli
-  checksum: 10/452861007c790c4accb6fe84c5e07da1b01c4f814d35ef0451850933d40ba45c62811c119a5d87520a7e9a76525ee0ae27a8d6a8967516796ba801d10bd2eb19
+  checksum: 10/e251115c8b404ba0bccc2e9bcdd77ac41bcdf59a2b212f722435bc922169ec956d5691a5122343ceabb6b9c23ba21e22199fb0c76ac5974f1d7722f262d7be1c
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:1.11.2, @backstage/config-loader@npm:^1.11.2":
+"@backstage/config-loader@npm:1.11.3-next.0":
+  version: 1.11.3-next.0
+  resolution: "@backstage/config-loader@npm:1.11.3-next.0"
+  dependencies:
+    "@backstage/cli-common": "npm:0.3.0"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    "@types/json-schema": "npm:^7.0.6"
+    ajv: "npm:^8.10.0"
+    chokidar: "npm:^3.5.2"
+    fs-extra: "npm:^11.2.0"
+    json-schema-merge-allof: "npm:^0.8.1"
+    json-schema-traverse: "npm:^1.0.0"
+    lodash: "npm:^4.17.21"
+    minimist: "npm:^1.2.5"
+    ts-json-schema-generator: "npm:^2.9.0"
+    typescript: "npm:^5.9.3"
+    yaml: "npm:^2.0.0"
+  checksum: 10/2bb34de111ee86a3764eb3eba5adbdda91f31a7aa1fdf86e260ea14aa5a42b58d127f9d9444ae5dca775f51bf1d508e1368da8dd3677f9cb912a21127c0f57c2
+  languageName: node
+  linkType: hard
+
+"@backstage/config-loader@npm:^1.11.2":
   version: 1.11.2
   resolution: "@backstage/config-loader@npm:1.11.2"
   dependencies:
@@ -2954,7 +2917,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config@backstage:^::backstage=1.55.0-next.1&npm=1.3.8, @backstage/config@npm:1.3.8, @backstage/config@npm:^1.3.8":
+"@backstage/config@backstage:^::backstage=1.55.0-next.2&npm=1.3.9-next.0, @backstage/config@npm:1.3.9-next.0, @backstage/config@npm:^1.3.9-next.0":
+  version: 1.3.9-next.0
+  resolution: "@backstage/config@npm:1.3.9-next.0"
+  dependencies:
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    ms: "npm:^2.1.3"
+  checksum: 10/8fa1bb5add20331ef11df2cb4c45cfea776ae13c4394e9d9098b6283b755e64d8d00b73980671209e53e140cc1387ab23161f6e698096448262723d97ee15e4a
+  languageName: node
+  linkType: hard
+
+"@backstage/config@npm:1.3.8, @backstage/config@npm:^1.3.8":
   version: 1.3.8
   resolution: "@backstage/config@npm:1.3.8"
   dependencies:
@@ -2977,7 +2951,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@backstage:^::backstage=1.55.0-next.1&npm=1.20.5-next.1, @backstage/core-app-api@npm:1.20.5-next.1, @backstage/core-app-api@npm:^1.20.5-next.1":
+"@backstage/connections@npm:0.4.0-next.0":
+  version: 0.4.0-next.0
+  resolution: "@backstage/connections@npm:0.4.0-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    zod: "npm:^4.0.0"
+  checksum: 10/b7712ec046a6e1c8bd3e2348c31e0a8b21f9ef5eca46bb50d38be65114cee3faed848df26ea5aad758f67b14135fa0d39fda6369459fd410ce47369e96ab5fe9
+  languageName: node
+  linkType: hard
+
+"@backstage/core-app-api@backstage:^::backstage=1.55.0-next.2&npm=1.20.5-next.2, @backstage/core-app-api@npm:1.20.5-next.2, @backstage/core-app-api@npm:^1.20.5-next.2":
+  version: 1.20.5-next.2
+  resolution: "@backstage/core-app-api@npm:1.20.5-next.2"
+  dependencies:
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/ui": "npm:0.18.0-next.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@types/prop-types": "npm:^15.7.3"
+    history: "npm:^5.0.0"
+    i18next: "npm:^22.4.15"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/4bec08759c06bfd65ae91a8320e749ffbd520dd333d43b3372e27320820808be050d2d9c49fc639d288eb3a611efe478454d64cdea61560ca4f967cb94f1a89e
+  languageName: node
+  linkType: hard
+
+"@backstage/core-app-api@npm:1.20.5-next.1":
   version: 1.20.5-next.1
   resolution: "@backstage/core-app-api@npm:1.20.5-next.1"
   dependencies:
@@ -3006,7 +3021,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@backstage:^::backstage=1.55.0-next.1&npm=0.5.15-next.1, @backstage/core-compat-api@npm:0.5.15-next.1, @backstage/core-compat-api@npm:^0.5.15-next.1":
+"@backstage/core-compat-api@backstage:^::backstage=1.55.0-next.2&npm=0.5.15-next.1, @backstage/core-compat-api@npm:0.5.15-next.1, @backstage/core-compat-api@npm:^0.5.15-next.1":
   version: 0.5.15-next.1
   resolution: "@backstage/core-compat-api@npm:0.5.15-next.1"
   dependencies:
@@ -3056,7 +3071,67 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@backstage:^::backstage=1.55.0-next.1&npm=0.18.14-next.1, @backstage/core-components@npm:0.18.14-next.1, @backstage/core-components@npm:^0.18.14-next.1":
+"@backstage/core-components@backstage:^::backstage=1.55.0-next.2&npm=0.18.14-next.2, @backstage/core-components@npm:0.18.14-next.2, @backstage/core-components@npm:^0.18.14-next.2":
+  version: 0.18.14-next.2
+  resolution: "@backstage/core-components@npm:0.18.14-next.2"
+  dependencies:
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/theme": "npm:0.7.3"
+    "@backstage/ui": "npm:0.18.0-next.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@dagrejs/dagre": "npm:^1.1.4"
+    "@date-io/core": "npm:^1.3.13"
+    "@material-table/core": "npm:^3.1.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@testing-library/dom": "npm:^10.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react-sparklines": "npm:^1.7.0"
+    ansi-regex: "npm:^6.0.1"
+    classnames: "npm:^2.2.6"
+    csstype: "npm:^3.0.2"
+    d3-selection: "npm:^3.0.0"
+    d3-shape: "npm:^3.0.0"
+    d3-zoom: "npm:^3.0.0"
+    js-yaml: "npm:^4.3.0"
+    linkify-react: "npm:4.3.2"
+    linkifyjs: "npm:4.3.2"
+    lodash: "npm:^4.17.21"
+    parse5: "npm:^6.0.0"
+    qs: "npm:^6.15.2"
+    rc-progress: "npm:3.5.1"
+    react-full-screen: "npm:^1.1.1"
+    react-helmet: "npm:6.1.0"
+    react-hook-form: "npm:^7.12.2"
+    react-idle-timer: "npm:5.7.2"
+    react-markdown: "npm:^8.0.0"
+    react-sparklines: "npm:^1.7.0"
+    react-syntax-highlighter: "npm:^15.4.5"
+    react-use: "npm:^17.3.2"
+    react-virtualized-auto-sizer: "npm:^1.0.11"
+    react-window: "npm:^1.8.6"
+    rehype-raw: "npm:^6.0.0"
+    rehype-sanitize: "npm:^5.0.0"
+    remark-gfm: "npm:^3.0.1"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/7817ef7b5a80166f04478c9b6215290e65e9c7779e1e75e31e96dd147c2cb4a62db45cd354cb3ccf1daf91731cc08cdb7423951c894b71e9d862bb0654b6f257
+  languageName: node
+  linkType: hard
+
+"@backstage/core-components@npm:0.18.14-next.1":
   version: 0.18.14-next.1
   resolution: "@backstage/core-components@npm:0.18.14-next.1"
   dependencies:
@@ -3175,7 +3250,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@backstage:^::backstage=1.55.0-next.1&npm=1.12.10-next.0, @backstage/core-plugin-api@npm:1.12.10-next.0, @backstage/core-plugin-api@npm:^1.12.10-next.0":
+"@backstage/core-plugin-api@backstage:^::backstage=1.55.0-next.2&npm=1.12.10-next.1, @backstage/core-plugin-api@npm:1.12.10-next.1, @backstage/core-plugin-api@npm:^1.12.10-next.1":
+  version: 1.12.10-next.1
+  resolution: "@backstage/core-plugin-api@npm:1.12.10-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    history: "npm:^5.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/1be19a13354f8816e6ff061ab69fa1d539270d39b56686eb92e474571347043f30d31af46ee536862d9ca5fa37af6209bc2de2969eddd5031c28d8808dba7554
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:1.12.10-next.0":
   version: 1.12.10-next.0
   resolution: "@backstage/core-plugin-api@npm:1.12.10-next.0"
   dependencies:
@@ -3221,7 +3319,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/e2e-test-utils@backstage:^::backstage=1.55.0-next.1&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
+"@backstage/e2e-test-utils@backstage:^::backstage=1.55.0-next.2&npm=0.1.2, @backstage/e2e-test-utils@npm:^0.1.2":
   version: 0.1.2
   resolution: "@backstage/e2e-test-utils@npm:0.1.2"
   dependencies:
@@ -3269,6 +3367,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/filter-predicates@npm:0.1.5-next.1":
+  version: 0.1.5-next.1
+  resolution: "@backstage/filter-predicates@npm:0.1.5-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10/3e71e973d94f1fac56d3e6c9c9f26c473e2e5d6d0d65e730adc86e37ddca3c08953e27105e7101751df58be1b3b8e68eb17da4a8623ef4c0e17f40c94419155c
+  languageName: node
+  linkType: hard
+
 "@backstage/filter-predicates@npm:^0.1.4":
   version: 0.1.4
   resolution: "@backstage/filter-predicates@npm:0.1.4"
@@ -3282,17 +3393,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-app-api@npm:0.16.8-next.1":
-  version: 0.16.8-next.1
-  resolution: "@backstage/frontend-app-api@npm:0.16.8-next.1"
+"@backstage/frontend-app-api@npm:0.16.8-next.2":
+  version: 0.16.8-next.2
+  resolution: "@backstage/frontend-app-api@npm:0.16.8-next.2"
   dependencies:
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/core-app-api": "npm:1.20.5-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/core-app-api": "npm:1.20.5-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/filter-predicates": "npm:0.1.5-next.0"
-    "@backstage/frontend-defaults": "npm:0.5.6-next.1"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
+    "@backstage/filter-predicates": "npm:0.1.5-next.1"
+    "@backstage/frontend-defaults": "npm:0.5.6-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.12"
     lodash: "npm:^4.17.21"
@@ -3304,19 +3415,19 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a3c0648b809674485e23d303bfd3ba9cf28080d689f59da77ca94389096a0519f53858e76b098b10d8ce286ce455553b869e074db77ac45515cc15a98fc9c653
+  checksum: 10/bc75abd06784b986b3c8f93b84553305fe5dea91b6a89e4b2a5e59ee48c8cde3e217a25873aeea3a09ff56c1b509087cacbe7831ac315bda3e7b7487fafd3820
   languageName: node
   linkType: hard
 
-"@backstage/frontend-defaults@backstage:^::backstage=1.55.0-next.1&npm=0.5.6-next.1, @backstage/frontend-defaults@npm:0.5.6-next.1, @backstage/frontend-defaults@npm:^0.5.6-next.1":
-  version: 0.5.6-next.1
-  resolution: "@backstage/frontend-defaults@npm:0.5.6-next.1"
+"@backstage/frontend-defaults@backstage:^::backstage=1.55.0-next.2&npm=0.5.6-next.2, @backstage/frontend-defaults@npm:0.5.6-next.2, @backstage/frontend-defaults@npm:^0.5.6-next.2":
+  version: 0.5.6-next.2
+  resolution: "@backstage/frontend-defaults@npm:0.5.6-next.2"
   dependencies:
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/core-components": "npm:0.18.14-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/core-components": "npm:0.18.14-next.2"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-app-api": "npm:0.16.8-next.1"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
+    "@backstage/frontend-app-api": "npm:0.16.8-next.2"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
     "@backstage/plugin-app": "npm:0.5.3-next.1"
     "@react-hookz/web": "npm:^24.0.0"
   peerDependencies:
@@ -3327,11 +3438,33 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/6fc69022c69c5d432ce2066f68926d4c8c8b7e76db7575183ba5462844e1f707ae8c1fb53eef97bbe98a2eb9504aa558c70a4d06c0359acf523b229f62825f8a
+  checksum: 10/20767d0ad38c27f97eaf8b25e1262c1ca047cdc31a143505ee2be37dc0106c4fabb75c9704ba7c12136c8ed6ab9549a1e6aafa59a236f2cf516b52346e2cfb91
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@backstage:^::backstage=1.55.0-next.1&npm=0.18.1-next.0, @backstage/frontend-plugin-api@npm:0.18.1-next.0, @backstage/frontend-plugin-api@npm:^0.18.1-next.0":
+"@backstage/frontend-plugin-api@backstage:^::backstage=1.55.0-next.2&npm=0.18.1-next.1, @backstage/frontend-plugin-api@npm:0.18.1-next.1, @backstage/frontend-plugin-api@npm:^0.18.1-next.1":
+  version: 0.18.1-next.1
+  resolution: "@backstage/frontend-plugin-api@npm:0.18.1-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/filter-predicates": "npm:0.1.5-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@standard-schema/spec": "npm:^1.1.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/99f0c86e6482542ef73ee8489ee8df5f60066880f8a143aca5eb1252e6ce6b31a14f961a2b0fcc8ccf238d5666a33e3f8c5f2930e76e226de39e175a755a5abe
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:0.18.1-next.0":
   version: 0.18.1-next.0
   resolution: "@backstage/frontend-plugin-api@npm:0.18.1-next.0"
   dependencies:
@@ -3399,7 +3532,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-aws-node@npm:0.2.1, @backstage/integration-aws-node@npm:^0.2.1":
+"@backstage/integration-aws-node@npm:0.2.2-next.0":
+  version: 0.2.2-next.0
+  resolution: "@backstage/integration-aws-node@npm:0.2.2-next.0"
+  dependencies:
+    "@aws-sdk/client-sts": "npm:^3.350.0"
+    "@aws-sdk/credential-provider-node": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@aws-sdk/util-arn-parser": "npm:^3.310.0"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/connections": "npm:0.4.0-next.0"
+    "@backstage/errors": "npm:1.3.1"
+  checksum: 10/23bbb68e0362a7b93024b9488a24a523b85d98e0a83ff4b660eaa5ee6647e863f3eb152b3b9cf0271b377423dde48058c81031527a62c9eb2515e018e5933676
+  languageName: node
+  linkType: hard
+
+"@backstage/integration-aws-node@npm:^0.2.1":
   version: 0.2.1
   resolution: "@backstage/integration-aws-node@npm:0.2.1"
   dependencies:
@@ -3415,7 +3564,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@backstage:^::backstage=1.55.0-next.1&npm=1.2.22-next.0, @backstage/integration-react@npm:1.2.22-next.0, @backstage/integration-react@npm:^1.2.22-next.0":
+"@backstage/integration-react@backstage:^::backstage=1.55.0-next.2&npm=1.2.22-next.1, @backstage/integration-react@npm:1.2.22-next.1, @backstage/integration-react@npm:^1.2.22-next.1":
+  version: 1.2.22-next.1
+  resolution: "@backstage/integration-react@npm:1.2.22-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/879d27410731de065e9c5ea4eeab0eadbc1bd2ad412b86eadfcba6ed96d7625bd2efed7c919bed7b8ca1d9ebddcb2d0e8a4d06059ed4c37cce039250f13e86e3
+  languageName: node
+  linkType: hard
+
+"@backstage/integration-react@npm:1.2.22-next.0":
   version: 1.2.22-next.0
   resolution: "@backstage/integration-react@npm:1.2.22-next.0"
   dependencies:
@@ -3477,6 +3647,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration@npm:2.1.2-next.1":
+  version: 2.1.2-next.1
+  resolution: "@backstage/integration@npm:2.1.2-next.1"
+  dependencies:
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/connections": "npm:0.4.0-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@octokit/auth-app": "npm:^4.0.0"
+    "@octokit/rest": "npm:^19.0.3"
+    cross-fetch: "npm:^4.0.0"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    p-throttle: "npm:^4.1.1"
+  checksum: 10/912e6489dcdb35d46686e66e95a5aa45f63f7bd7ed4556f1d8d4ec735a31ad139d325d6cf91b95f2c55054056f8c431b343a0ee4a4f034d6a8dfc58f59ce7b39
+  languageName: node
+  linkType: hard
+
 "@backstage/integration@npm:^2.0.3, @backstage/integration@npm:^2.1.0":
   version: 2.1.0
   resolution: "@backstage/integration@npm:2.1.0"
@@ -3497,14 +3687,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/module-federation-common@npm:0.1.4":
-  version: 0.1.4
-  resolution: "@backstage/module-federation-common@npm:0.1.4"
+"@backstage/module-federation-common@npm:0.1.5-next.0":
+  version: 0.1.5-next.0
+  resolution: "@backstage/module-federation-common@npm:0.1.5-next.0"
   dependencies:
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/errors": "npm:^1.3.1"
-    "@backstage/types": "npm:^1.2.2"
-    "@module-federation/runtime": "npm:^2.3.3"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    "@module-federation/runtime": "npm:~2.8.2"
   peerDependencies:
     "@emotion/react": ^11.10.5
     "@material-ui/core": ^4.12.2
@@ -3518,24 +3708,24 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/acb599f98ade3d960aeb1acc16232c93d42696244e2bb192e9f5bdc76109bfe08d53487bf638fca64e092df446b551917a535eef7d466d41c7df159d997a4221
+  checksum: 10/80b3822ea9ccea7d5be36b8bfc6fe6ba3d7fc5d73d8301fa5fe971305c6024ca95e28f651beef015c0526a4933445ff260d6e6103d02d84d376780326da2f5b7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-api-docs@backstage:^::backstage=1.55.0-next.1&npm=0.14.5-next.1, @backstage/plugin-api-docs@npm:^0.14.5-next.1":
-  version: 0.14.5-next.1
-  resolution: "@backstage/plugin-api-docs@npm:0.14.5-next.1"
+"@backstage/plugin-api-docs@backstage:^::backstage=1.55.0-next.2&npm=0.14.5-next.2, @backstage/plugin-api-docs@npm:^0.14.5-next.2":
+  version: 0.14.5-next.2
+  resolution: "@backstage/plugin-api-docs@npm:0.14.5-next.2"
   dependencies:
     "@asyncapi/react-component": "npm:^2.3.3"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/plugin-catalog": "npm:2.0.9-next.1"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.3-next.1"
-    "@backstage/plugin-permission-react": "npm:0.5.5-next.0"
-    "@backstage/ui": "npm:0.18.0-next.1"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/plugin-catalog": "npm:2.0.9-next.2"
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.3-next.2"
+    "@backstage/plugin-permission-react": "npm:0.5.5-next.1"
+    "@backstage/ui": "npm:0.18.0-next.2"
     "@graphiql/react": "npm:0.29.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -3554,20 +3744,20 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/a67795b0b8f954fd7e3d0ae437002ce2be211c7b8d96475478f5f6272b8fddc5fb8917909797e9217fbcdd612abcfc068291fb0dca42a4e0707b0f38a0a1bee4
+  checksum: 10/e05677e467407a81ae1bd00fc1c98189f59f7bb5cba4c83a720dd2eb722fb6de38b33ac036d409aa728fba5b4f0f2fe3068f7362aca76858af8e99676e0f025b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-backend@backstage:^::backstage=1.55.0-next.1&npm=0.5.18-next.0, @backstage/plugin-app-backend@npm:^0.5.18-next.0":
-  version: 0.5.18-next.0
-  resolution: "@backstage/plugin-app-backend@npm:0.5.18-next.0"
+"@backstage/plugin-app-backend@backstage:^::backstage=1.55.0-next.2&npm=0.5.18-next.1, @backstage/plugin-app-backend@npm:^0.5.18-next.1":
+  version: 0.5.18-next.1
+  resolution: "@backstage/plugin-app-backend@npm:0.5.18-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/config-loader": "npm:1.11.2"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/config-loader": "npm:1.11.3-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-app-node": "npm:0.1.49-next.0"
-    "@backstage/plugin-auth-node": "npm:0.7.5-next.0"
+    "@backstage/plugin-app-node": "npm:0.1.49-next.1"
+    "@backstage/plugin-auth-node": "npm:0.7.5-next.1"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
@@ -3577,24 +3767,43 @@ __metadata:
     knex: "npm:^3.0.0"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-  checksum: 10/9b5db9f62a7c3c7040384575f76341f880281aac933a14c2c89b703349e5fd0277907322e590f8ccb49424138e291dba6ead1ae1c6fc60925aa7fd0d1325ff13
+  checksum: 10/e8f5b56e889ba2101c27a79bc7d526df3f65952077c46cb4ca6db752630278ff700fafc7766f558de75b488cb8b0dc07bdf89eb7672e5d0fd6a2194143a3706f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-node@npm:0.1.49-next.0":
-  version: 0.1.49-next.0
-  resolution: "@backstage/plugin-app-node@npm:0.1.49-next.0"
+"@backstage/plugin-app-node@npm:0.1.49-next.1":
+  version: 0.1.49-next.1
+  resolution: "@backstage/plugin-app-node@npm:0.1.49-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/config-loader": "npm:1.11.2"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/config-loader": "npm:1.11.3-next.0"
     "@types/express": "npm:^4.17.6"
     express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
-  checksum: 10/badd025f3b924e751ba5a184631e599bb4576b83cd19072cd9b888e35fba0f918b98f317ea73976b700b9f1f058453926edf9c6ea52a320a4d1ff66c21cf23e4
+  checksum: 10/ad637197736e5e9450f8afa22e4d8e9849b7215699559fea622d2398745627c838be069de07505c4eeec43d6b8aea5fdd345686fbef6639c9549aff9acff811b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-react@backstage:^::backstage=1.55.0-next.1&npm=0.2.7-next.0, @backstage/plugin-app-react@npm:0.2.7-next.0, @backstage/plugin-app-react@npm:^0.2.7-next.0":
+"@backstage/plugin-app-react@backstage:^::backstage=1.55.0-next.2&npm=0.2.7-next.1, @backstage/plugin-app-react@npm:^0.2.7-next.1":
+  version: 0.2.7-next.1
+  resolution: "@backstage/plugin-app-react@npm:0.2.7-next.1"
+  dependencies:
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@material-ui/core": "npm:^4.9.13"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/f566bf035d766f0e2801d512ba6bde00eb852b5a9f5dfca2a21797295b335ce3f78fe98bc91924a3eaa2c5a02dbcbb337262a25666d632877752644c73a095ea
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-app-react@npm:0.2.7-next.0":
   version: 0.2.7-next.0
   resolution: "@backstage/plugin-app-react@npm:0.2.7-next.0"
   dependencies:
@@ -3632,7 +3841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-visualizer@backstage:^::backstage=1.55.0-next.1&npm=0.2.8-next.1, @backstage/plugin-app-visualizer@npm:^0.2.8-next.1":
+"@backstage/plugin-app-visualizer@backstage:^::backstage=1.55.0-next.2&npm=0.2.8-next.1, @backstage/plugin-app-visualizer@npm:^0.2.8-next.1":
   version: 0.2.8-next.1
   resolution: "@backstage/plugin-app-visualizer@npm:0.2.8-next.1"
   dependencies:
@@ -3654,7 +3863,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app@backstage:^::backstage=1.55.0-next.1&npm=0.5.3-next.1, @backstage/plugin-app@npm:0.5.3-next.1, @backstage/plugin-app@npm:^0.5.3-next.1":
+"@backstage/plugin-app@backstage:^::backstage=1.55.0-next.2&npm=0.5.3-next.1, @backstage/plugin-app@npm:0.5.3-next.1, @backstage/plugin-app@npm:^0.5.3-next.1":
   version: 0.5.3-next.1
   resolution: "@backstage/plugin-app@npm:0.5.3-next.1"
   dependencies:
@@ -3692,7 +3901,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.55.0-next.1&npm=0.5.7-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.7-next.0":
+"@backstage/plugin-auth-backend-module-github-provider@backstage:^::backstage=1.55.0-next.2&npm=0.5.7-next.0, @backstage/plugin-auth-backend-module-github-provider@npm:^0.5.7-next.0":
   version: 0.5.7-next.0
   resolution: "@backstage/plugin-auth-backend-module-github-provider@npm:0.5.7-next.0"
   dependencies:
@@ -3704,7 +3913,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.55.0-next.1&npm=0.2.23-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.23-next.0":
+"@backstage/plugin-auth-backend-module-guest-provider@backstage:^::backstage=1.55.0-next.2&npm=0.2.23-next.0, @backstage/plugin-auth-backend-module-guest-provider@npm:^0.2.23-next.0":
   version: 0.2.23-next.0
   resolution: "@backstage/plugin-auth-backend-module-guest-provider@npm:0.2.23-next.0"
   dependencies:
@@ -3717,16 +3926,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-backend@backstage:^::backstage=1.55.0-next.1&npm=0.30.1-next.1, @backstage/plugin-auth-backend@npm:^0.30.1-next.1":
-  version: 0.30.1-next.1
-  resolution: "@backstage/plugin-auth-backend@npm:0.30.1-next.1"
+"@backstage/plugin-auth-backend@backstage:^::backstage=1.55.0-next.2&npm=0.30.1-next.2, @backstage/plugin-auth-backend@npm:^0.30.1-next.2":
+  version: 0.30.1-next.2
+  resolution: "@backstage/plugin-auth-backend@npm:0.30.1-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-auth-node": "npm:0.7.5-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
+    "@backstage/plugin-auth-node": "npm:0.7.5-next.1"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/firestore": "npm:^7.0.0"
     connect-session-knex: "npm:^4.0.0"
@@ -3744,7 +3953,7 @@ __metadata:
     passport: "npm:^0.7.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-validation-error: "npm:^5.0.0"
-  checksum: 10/224e0a4795a874588c6b0d1074673402e8043ddbaf7742eba2a1a306b64ce6460ed848d1f1e9428f57a237f8c401cdaacda777b9f86c6477466b53594589ef98
+  checksum: 10/c78b78f3bae5a5c3718bbcb6575a4138280316a9c0f5d28f02773dac6a0369785f1c71e05364420eb53978bdaaa320b05c843a7abbf0e8c520da983c41dc68cc
   languageName: node
   linkType: hard
 
@@ -3768,6 +3977,29 @@ __metadata:
     zod-to-json-schema: "npm:^3.25.1"
     zod-validation-error: "npm:^5.0.0"
   checksum: 10/fef1277c4decbff1f432a4be3f7e6002527e4cfee2b5ab953a46099783b920f3fa9aaf02eff09e47f350c4d9c8589c766d7fe4ae6f8e893f9e3dc1c93e0b2c93
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-auth-node@npm:0.7.5-next.1":
+  version: 0.7.5-next.1
+  resolution: "@backstage/plugin-auth-node@npm:0.7.5-next.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
+    "@backstage/catalog-model": "npm:1.10.0"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    "@types/express": "npm:^4.17.6"
+    "@types/passport": "npm:^1.0.3"
+    express: "npm:^4.22.0"
+    jose: "npm:^5.0.0"
+    lodash: "npm:^4.17.21"
+    passport: "npm:^0.7.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+    zod-validation-error: "npm:^5.0.0"
+  checksum: 10/5008a20e4586f83b7a84718737d6241b99829e61925009c287e26ba6018d3cb9d7f90abd79eb913a91e37762f7708f905fd0a3f7d3c59e99519e56621b1d4917
   languageName: node
   linkType: hard
 
@@ -3815,7 +4047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth@backstage:^::backstage=1.55.0-next.1&npm=0.1.12-next.1, @backstage/plugin-auth@npm:^0.1.12-next.1":
+"@backstage/plugin-auth@backstage:^::backstage=1.55.0-next.2&npm=0.1.12-next.1, @backstage/plugin-auth@npm:^0.1.12-next.1":
   version: 0.1.12-next.1
   resolution: "@backstage/plugin-auth@npm:0.1.12-next.1"
   dependencies:
@@ -3837,7 +4069,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-ai-model@backstage:^::backstage=1.55.0-next.1&npm=0.1.4-next.0, @backstage/plugin-catalog-backend-module-ai-model@npm:^0.1.4-next.0":
+"@backstage/plugin-catalog-backend-module-ai-model@backstage:^::backstage=1.55.0-next.2&npm=0.1.4-next.0, @backstage/plugin-catalog-backend-module-ai-model@npm:^0.1.4-next.0":
   version: 0.1.4-next.0
   resolution: "@backstage/plugin-catalog-backend-module-ai-model@npm:0.1.4-next.0"
   dependencies:
@@ -3848,35 +4080,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.55.0-next.1&npm=0.5.18-next.0, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.18-next.0":
-  version: 0.5.18-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-backstage-openapi@npm:0.5.18-next.0"
+"@backstage/plugin-catalog-backend-module-backstage-openapi@backstage:^::backstage=1.55.0-next.2&npm=0.5.18-next.1, @backstage/plugin-catalog-backend-module-backstage-openapi@npm:^0.5.18-next.1":
+  version: 0.5.18-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-backstage-openapi@npm:0.5.18-next.1"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.7.2-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
     cross-fetch: "npm:^4.0.0"
     lodash: "npm:^4.17.21"
     openapi-merge: "npm:^1.3.2"
     yaml: "npm:^2.7.0"
-  checksum: 10/fb6e74d2386ee3f2cbba73faf42c256d83423962e4d70af654d83d171bb902cad9a723f2ee1fd62b087f35058dec88fe346475a5b6eb79090001dc34b9cf2f84
+  checksum: 10/e45616486e033f64aa806c450fe18319a5ca64fc18311e5ccab7dd16e78ca1ced57ebdc5a4ed196f5d720885b2569f0aaff273ec84e84febbc567f1e3ccb7668
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.55.0-next.1&npm=0.14.0-next.0, @backstage/plugin-catalog-backend-module-github@npm:^0.14.0-next.0":
-  version: 0.14.0-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.14.0-next.0"
+"@backstage/plugin-catalog-backend-module-github@backstage:^::backstage=1.55.0-next.2&npm=0.14.0-next.1, @backstage/plugin-catalog-backend-module-github@npm:^0.14.0-next.1":
+  version: 0.14.0-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.14.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
     "@backstage/plugin-events-node": "npm:0.4.26-next.0"
     "@backstage/types": "npm:1.2.2"
     "@octokit/auth-callback": "npm:^5.0.0"
@@ -3890,51 +4122,51 @@ __metadata:
     lodash: "npm:^4.17.21"
     minimatch: "npm:^10.2.1"
     octokit: "npm:^3.0.0"
-  checksum: 10/1e06b72d22177d194ae831d81d51465f24f22daa23d00cf33360e23225bed1c897d401646eff9f1411552671f7adf3f49e669df81906df1e5c085e153388ecfd
+  checksum: 10/48642323ede396680c3c4bdd78b45532505d6a159c24d77440385047b8073c8f5e6f98b5d18ee34db6b03107340e6b0282268de7f9c9a456ff347e0d720a5a5b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.55.0-next.1&npm=0.1.26-next.0, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.26-next.0":
-  version: 0.1.26-next.0
-  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.26-next.0"
+"@backstage/plugin-catalog-backend-module-logs@backstage:^::backstage=1.55.0-next.2&npm=0.1.26-next.1, @backstage/plugin-catalog-backend-module-logs@npm:^0.1.26-next.1":
+  version: 0.1.26-next.1
+  resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.26-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/plugin-catalog-backend": "npm:3.9.2-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/plugin-catalog-backend": "npm:4.0.0-next.1"
     "@backstage/plugin-events-node": "npm:0.4.26-next.0"
-  checksum: 10/a59bde10898f36f4c487d3249c3c886fb888bbcfffced7f87e8e0c23850b37e01a5e0d293942f547b2c94e653a01c8451997cbe2ccf12c97ad0d27bb6320a556
+  checksum: 10/e390ed96289b97d9318f67dc698cc7cd69e5cd1ba1dc774944acfcbf3537c5e278350515b22480f03e64ad5ae503f1bfe6414adaa612ccea108071b3d499e5de
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.55.0-next.1&npm=0.2.24-next.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.24-next.1":
-  version: 0.2.24-next.1
-  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.24-next.1"
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@backstage:^::backstage=1.55.0-next.2&npm=0.2.24-next.2, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.24-next.2":
+  version: 0.2.24-next.2
+  resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.24-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.1"
-  checksum: 10/1fea9cc570c403a9055dff32f384d25f925242ee99921f77754f4515376ab1b258ba5e50340b516293117db9fc88ec6d61f6107839d1b0b0db41969ef8ae0a27
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.2"
+  checksum: 10/40a8948f7f321501cbf210c438c83a14a87909f2e07349efbdbcdf205801959266a2779a0b8ff2f3d6c398cf2c80a60ee37b41a2d0daf53f152749dac5f97859
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@backstage:^::backstage=1.55.0-next.1&npm=3.9.2-next.0, @backstage/plugin-catalog-backend@npm:3.9.2-next.0, @backstage/plugin-catalog-backend@npm:^3.9.2-next.0":
-  version: 3.9.2-next.0
-  resolution: "@backstage/plugin-catalog-backend@npm:3.9.2-next.0"
+"@backstage/plugin-catalog-backend@backstage:^::backstage=1.55.0-next.2&npm=4.0.0-next.1, @backstage/plugin-catalog-backend@npm:4.0.0-next.1, @backstage/plugin-catalog-backend@npm:^4.0.0-next.1":
+  version: 4.0.0-next.1
+  resolution: "@backstage/plugin-catalog-backend@npm:4.0.0-next.1"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.7.2-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/catalog-client": "npm:1.16.2-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/filter-predicates": "npm:0.1.5-next.0"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
+    "@backstage/filter-predicates": "npm:0.1.5-next.1"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
     "@backstage/plugin-events-node": "npm:0.4.26-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.10"
-    "@backstage/plugin-permission-node": "npm:0.11.4-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-permission-node": "npm:0.11.4-next.1"
     "@backstage/types": "npm:1.2.2"
     "@opentelemetry/api": "npm:^1.9.0"
     ajv: "npm:^8.10.0"
@@ -3956,11 +4188,22 @@ __metadata:
     yn: "npm:^4.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-validation-error: "npm:^5.0.0"
-  checksum: 10/24c6a539fd759b3e28e4e7c9c901f10a2b9d6826080fc0ae37e024fb651318d2004fba00f4033b0a3e2f3e5f85f2380edc9922769e98aec16a1d9a444ac8d3fc
+  checksum: 10/ec81c629ede00e3c0261a2abc2203a6e84d5aadf868fafcb5d45f4c72c666b69029d8f314eff4681e681b11d258e7d794d49c8448cab7ecaba912fc0a922ba73
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@backstage:^::backstage=1.55.0-next.1&npm=1.1.10, @backstage/plugin-catalog-common@npm:1.1.10, @backstage/plugin-catalog-common@npm:^1.1.10":
+"@backstage/plugin-catalog-common@backstage:^::backstage=1.55.0-next.2&npm=1.2.0-next.0, @backstage/plugin-catalog-common@npm:1.2.0-next.0, @backstage/plugin-catalog-common@npm:^1.2.0-next.0":
+  version: 1.2.0-next.0
+  resolution: "@backstage/plugin-catalog-common@npm:1.2.0-next.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.10.0"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.25-next.0"
+  checksum: 10/4a894bc9f82a0835f3798f4de6f7a79c5d524520fd64ab94f19615f427e4442fd4bdd317c6dee2c9dc695d3f27d2a818bbcf92afabecab0e5ea11845a258f1aa
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-common@npm:1.1.10, @backstage/plugin-catalog-common@npm:^1.1.10":
   version: 1.1.10
   resolution: "@backstage/plugin-catalog-common@npm:1.1.10"
   dependencies:
@@ -3971,7 +4214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-graph@backstage:^::backstage=1.55.0-next.1&npm=0.6.8-next.1, @backstage/plugin-catalog-graph@npm:^0.6.8-next.1":
+"@backstage/plugin-catalog-graph@backstage:^::backstage=1.55.0-next.2&npm=0.6.8-next.1, @backstage/plugin-catalog-graph@npm:^0.6.8-next.1":
   version: 0.6.8-next.1
   resolution: "@backstage/plugin-catalog-graph@npm:0.6.8-next.1"
   dependencies:
@@ -4004,7 +4247,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@backstage:^::backstage=1.55.0-next.1&npm=2.2.5-next.0, @backstage/plugin-catalog-node@npm:2.2.5-next.0, @backstage/plugin-catalog-node@npm:^2.2.5-next.0":
+"@backstage/plugin-catalog-node@backstage:^::backstage=1.55.0-next.2&npm=2.2.5-next.1, @backstage/plugin-catalog-node@npm:2.2.5-next.1, @backstage/plugin-catalog-node@npm:^2.2.5-next.1":
+  version: 2.2.5-next.1
+  resolution: "@backstage/plugin-catalog-node@npm:2.2.5-next.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
+    "@backstage/catalog-model": "npm:1.10.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-permission-node": "npm:0.11.4-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@opentelemetry/api": "npm:^1.9.0"
+    lodash: "npm:^4.17.21"
+    yaml: "npm:^2.0.0"
+  peerDependencies:
+    "@backstage/backend-test-utils": 1.11.7-next.1
+  peerDependenciesMeta:
+    "@backstage/backend-test-utils":
+      optional: true
+  checksum: 10/9a254eb51230663c42cfaeb98ec1947f713d8addef794b3ef60eb98ff05adf4801d14ee731c96bd67660460ef0f398f7533098d010521646356f95f25cc01f62
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-node@npm:2.2.5-next.0":
   version: 2.2.5-next.0
   resolution: "@backstage/plugin-catalog-node@npm:2.2.5-next.0"
   dependencies:
@@ -4052,7 +4319,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-react@backstage:^::backstage=1.55.0-next.1&npm=3.2.3-next.1, @backstage/plugin-catalog-react@npm:3.2.3-next.1, @backstage/plugin-catalog-react@npm:^3.2.3-next.1":
+"@backstage/plugin-catalog-react@backstage:^::backstage=1.55.0-next.2&npm=3.2.3-next.2, @backstage/plugin-catalog-react@npm:3.2.3-next.2, @backstage/plugin-catalog-react@npm:^3.2.3-next.2":
+  version: 3.2.3-next.2
+  resolution: "@backstage/plugin-catalog-react@npm:3.2.3-next.2"
+  dependencies:
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
+    "@backstage/catalog-model": "npm:1.10.0"
+    "@backstage/core-compat-api": "npm:0.5.15-next.1"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/filter-predicates": "npm:0.1.5-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/integration-react": "npm:1.2.22-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-permission-react": "npm:0.5.5-next.1"
+    "@backstage/types": "npm:1.2.2"
+    "@backstage/ui": "npm:0.18.0-next.2"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@mui/material": "npm:^5.12.2"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    classnames: "npm:^2.2.6"
+    lodash: "npm:^4.17.21"
+    material-ui-popup-state: "npm:^5.3.6"
+    qs: "npm:^6.15.2"
+    react-use: "npm:^17.2.4"
+    react-window: "npm:^1.8.10"
+    yaml: "npm:^2.0.0"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^4.0.0"
+  peerDependencies:
+    "@backstage/frontend-test-utils": 0.6.4-next.2
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@backstage/frontend-test-utils":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 10/9046f4b43b46e73a717d408bc2fe54d1184f84678b5aa0bef410fe7d6f9a155103db74dda484d57080a53eca5fc0de7994b9b6022fe5412499e41ae8045bea42
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-react@npm:3.2.3-next.1":
   version: 3.2.3-next.1
   resolution: "@backstage/plugin-catalog-react@npm:3.2.3-next.1"
   dependencies:
@@ -4147,28 +4462,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@backstage:^::backstage=1.55.0-next.1&npm=2.0.9-next.1, @backstage/plugin-catalog@npm:2.0.9-next.1, @backstage/plugin-catalog@npm:^2.0.9-next.1":
-  version: 2.0.9-next.1
-  resolution: "@backstage/plugin-catalog@npm:2.0.9-next.1"
+"@backstage/plugin-catalog@backstage:^::backstage=1.55.0-next.2&npm=2.0.9-next.2, @backstage/plugin-catalog@npm:2.0.9-next.2, @backstage/plugin-catalog@npm:^2.0.9-next.2":
+  version: 2.0.9-next.2
+  resolution: "@backstage/plugin-catalog@npm:2.0.9-next.2"
   dependencies:
-    "@backstage/catalog-client": "npm:1.16.2-next.0"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
     "@backstage/core-compat-api": "npm:0.5.15-next.1"
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/integration-react": "npm:1.2.22-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.3-next.1"
-    "@backstage/plugin-permission-react": "npm:0.5.5-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.1"
-    "@backstage/plugin-search-common": "npm:1.2.24"
-    "@backstage/plugin-search-react": "npm:1.11.8-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/integration-react": "npm:1.2.22-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.3-next.2"
+    "@backstage/plugin-permission-react": "npm:0.5.5-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.2"
+    "@backstage/plugin-search-common": "npm:1.2.25-next.0"
+    "@backstage/plugin-search-react": "npm:1.11.8-next.2"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.15-next.1"
+    "@backstage/plugin-techdocs-react": "npm:1.3.15-next.2"
     "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.18.0-next.1"
+    "@backstage/ui": "npm:0.18.0-next.2"
     "@backstage/version-bridge": "npm:1.0.12"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -4192,34 +4507,34 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/502f8e9d5c63bc91f4d5a9f1ed690544b76939150693799bd849102290e9b89a1d15acee8bb028f9b0333a2ef1b4936718407c863ab9e010de0e21e2dd2e4867
+  checksum: 10/b7c26f31b737334b8a108e99e0a09abe08bebdfeef41a77a7b4fbfd6d9c44119509cc42dd26a2498a25deac5d9dc1a1789bd8807d852c29e52b80dd5c8c16d60
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.55.0-next.1&npm=0.4.16-next.0, @backstage/plugin-events-backend-module-github@npm:^0.4.16-next.0":
-  version: 0.4.16-next.0
-  resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.16-next.0"
+"@backstage/plugin-events-backend-module-github@backstage:^::backstage=1.55.0-next.2&npm=0.4.16-next.1, @backstage/plugin-events-backend-module-github@npm:^0.4.16-next.1":
+  version: 0.4.16-next.1
+  resolution: "@backstage/plugin-events-backend-module-github@npm:0.4.16-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/integration": "npm:2.1.2-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/integration": "npm:2.1.2-next.1"
     "@backstage/plugin-events-node": "npm:0.4.26-next.0"
     "@backstage/types": "npm:1.2.2"
     "@octokit/auth-callback": "npm:^5.0.0"
     "@octokit/webhooks-methods": "npm:^3.0.0"
     lodash: "npm:^4.17.21"
     octokit: "npm:^3.0.0"
-  checksum: 10/bdcebbe9f58276853deaf982cc24fdc0e10c5aa59fec981b272a82260571f22e866d24cb49be8ca5e0298c54f3ba9a21738e748b236ae040e6bfd9419e40bf58
+  checksum: 10/48a7f73e2525ce71a47565ef01a9dc40788d457e37a81ec5cbea3d342181ccaa3bdb50633a5b4c4ca172e28bb852245ed8b6906b1bd404da48dc65c21e052f1d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@backstage:^::backstage=1.55.0-next.1&npm=0.6.6-next.0, @backstage/plugin-events-backend@npm:^0.6.6-next.0":
-  version: 0.6.6-next.0
-  resolution: "@backstage/plugin-events-backend@npm:0.6.6-next.0"
+"@backstage/plugin-events-backend@backstage:^::backstage=1.55.0-next.2&npm=0.6.6-next.1, @backstage/plugin-events-backend@npm:^0.6.6-next.1":
+  version: 0.6.6-next.1
+  resolution: "@backstage/plugin-events-backend@npm:0.6.6-next.1"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.7.2-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
     "@backstage/plugin-events-node": "npm:0.4.26-next.0"
     "@backstage/types": "npm:1.2.2"
@@ -4228,7 +4543,7 @@ __metadata:
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
-  checksum: 10/ab49d5ad96cc0a97ed7a6f0a28a319608c098a3c5433808eaa851a5bfb6a287f00a5e26f9071d8e40d8fffcdf35c1a3851eac35c591aefccaf1a15cb14c0ec49
+  checksum: 10/05c1bbba221a6437204dfa8b86cd37eb086d5278ec3caf14f77179919dce85b8509550819d5143f2a472b6a69acf09137db368c0c89a5ad203f16feeb2569660
   languageName: node
   linkType: hard
 
@@ -4266,7 +4581,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home-react@backstage:^::backstage=1.55.0-next.1&npm=0.1.42-next.1, @backstage/plugin-home-react@npm:0.1.42-next.1, @backstage/plugin-home-react@npm:^0.1.42-next.1":
+"@backstage/plugin-home-react@backstage:^::backstage=1.55.0-next.2&npm=0.1.42-next.1, @backstage/plugin-home-react@npm:0.1.42-next.1, @backstage/plugin-home-react@npm:^0.1.42-next.1":
   version: 0.1.42-next.1
   resolution: "@backstage/plugin-home-react@npm:0.1.42-next.1"
   dependencies:
@@ -4289,19 +4604,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-home@backstage:^::backstage=1.55.0-next.1&npm=0.9.10-next.1, @backstage/plugin-home@npm:^0.9.10-next.1":
-  version: 0.9.10-next.1
-  resolution: "@backstage/plugin-home@npm:0.9.10-next.1"
+"@backstage/plugin-home@backstage:^::backstage=1.55.0-next.2&npm=0.9.10-next.2, @backstage/plugin-home@npm:^0.9.10-next.2":
+  version: 0.9.10-next.2
+  resolution: "@backstage/plugin-home@npm:0.9.10-next.2"
   dependencies:
-    "@backstage/catalog-client": "npm:1.16.2-next.0"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/core-app-api": "npm:1.20.5-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/core-app-api": "npm:1.20.5-next.2"
     "@backstage/core-compat-api": "npm:0.5.15-next.1"
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:3.2.3-next.1"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:3.2.3-next.2"
     "@backstage/plugin-home-react": "npm:0.1.42-next.1"
     "@backstage/theme": "npm:0.7.3"
     "@material-ui/core": "npm:^4.12.2"
@@ -4325,28 +4640,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/54fcdde65979c40acec768b1ef84f93c1a941095f4f80d369048ee3a031b288dd8a88d6c6df2b0102c763d8b356b3c691b15109c82008405f2bf118795a52e4f
+  checksum: 10/fec3b00ef153aa388cf2881efb27713b2505b013681f87038376303df508a4cdd657709abeafaab4d4fee0594d6e8a9ec3262208a7e3353ecd7f5512b1f64091
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.55.0-next.1&npm=0.21.11-next.1, @backstage/plugin-kubernetes-backend@npm:^0.21.11-next.1":
-  version: 0.21.11-next.1
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.11-next.1"
+"@backstage/plugin-kubernetes-backend@backstage:^::backstage=1.55.0-next.2&npm=0.21.11-next.2, @backstage/plugin-kubernetes-backend@npm:^0.21.11-next.2":
+  version: 0.21.11-next.2
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.21.11-next.2"
   dependencies:
     "@aws-crypto/sha256-js": "npm:^5.0.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
     "@azure/identity": "npm:^4.0.0"
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/catalog-client": "npm:1.16.2-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/integration-aws-node": "npm:0.2.1"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.13-next.0"
-    "@backstage/plugin-kubernetes-node": "npm:0.4.8-next.1"
-    "@backstage/plugin-permission-common": "npm:0.9.10"
-    "@backstage/plugin-permission-node": "npm:0.11.4-next.0"
+    "@backstage/integration-aws-node": "npm:0.2.2-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.13-next.1"
+    "@backstage/plugin-kubernetes-node": "npm:0.4.8-next.2"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-permission-node": "npm:0.11.4-next.1"
     "@backstage/types": "npm:1.2.2"
     "@google-cloud/container": "npm:^5.0.0"
     "@jest-mock/express": "npm:^2.0.1"
@@ -4357,53 +4672,54 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     fs-extra: "npm:^11.2.0"
     http-proxy-middleware: "npm:^2.0.6"
+    ipaddr.js: "npm:^2.3.0"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
     node-fetch: "npm:^2.7.0"
     split2: "npm:^4.2.0"
-  checksum: 10/47d5a4214904a43b1d067d156aa0fe9bb3370cdc6a4a5b35e7ed491ecc0aa8f00bcad19aa2423a0fab3025280e47c5760eb5a0a93f5163aa375acfa7c0ba3772
+  checksum: 10/daf80af94d4f0e53240e7ca24aa2530b266c0cc4b089c19a07f3ca15fd84a93b47b4aaf8381729db4373bc04fcb8daf0709fc4e7b6972129de5c2241547f9590
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-common@npm:0.9.13-next.0":
-  version: 0.9.13-next.0
-  resolution: "@backstage/plugin-kubernetes-common@npm:0.9.13-next.0"
+"@backstage/plugin-kubernetes-common@npm:0.9.13-next.1":
+  version: 0.9.13-next.1
+  resolution: "@backstage/plugin-kubernetes-common@npm:0.9.13-next.1"
   dependencies:
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/plugin-permission-common": "npm:0.9.10"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
     "@backstage/types": "npm:1.2.2"
     "@kubernetes/client-node": "npm:1.4.0"
     kubernetes-models: "npm:^4.3.1"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-  checksum: 10/47147d8cddd548e2125cbd9c9651714fb95ca738bd585c900851311f6bbc8f5fc76dbe8e74b9ef1c6ec09ecfdc3091ee866420c6cb1b138d9d97a01a15fce804
+  checksum: 10/d36f3b5e7ee073446c3fd9eff10aa3519baab39d8f8f5373a074625017d01486417f195f6374bc5031780f86a1b4b5609d897c6556c39e3a56305d07ae80785a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-node@npm:0.4.8-next.1":
-  version: 0.4.8-next.1
-  resolution: "@backstage/plugin-kubernetes-node@npm:0.4.8-next.1"
+"@backstage/plugin-kubernetes-node@npm:0.4.8-next.2":
+  version: 0.4.8-next.2
+  resolution: "@backstage/plugin-kubernetes-node@npm:0.4.8-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.13-next.0"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.13-next.1"
     "@backstage/types": "npm:1.2.2"
     "@kubernetes/client-node": "npm:1.4.0"
     "@types/express": "npm:^4.17.6"
     node-fetch: "npm:^2.7.0"
-  checksum: 10/adb6ca94f8d0e4366a5fefedacc32fa24b64a8b7c2b513c534513db4dbe122405ee1b7702f83cbe251e8aeffb0b4ec9720a4eb623d49e50fc42e6f165e4c3192
+  checksum: 10/92dacabe909e828d56edc723755e3b84a967bc34a50db0b2980d9c7eecd615e4c8e0b554318fd3118163f4774e6701adb1feda7090d40677e49ecb9b5954632c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-react@npm:0.5.24-next.1":
-  version: 0.5.24-next.1
-  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.24-next.1"
+"@backstage/plugin-kubernetes-react@npm:0.6.0-next.2":
+  version: 0.6.0-next.2
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.6.0-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.13-next.0"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.13-next.1"
     "@backstage/types": "npm:1.2.2"
     "@kubernetes-models/apimachinery": "npm:^2.0.0"
     "@kubernetes-models/base": "npm:^5.0.0"
@@ -4428,22 +4744,22 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/144b91237e11f73816a383ddb2e010f5effeed70563045da3ca374b622b023c57e7b4541c59cd9824fcb57a80767ac86c4d380bee35bab7dfffbe26451b79b55
+  checksum: 10/ac4c10a35e5c20cf65dcaa6e32b1ef11a96e0cee15044ec27def0aa79a27127164a9939d8a544db2324882db0cf2989e2e95a44d3cd4a6cd0a82c36e61f71d58
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@backstage:^::backstage=1.55.0-next.1&npm=0.12.23-next.1, @backstage/plugin-kubernetes@npm:^0.12.23-next.1":
-  version: 0.12.23-next.1
-  resolution: "@backstage/plugin-kubernetes@npm:0.12.23-next.1"
+"@backstage/plugin-kubernetes@backstage:^::backstage=1.55.0-next.2&npm=0.12.23-next.2, @backstage/plugin-kubernetes@npm:^0.12.23-next.2":
+  version: 0.12.23-next.2
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.23-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:3.2.3-next.1"
-    "@backstage/plugin-kubernetes-common": "npm:0.9.13-next.0"
-    "@backstage/plugin-kubernetes-react": "npm:0.5.24-next.1"
-    "@backstage/plugin-permission-react": "npm:0.5.5-next.0"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:3.2.3-next.2"
+    "@backstage/plugin-kubernetes-common": "npm:0.9.13-next.1"
+    "@backstage/plugin-kubernetes-react": "npm:0.6.0-next.2"
+    "@backstage/plugin-permission-react": "npm:0.5.5-next.1"
     "@material-ui/core": "npm:^4.12.2"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
@@ -4453,19 +4769,19 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/7e601958a60065404200eb2581f9d26d3d685dcd41f6a90a2984ec7e51a06dc76e349262c529a26d389d4a5710206b848525d71b2d544a6dfae1c6de29fa22ca
+  checksum: 10/3843de9de55795343a43a147f027e2c5f56e843ea95e0a147ebeebfd842166f91f6ae6b73d79f91eb1ac34cf296eb99ef922aac7410d36de8867b5da88f209d2
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.55.0-next.1&npm=0.2.2-next.0, @backstage/plugin-mcp-actions-backend@npm:^0.2.2-next.0":
-  version: 0.2.2-next.0
-  resolution: "@backstage/plugin-mcp-actions-backend@npm:0.2.2-next.0"
+"@backstage/plugin-mcp-actions-backend@backstage:^::backstage=1.55.0-next.2&npm=0.2.2-next.1, @backstage/plugin-mcp-actions-backend@npm:^0.2.2-next.1":
+  version: 0.2.2-next.1
+  resolution: "@backstage/plugin-mcp-actions-backend@npm:0.2.2-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/catalog-client": "npm:1.16.2-next.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
     "@backstage/types": "npm:1.2.2"
     "@cfworker/json-schema": "npm:^4.1.1"
     "@modelcontextprotocol/sdk": "npm:^1.25.2"
@@ -4473,11 +4789,11 @@ __metadata:
     express-promise-router: "npm:^4.1.0"
     minimatch: "npm:^10.2.1"
     zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10/0a2246e7b7b24b0c916b8286ef73078ac7cde8b3d2f34f1c796b0aef03590e8011d9fad28b5dd1830a4e7b7d66d963a046f10d87d4c88349170e6259129798eb
+  checksum: 10/63315daa1916b743e456a0e85742e6e51ae195b82569ed56a74dac8c83fa3a75811f6ee61986ecf521e9d9f08a69aa42e8d366992a81f0659e51d53a427db0a9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.55.0-next.1&npm=0.2.11-next.1, @backstage/plugin-mui-to-bui@npm:^0.2.11-next.1":
+"@backstage/plugin-mui-to-bui@backstage:^::backstage=1.55.0-next.2&npm=0.2.11-next.1, @backstage/plugin-mui-to-bui@npm:^0.2.11-next.1":
   version: 0.2.11-next.1
   resolution: "@backstage/plugin-mui-to-bui@npm:0.2.11-next.1"
   dependencies:
@@ -4499,60 +4815,60 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@backstage:^::backstage=1.55.0-next.1&npm=0.6.9-next.0, @backstage/plugin-notifications-backend@npm:^0.6.9-next.0":
-  version: 0.6.9-next.0
-  resolution: "@backstage/plugin-notifications-backend@npm:0.6.9-next.0"
+"@backstage/plugin-notifications-backend@backstage:^::backstage=1.55.0-next.2&npm=0.6.9-next.1, @backstage/plugin-notifications-backend@npm:^0.6.9-next.1":
+  version: 0.6.9-next.1
+  resolution: "@backstage/plugin-notifications-backend@npm:0.6.9-next.1"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.7.2-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
-    "@backstage/plugin-notifications-common": "npm:0.2.3"
-    "@backstage/plugin-notifications-node": "npm:0.2.30-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
+    "@backstage/plugin-notifications-common": "npm:0.2.4-next.0"
+    "@backstage/plugin-notifications-node": "npm:0.2.30-next.1"
     "@backstage/plugin-signals-node": "npm:0.2.5-next.0"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     p-throttle: "npm:^4.1.1"
-  checksum: 10/731bfea4b74b03228e151b38b838909320a29cc756547cf1e01813cea49297ad1d9a77df8018d95c939d3d5e72685744befbbcbcaeeced62a75929935a410a47
+  checksum: 10/d86baf4eb19803be2927c089c25c6756a9630a91b504f930c866f13d904940a00297e9754f128608a455c783ac77de9f073b1537597bb51e2d8dcd64c3d3e89a
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-common@npm:0.2.3":
-  version: 0.2.3
-  resolution: "@backstage/plugin-notifications-common@npm:0.2.3"
+"@backstage/plugin-notifications-common@npm:0.2.4-next.0":
+  version: 0.2.4-next.0
+  resolution: "@backstage/plugin-notifications-common@npm:0.2.4-next.0"
   dependencies:
-    "@backstage/config": "npm:^1.3.8"
-    "@backstage/types": "npm:^1.2.2"
-  checksum: 10/61cbff7455d49ea21210d946d7c2fa752bd265299a6fd739a56708987f8d442c10033046c8867ebe1c9947a980490e9363586c969fb4a4ad2c0c7b4427377616
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/types": "npm:1.2.2"
+  checksum: 10/82f32debaafd419a59ddde5a4f36e8ab237b551cf916a3c6d31dc337c7717ae3e47edcbe1e09e6da83e4cadabcc8021bb63751ddc83fdb58faf238db767ca0c7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@backstage:^::backstage=1.55.0-next.1&npm=0.2.30-next.0, @backstage/plugin-notifications-node@npm:0.2.30-next.0, @backstage/plugin-notifications-node@npm:^0.2.30-next.0":
-  version: 0.2.30-next.0
-  resolution: "@backstage/plugin-notifications-node@npm:0.2.30-next.0"
+"@backstage/plugin-notifications-node@backstage:^::backstage=1.55.0-next.2&npm=0.2.30-next.1, @backstage/plugin-notifications-node@npm:0.2.30-next.1, @backstage/plugin-notifications-node@npm:^0.2.30-next.1":
+  version: 0.2.30-next.1
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.30-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/plugin-notifications-common": "npm:0.2.3"
-  checksum: 10/96db51d895d5561af017352b72593cc394d9357adfa09909bf51ba6db154754892cf35a1cb1e8de4a0d3c61ef0cc949321b4e0dee34b2b2d9572d21c68291282
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/plugin-notifications-common": "npm:0.2.4-next.0"
+  checksum: 10/fe69a173eab82e4f42bde5ac07ff33920e8915ac0a2578010b6e23841e2c1e863123ae52d2e7f88db72eb298872b599205e44a40f42095a510712f3a1df17f19
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@backstage:^::backstage=1.55.0-next.1&npm=0.5.21-next.1, @backstage/plugin-notifications@npm:^0.5.21-next.1":
-  version: 0.5.21-next.1
-  resolution: "@backstage/plugin-notifications@npm:0.5.21-next.1"
+"@backstage/plugin-notifications@backstage:^::backstage=1.55.0-next.2&npm=0.5.21-next.2, @backstage/plugin-notifications@npm:^0.5.21-next.2":
+  version: 0.5.21-next.2
+  resolution: "@backstage/plugin-notifications@npm:0.5.21-next.2"
   dependencies:
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/plugin-notifications-common": "npm:0.2.3"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/plugin-notifications-common": "npm:0.2.4-next.0"
     "@backstage/plugin-signals-react": "npm:0.0.26-next.0"
     "@backstage/theme": "npm:0.7.3"
-    "@backstage/ui": "npm:0.18.0-next.1"
+    "@backstage/ui": "npm:0.18.0-next.2"
     "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     lodash: "npm:^4.17.21"
     notistack: "npm:^3.0.1"
@@ -4567,21 +4883,21 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/18f37113252189c6ba6ba110959d841c07b6d3ae216af5b680ec41ab6fbc324a686fe6ad0610f2a32071b728e184eae356d01ad316096ae79edcd38e06b8597e
+  checksum: 10/eb1dce99ce1cc0da03a054295d8b519e93bd0ecbac18d50d2bc524318633da3f372132b6e5222dad96eaada490b917194745ba5fd90ac2489502a7cd741fb4d9
   languageName: node
   linkType: hard
 
-"@backstage/plugin-org@backstage:^::backstage=1.55.0-next.1&npm=0.7.9-next.1, @backstage/plugin-org@npm:^0.7.9-next.1":
-  version: 0.7.9-next.1
-  resolution: "@backstage/plugin-org@npm:0.7.9-next.1"
+"@backstage/plugin-org@backstage:^::backstage=1.55.0-next.2&npm=0.7.9-next.2, @backstage/plugin-org@npm:^0.7.9-next.2":
+  version: 0.7.9-next.2
+  resolution: "@backstage/plugin-org@npm:0.7.9-next.2"
   dependencies:
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.3-next.1"
-    "@backstage/ui": "npm:0.18.0-next.1"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.3-next.2"
+    "@backstage/ui": "npm:0.18.0-next.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -4600,7 +4916,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/b66daf844abdede30a46435ae7bf3b0b13a7c9593b72059c9d9677ab2ee154c75ca4996a29bdf33c78fa9404d2b0184c9da93044e6443fd2b5aeeb448d7278ef
+  checksum: 10/5356d74b5a660c82f0cd4efba32d6600cf164cd60a6f3921f9e5ffac33ae768eab2c163b3c30677979888ab985d2f441a0b55a7f34d278fd1bd956fca260b92a
   languageName: node
   linkType: hard
 
@@ -4615,6 +4931,20 @@ __metadata:
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   checksum: 10/5fc83f54b5a7a19a25dec574a1bd8cfda310d0fa99a64f9e128ac4e55712df3cce0422b94edfeac322795160c8708bd28986be0d4f0ad5ade453c423e4483bee
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-common@npm:0.9.11-next.0":
+  version: 0.9.11-next.0
+  resolution: "@backstage/plugin-permission-common@npm:0.9.11-next.0"
+  dependencies:
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/types": "npm:1.2.2"
+    cross-fetch: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10/f0598c88065b17fb2871512669bc9d524e278ae11b7fb09712b95cebb1728168b41cae61f5a8538f18c6c720aa090dd7029a99513492f2e09924dbbdf6d77f8d
   languageName: node
   linkType: hard
 
@@ -4633,6 +4963,24 @@ __metadata:
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   checksum: 10/eade3d7e9ffd110e0f15dcbbbbb200b35e4ff520f1595ec60b9b62078e6cefa750025477c11789bff69f305dfb74b5487653d94833595c66c2c4b50c31a18bfe
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-node@npm:0.11.4-next.1":
+  version: 0.11.4-next.1
+  resolution: "@backstage/plugin-permission-node@npm:0.11.4-next.1"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/express": "npm:^4.17.6"
+    express: "npm:^4.22.0"
+    express-promise-router: "npm:^4.1.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  checksum: 10/bc199a9ab59def8df2893aba5305f730da84228300d9a63d61bd22078327b9adadf69068342811bbc1b7d05d2ca5e9537accfbcd4788bfaccd2ea9a1dcebe5e5
   languageName: node
   linkType: hard
 
@@ -4674,6 +5022,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-react@npm:0.5.5-next.1":
+  version: 0.5.5-next.1
+  resolution: "@backstage/plugin-permission-react@npm:0.5.5-next.1"
+  dependencies:
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    dataloader: "npm:^2.0.0"
+    swr: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/6af711982043298272b8471860c3bf7444f79df373d4a1e40900c99e75f0146d293642db17bc412143d61e085170629c49dc43928d7eebeab42953a3118554c7
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-react@npm:^0.5.4":
   version: 0.5.4
   resolution: "@backstage/plugin-permission-react@npm:0.5.4"
@@ -4694,7 +5062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-proxy-backend@backstage:^::backstage=1.55.0-next.1&npm=0.6.18-next.0, @backstage/plugin-proxy-backend@npm:^0.6.18-next.0":
+"@backstage/plugin-proxy-backend@backstage:^::backstage=1.55.0-next.2&npm=0.6.18-next.0, @backstage/plugin-proxy-backend@npm:^0.6.18-next.0":
   version: 0.6.18-next.0
   resolution: "@backstage/plugin-proxy-backend@npm:0.6.18-next.0"
   dependencies:
@@ -4717,17 +5085,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.55.0-next.1&npm=0.9.14-next.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.14-next.1":
-  version: 0.9.14-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.14-next.1"
+"@backstage/plugin-scaffolder-backend-module-github@backstage:^::backstage=1.55.0-next.2&npm=0.9.14-next.2, @backstage/plugin-scaffolder-backend-module-github@npm:^0.9.14-next.2":
+  version: 0.9.14-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.9.14-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.13.7-next.1"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.13.7-next.2"
     "@backstage/types": "npm:1.2.2"
     "@octokit/core": "npm:^5.0.0"
     "@octokit/plugin-retry": "npm:^6.0.0"
@@ -4737,39 +5105,39 @@ __metadata:
     octokit-plugin-create-pull-request: "npm:^5.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10/15a5189fcf841c9c92f4b1ec1989e5e56495cbaeca9aaa0545c49fb8582affee1faf4f537b3c132d23936d97143e7280f7d479f8df7241d91faf877de5c2ebb6
+  checksum: 10/6cc82ac4c0ffda27a117b71548911000a0f543f52acac5ebc5cfb1f5c6b0a168466bc83fbdf8348e9c8e795a050da0e8f3df0c31eb522ba34df44a2b92407a74
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.55.0-next.1&npm=0.1.26-next.1, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.26-next.1":
-  version: 0.1.26-next.1
-  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.26-next.1"
+"@backstage/plugin-scaffolder-backend-module-notifications@backstage:^::backstage=1.55.0-next.2&npm=0.1.26-next.2, @backstage/plugin-scaffolder-backend-module-notifications@npm:^0.1.26-next.2":
+  version: 0.1.26-next.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-notifications@npm:0.1.26-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/plugin-notifications-common": "npm:0.2.3"
-    "@backstage/plugin-notifications-node": "npm:0.2.30-next.0"
-    "@backstage/plugin-scaffolder-node": "npm:0.13.7-next.1"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/plugin-notifications-common": "npm:0.2.4-next.0"
+    "@backstage/plugin-notifications-node": "npm:0.2.30-next.1"
+    "@backstage/plugin-scaffolder-node": "npm:0.13.7-next.2"
     yaml: "npm:^2.0.0"
-  checksum: 10/8e84f49b3bfb2d60df12cde332cb07be52f8b7169ba6349e63b4791d376a71a2f927bd5720f610a56867ea300f332f57285bad4cff66a67540c9180c2057f778
+  checksum: 10/0e4dc61e342338612f0e567f091c17718c83ebdb067e376e849b5c8d38f53974a6226f8650be2c53a8f723c51ccdde521f81df9503bedfce64775d920840983f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.55.0-next.1&npm=4.2.0-next.1, @backstage/plugin-scaffolder-backend@npm:^4.2.0-next.1":
-  version: 4.2.0-next.1
-  resolution: "@backstage/plugin-scaffolder-backend@npm:4.2.0-next.1"
+"@backstage/plugin-scaffolder-backend@backstage:^::backstage=1.55.0-next.2&npm=4.2.0-next.2, @backstage/plugin-scaffolder-backend@npm:^4.2.0-next.2":
+  version: 4.2.0-next.2
+  resolution: "@backstage/plugin-scaffolder-backend@npm:4.2.0-next.2"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.7.2-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
     "@backstage/plugin-events-node": "npm:0.4.26-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.10"
-    "@backstage/plugin-permission-node": "npm:0.11.4-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.1"
-    "@backstage/plugin-scaffolder-node": "npm:0.13.7-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-permission-node": "npm:0.11.4-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.2"
+    "@backstage/plugin-scaffolder-node": "npm:0.13.7-next.2"
     "@backstage/types": "npm:1.2.2"
     "@types/luxon": "npm:^3.0.0"
     express: "npm:^4.22.0"
@@ -4791,7 +5159,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10/96540f9788cd08a0a506d788875941d62cc8423c4305dda40cfda99ed31fec18dd18f7dec952494908829fe2b4cba3b87edde257289825bf8ccd6d25673dd9dd
+  checksum: 10/f0b33d11a61f57541e8d06f6e6ea132c01afe713dd0d30e7635f0f493617697090624d40eac6e5003e7be27db96fed1b08dca99957beaf025fba2c77a9922e59
   languageName: node
   linkType: hard
 
@@ -4813,17 +5181,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:0.13.7-next.1":
-  version: 0.13.7-next.1
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.13.7-next.1"
+"@backstage/plugin-scaffolder-common@npm:2.3.0-next.2":
+  version: 2.3.0-next.2
+  resolution: "@backstage/plugin-scaffolder-common@npm:2.3.0-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
     "@backstage/catalog-model": "npm:1.10.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.10"
-    "@backstage/plugin-permission-node": "npm:0.11.4-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.1"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/types": "npm:1.2.2"
+    "@microsoft/fetch-event-source": "npm:^2.0.1"
+    "@types/json-schema": "npm:^7.0.9"
+    cross-fetch: "npm:^4.0.0"
+    uri-template: "npm:^2.0.0"
+    zen-observable: "npm:^0.10.0"
+  checksum: 10/af5878bbe7ee0b419b84ea03c91349a4d51f3e20ad10fc84d4292ffc307b4bc6fc33692d4bc50bd3b4359cde24768259c0dc4f7c7c70c1033966c40e334af015
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-node@npm:0.13.7-next.2":
+  version: 0.13.7-next.2
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.13.7-next.2"
+  dependencies:
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/catalog-model": "npm:1.10.0"
+    "@backstage/errors": "npm:1.3.1"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-permission-node": "npm:0.11.4-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.2"
     "@backstage/types": "npm:1.2.2"
     "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
     concat-stream: "npm:^2.0.0"
@@ -4839,11 +5225,11 @@ __metadata:
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   peerDependencies:
-    "@backstage/backend-test-utils": 1.11.7-next.0
+    "@backstage/backend-test-utils": 1.11.7-next.1
   peerDependenciesMeta:
     "@backstage/backend-test-utils":
       optional: true
-  checksum: 10/d7617109869cf0099e56e208e2ce8e073a93be4799dfed5b8f51ff96f199a987e41ade9dc8d23186c59434c2b37da6356d94613634c125973a1301bd58106e48
+  checksum: 10/90b766b05308e4ca7a617ff22c79aac269ee59551135bbe8ad93e1c53b3fd9bf83add0bf4087f2a459d1c5ed46a3ea0e950cf88a15349fb9ce945c55802406f1
   languageName: node
   linkType: hard
 
@@ -4905,28 +5291,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder@backstage:^::backstage=1.55.0-next.1&npm=1.39.0-next.1, @backstage/plugin-scaffolder@npm:^1.39.0-next.1":
-  version: 1.39.0-next.1
-  resolution: "@backstage/plugin-scaffolder@npm:1.39.0-next.1"
+"@backstage/plugin-scaffolder@backstage:^::backstage=1.55.0-next.2&npm=1.39.0-next.2, @backstage/plugin-scaffolder@npm:^1.39.0-next.2":
+  version: 1.39.0-next.2
+  resolution: "@backstage/plugin-scaffolder@npm:1.39.0-next.2"
   dependencies:
-    "@backstage/catalog-client": "npm:1.16.2-next.0"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/filter-predicates": "npm:0.1.5-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/integration-react": "npm:1.2.22-next.0"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-react": "npm:3.2.3-next.1"
-    "@backstage/plugin-permission-react": "npm:0.5.5-next.0"
-    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.1"
+    "@backstage/filter-predicates": "npm:0.1.5-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/integration-react": "npm:1.2.22-next.1"
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    "@backstage/plugin-catalog-react": "npm:3.2.3-next.2"
+    "@backstage/plugin-permission-react": "npm:0.5.5-next.1"
+    "@backstage/plugin-scaffolder-common": "npm:2.3.0-next.2"
     "@backstage/plugin-scaffolder-react": "npm:2.1.0-next.1"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.15-next.1"
+    "@backstage/plugin-techdocs-react": "npm:1.3.15-next.2"
     "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.18.0-next.1"
+    "@backstage/ui": "npm:0.18.0-next.2"
     "@codemirror/language": "npm:^6.0.0"
     "@codemirror/legacy-modes": "npm:^6.1.0"
     "@codemirror/view": "npm:^6.0.0"
@@ -4965,42 +5351,42 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/531405898ad2df7fbe6f54b108957083f1fae3e673d547afc7c05a58727aa81e37197492b29bcca0b1d2c543fc2bd8b520c734ce547d770c16b14b828c5f60bc
+  checksum: 10/79b5e78cc105dd00e9a5f541aeb7c51e3b764fbe9d06bb9f4f38ab044d0408708adf28319aefa6f8281dd501e8c5b3113a2da88ee0140f631942f63e680bc29c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.55.0-next.1&npm=0.3.19-next.1, @backstage/plugin-search-backend-module-catalog@npm:^0.3.19-next.1":
-  version: 0.3.19-next.1
-  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.19-next.1"
+"@backstage/plugin-search-backend-module-catalog@backstage:^::backstage=1.55.0-next.2&npm=0.3.19-next.2, @backstage/plugin-search-backend-module-catalog@npm:^0.3.19-next.2":
+  version: 0.3.19-next.2
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.19-next.2"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/catalog-client": "npm:1.16.2-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-catalog-common": "npm:1.1.10"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
-    "@backstage/plugin-permission-common": "npm:0.9.10"
-    "@backstage/plugin-search-backend-node": "npm:1.4.8-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.24"
-  checksum: 10/e274b1e6bf6a3c8add34aa8d484edc97c33c217ef115eab59b48974e765c42643dbbd2d0435cd98f0dc8a849296fc5a7c563308a968b7bfd24bb61bcdb6a940c
+    "@backstage/plugin-catalog-common": "npm:1.2.0-next.0"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-search-backend-node": "npm:1.4.8-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.25-next.0"
+  checksum: 10/762b7141cbf8fda5d3f6990eecee7df47022de5329a6e88add1e724cff20f319d4e2da5b55815b8b7f3408f663c8bfae8ddb7c1627a8f8d4873297107785df72
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-node@npm:1.4.8-next.0":
-  version: 1.4.8-next.0
-  resolution: "@backstage/plugin-search-backend-node@npm:1.4.8-next.0"
+"@backstage/plugin-search-backend-node@npm:1.4.8-next.1":
+  version: 1.4.8-next.1
+  resolution: "@backstage/plugin-search-backend-node@npm:1.4.8-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-permission-common": "npm:0.9.10"
-    "@backstage/plugin-search-common": "npm:1.2.24"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.25-next.0"
     "@types/lunr": "npm:^2.3.3"
     lodash: "npm:^4.17.21"
     lunr: "npm:^2.3.9"
     ndjson: "npm:^2.0.0"
-  checksum: 10/cbe1e5314b6ea03ac43b58f783a25f2f1876ad2305e5e428501db5747b2cfa47f4fa47ba0030a10b5bfbdc50a3d1b55721083210bac97f7fd22112dd5ac1524d
+  checksum: 10/ba6906bcc5e3ec1b1c6d182e28913fb77f6f6de1bfa74b17d33fc5a4c066ea951802b2c139af03ffe5407d47167745803004592552101e346e82e680aa87d112
   languageName: node
   linkType: hard
 
@@ -5021,29 +5407,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend@backstage:^::backstage=1.55.0-next.1&npm=2.1.7-next.1, @backstage/plugin-search-backend@npm:^2.1.7-next.1":
-  version: 2.1.7-next.1
-  resolution: "@backstage/plugin-search-backend@npm:2.1.7-next.1"
+"@backstage/plugin-search-backend@backstage:^::backstage=1.55.0-next.2&npm=2.1.7-next.2, @backstage/plugin-search-backend@npm:^2.1.7-next.2":
+  version: 2.1.7-next.2
+  resolution: "@backstage/plugin-search-backend@npm:2.1.7-next.2"
   dependencies:
     "@backstage/backend-openapi-utils": "npm:0.7.2-next.0"
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/plugin-permission-common": "npm:0.9.10"
-    "@backstage/plugin-permission-node": "npm:0.11.4-next.0"
-    "@backstage/plugin-search-backend-node": "npm:1.4.8-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.24"
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/plugin-permission-node": "npm:0.11.4-next.1"
+    "@backstage/plugin-search-backend-node": "npm:1.4.8-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.25-next.0"
     "@backstage/types": "npm:1.2.2"
     dataloader: "npm:^2.0.0"
     express: "npm:^4.22.0"
     lodash: "npm:^4.17.21"
     qs: "npm:^6.15.2"
     zod: "npm:^3.25.76 || ^4.0.0"
-  checksum: 10/4437e10015f38beef3c2286dc1c0a24c2ffe1b3fb208444e2d1bd6931ed8d038277ef44c2cc2fe77b1d8ae9879ff59909013e390c2b410273d039407a7834bfa
+  checksum: 10/00e82e0eb80f1dd0ec93b43e01d75c4fff505027d4fd11ee9b1198f892fa24dfd4f79dfd5be257a541765e14acefcb22401908f1adb67d06e3cb5f60f7f8eda7
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-common@npm:1.2.24, @backstage/plugin-search-common@npm:^1.2.24":
+"@backstage/plugin-search-common@npm:1.2.25-next.0":
+  version: 1.2.25-next.0
+  resolution: "@backstage/plugin-search-common@npm:1.2.25-next.0"
+  dependencies:
+    "@backstage/plugin-permission-common": "npm:0.9.11-next.0"
+    "@backstage/types": "npm:1.2.2"
+  checksum: 10/082edb94ca30970a1ec79792a2a75f2f55bd855edee65b353e806f32be99efe53bbd9e99801ca137afd2c710196dbfab129183cd78986c0430cc1331cc2bdfbe
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-common@npm:^1.2.24":
   version: 1.2.24
   resolution: "@backstage/plugin-search-common@npm:1.2.24"
   dependencies:
@@ -5053,14 +5449,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-react@backstage:^::backstage=1.55.0-next.1&npm=1.11.8-next.1, @backstage/plugin-search-react@npm:1.11.8-next.1, @backstage/plugin-search-react@npm:^1.11.8-next.1":
-  version: 1.11.8-next.1
-  resolution: "@backstage/plugin-search-react@npm:1.11.8-next.1"
+"@backstage/plugin-search-react@backstage:^::backstage=1.55.0-next.2&npm=1.11.8-next.2, @backstage/plugin-search-react@npm:1.11.8-next.2, @backstage/plugin-search-react@npm:^1.11.8-next.2":
+  version: 1.11.8-next.2
+  resolution: "@backstage/plugin-search-react@npm:1.11.8-next.2"
   dependencies:
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/plugin-search-common": "npm:1.2.24"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.25-next.0"
     "@backstage/theme": "npm:0.7.3"
     "@backstage/types": "npm:1.2.2"
     "@backstage/version-bridge": "npm:1.0.12"
@@ -5079,7 +5475,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/8d8da3f5a909088952ed678eeb0dd83d430dcf092d6ee7bdd2ce39f3cd8b3ca0c6cc8dca1742a29075b28a9876a25d3773516c3f36302736cab8e988cfdb9929
+  checksum: 10/7c12873fe82c08f1ac350da2548208b7b1a79b105a177281fa82075d8cf530fa37b39a492b097a04f66069f18630f2cdeeae256533473738fc3f673c2431c7fc
   languageName: node
   linkType: hard
 
@@ -5113,20 +5509,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search@backstage:^::backstage=1.55.0-next.1&npm=1.7.8-next.1, @backstage/plugin-search@npm:^1.7.8-next.1":
-  version: 1.7.8-next.1
-  resolution: "@backstage/plugin-search@npm:1.7.8-next.1"
+"@backstage/plugin-search@backstage:^::backstage=1.55.0-next.2&npm=1.7.8-next.2, @backstage/plugin-search@npm:^1.7.8-next.2":
+  version: 1.7.8-next.2
+  resolution: "@backstage/plugin-search@npm:1.7.8-next.2"
   dependencies:
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/plugin-catalog-react": "npm:3.2.3-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/plugin-catalog-react": "npm:3.2.3-next.2"
     "@backstage/plugin-home-react": "npm:0.1.42-next.1"
-    "@backstage/plugin-search-common": "npm:1.2.24"
-    "@backstage/plugin-search-react": "npm:1.11.8-next.1"
+    "@backstage/plugin-search-common": "npm:1.2.25-next.0"
+    "@backstage/plugin-search-react": "npm:1.11.8-next.2"
     "@backstage/types": "npm:1.2.2"
-    "@backstage/ui": "npm:0.18.0-next.1"
+    "@backstage/ui": "npm:0.18.0-next.2"
     "@backstage/version-bridge": "npm:1.0.12"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
@@ -5141,23 +5537,23 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3792799a9ed59d017c79e067169558998e50c88434f4e03e0a8d13925bbd5fdc8a79d01b21658cd1bdc6314c7b410d1ccb7c16fe0ac384305ff59d5ff05d5105
+  checksum: 10/350bcb20ff711aadb00f02db3a68595e25bef22510bdc01bebe6ecb8f84d38dbb766baf914a11e5a8c0eb7253cb97758495bc5491d29e2f814e01e2719f1b19b
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@backstage:^::backstage=1.55.0-next.1&npm=0.3.19-next.0, @backstage/plugin-signals-backend@npm:^0.3.19-next.0":
-  version: 0.3.19-next.0
-  resolution: "@backstage/plugin-signals-backend@npm:0.3.19-next.0"
+"@backstage/plugin-signals-backend@backstage:^::backstage=1.55.0-next.2&npm=0.3.19-next.1, @backstage/plugin-signals-backend@npm:^0.3.19-next.1":
+  version: 0.3.19-next.1
+  resolution: "@backstage/plugin-signals-backend@npm:0.3.19-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/plugin-events-node": "npm:0.4.26-next.0"
     "@backstage/plugin-signals-node": "npm:0.2.5-next.0"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     ws: "npm:^8.20.1"
-  checksum: 10/80fca25ba7aaf47d52f37045d707f56974759d484c3eb16757dda636abca5a0170b1dd1c954161c14ec2abebbe69f5b9e2cfcade7592897ee5e5c9468e809cfe
+  checksum: 10/362a8019dcfc92c74de40cc7eb56a6f4ae1e96885407a555ba68f69307b0fa5a7c64b620dc9eb99ed9b596b0211a8a9b87dd31fcdd2f675c26cca0fd85652ac6
   languageName: node
   linkType: hard
 
@@ -5191,7 +5587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@backstage:^::backstage=1.55.0-next.1&npm=0.0.35-next.1, @backstage/plugin-signals@npm:^0.0.35-next.1":
+"@backstage/plugin-signals@backstage:^::backstage=1.55.0-next.2&npm=0.0.35-next.1, @backstage/plugin-signals@npm:^0.0.35-next.1":
   version: 0.0.35-next.1
   resolution: "@backstage/plugin-signals@npm:0.0.35-next.1"
   dependencies:
@@ -5215,18 +5611,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.55.0-next.1&npm=2.3.0-next.0, @backstage/plugin-techdocs-backend@npm:^2.3.0-next.0":
-  version: 2.3.0-next.0
-  resolution: "@backstage/plugin-techdocs-backend@npm:2.3.0-next.0"
+"@backstage/plugin-techdocs-backend@backstage:^::backstage=1.55.0-next.2&npm=2.3.0-next.1, @backstage/plugin-techdocs-backend@npm:^2.3.0-next.1":
+  version: 2.3.0-next.1
+  resolution: "@backstage/plugin-techdocs-backend@npm:2.3.0-next.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
-    "@backstage/catalog-client": "npm:1.16.2-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/plugin-catalog-node": "npm:2.2.5-next.0"
-    "@backstage/plugin-techdocs-node": "npm:1.16.0-next.0"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/plugin-catalog-node": "npm:2.2.5-next.1"
+    "@backstage/plugin-techdocs-node": "npm:1.16.0-next.1"
     "@backstage/types": "npm:1.2.2"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
@@ -5234,7 +5630,7 @@ __metadata:
     knex: "npm:^3.0.0"
     p-limit: "npm:^3.1.0"
     winston: "npm:^3.2.1"
-  checksum: 10/288739dd3ddae62619bd80bb13e6b20eb08e6bc10ff60733b6843b239c618bfbc7dd48ffee931e24827afadf0157dfc6b18ede5cf08479ed75a2a3556db265ce
+  checksum: 10/3557063655673d966888bb128e9e7177e1083116c5032a92b5eccb7e48e6e2f4c816673fef1d6103fd52f20b1b019662dd045332c43718d1b7cb06924a5da392
   languageName: node
   linkType: hard
 
@@ -5245,7 +5641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.55.0-next.1&npm=1.1.40-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.40-next.1":
+"@backstage/plugin-techdocs-module-addons-contrib@backstage:^::backstage=1.55.0-next.2&npm=1.1.40-next.1, @backstage/plugin-techdocs-module-addons-contrib@npm:^1.1.40-next.1":
   version: 1.1.40-next.1
   resolution: "@backstage/plugin-techdocs-module-addons-contrib@npm:1.1.40-next.1"
   dependencies:
@@ -5272,9 +5668,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@backstage:^::backstage=1.55.0-next.1&npm=1.16.0-next.0, @backstage/plugin-techdocs-node@npm:1.16.0-next.0, @backstage/plugin-techdocs-node@npm:^1.16.0-next.0":
-  version: 1.16.0-next.0
-  resolution: "@backstage/plugin-techdocs-node@npm:1.16.0-next.0"
+"@backstage/plugin-techdocs-node@backstage:^::backstage=1.55.0-next.2&npm=1.16.0-next.1, @backstage/plugin-techdocs-node@npm:1.16.0-next.1, @backstage/plugin-techdocs-node@npm:^1.16.0-next.1":
+  version: 1.16.0-next.1
+  resolution: "@backstage/plugin-techdocs-node@npm:1.16.0-next.1"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -5282,13 +5678,13 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-plugin-api": "npm:1.10.1-next.0"
+    "@backstage/backend-plugin-api": "npm:1.10.1-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
+    "@backstage/config": "npm:1.3.9-next.0"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/integration-aws-node": "npm:0.2.1"
-    "@backstage/plugin-search-common": "npm:1.2.24"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/integration-aws-node": "npm:0.2.2-next.0"
+    "@backstage/plugin-search-common": "npm:1.2.25-next.0"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
     "@google-cloud/storage": "npm:^7.0.0"
     "@smithy/node-http-handler": "npm:^3.0.0"
@@ -5305,11 +5701,39 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10/4386176cd54cefb06a34b84edb8d64b2abff3149d48183d28cf59bd96f5af255264a7dfeca2c151981e9b3fbf960478dad887198acf60be17c4dcb3beffdd4e6
+  checksum: 10/625c9e431560611d9e3fc9fd1975470c2eaf8d03bc6cbde1c3e01b205ba1b2b474a95bf43ed20833269d77d408a49ff3d8c093d969abdff5973659f9827fc79c
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-react@backstage:^::backstage=1.55.0-next.1&npm=1.3.15-next.1, @backstage/plugin-techdocs-react@npm:1.3.15-next.1, @backstage/plugin-techdocs-react@npm:^1.3.15-next.1":
+"@backstage/plugin-techdocs-react@backstage:^::backstage=1.55.0-next.2&npm=1.3.15-next.2, @backstage/plugin-techdocs-react@npm:1.3.15-next.2, @backstage/plugin-techdocs-react@npm:^1.3.15-next.2":
+  version: 1.3.15-next.2
+  resolution: "@backstage/plugin-techdocs-react@npm:1.3.15-next.2"
+  dependencies:
+    "@backstage/catalog-model": "npm:1.10.0"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/plugin-techdocs-common": "npm:0.1.1"
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/styles": "npm:^4.11.0"
+    jss: "npm:~10.10.0"
+    lodash: "npm:^4.17.21"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/147622057272011d3b59e4de292630508a43e3d798c54813d363fab1f0edd26764fd890b6938baf9c276c0fcc78aafaaa7fc736b3dca612be63d4158560b5fea
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs-react@npm:1.3.15-next.1":
   version: 1.3.15-next.1
   resolution: "@backstage/plugin-techdocs-react@npm:1.3.15-next.1"
   dependencies:
@@ -5365,27 +5789,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@backstage:^::backstage=1.55.0-next.1&npm=1.18.1-next.1, @backstage/plugin-techdocs@npm:^1.18.1-next.1":
-  version: 1.18.1-next.1
-  resolution: "@backstage/plugin-techdocs@npm:1.18.1-next.1"
+"@backstage/plugin-techdocs@backstage:^::backstage=1.55.0-next.2&npm=1.18.1-next.2, @backstage/plugin-techdocs@npm:^1.18.1-next.2":
+  version: 1.18.1-next.2
+  resolution: "@backstage/plugin-techdocs@npm:1.18.1-next.2"
   dependencies:
-    "@backstage/catalog-client": "npm:1.16.2-next.0"
+    "@backstage/catalog-client": "npm:1.16.2-next.1"
     "@backstage/catalog-model": "npm:1.10.0"
-    "@backstage/config": "npm:1.3.8"
-    "@backstage/core-components": "npm:0.18.14-next.1"
-    "@backstage/core-plugin-api": "npm:1.12.10-next.0"
+    "@backstage/config": "npm:1.3.9-next.0"
+    "@backstage/core-components": "npm:0.18.14-next.2"
+    "@backstage/core-plugin-api": "npm:1.12.10-next.1"
     "@backstage/errors": "npm:1.3.1"
-    "@backstage/frontend-plugin-api": "npm:0.18.1-next.0"
-    "@backstage/integration": "npm:2.1.2-next.0"
-    "@backstage/integration-react": "npm:1.2.22-next.0"
+    "@backstage/frontend-plugin-api": "npm:0.18.1-next.1"
+    "@backstage/integration": "npm:2.1.2-next.1"
+    "@backstage/integration-react": "npm:1.2.22-next.1"
     "@backstage/plugin-auth-react": "npm:0.1.31-next.1"
-    "@backstage/plugin-catalog-react": "npm:3.2.3-next.1"
-    "@backstage/plugin-search-common": "npm:1.2.24"
-    "@backstage/plugin-search-react": "npm:1.11.8-next.1"
+    "@backstage/plugin-catalog-react": "npm:3.2.3-next.2"
+    "@backstage/plugin-search-common": "npm:1.2.25-next.0"
+    "@backstage/plugin-search-react": "npm:1.11.8-next.2"
     "@backstage/plugin-techdocs-common": "npm:0.1.1"
-    "@backstage/plugin-techdocs-react": "npm:1.3.15-next.1"
+    "@backstage/plugin-techdocs-react": "npm:1.3.15-next.2"
     "@backstage/theme": "npm:0.7.3"
-    "@backstage/ui": "npm:0.18.0-next.1"
+    "@backstage/ui": "npm:0.18.0-next.2"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
@@ -5406,7 +5830,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/3606cd3d17f81d6fe2bbfe91e7dbc6b0bd2bae349e4cd2e22d2e7caaa6efe37c185f7519cfe40c421b80d730c16aa755611f73b28b840293a774a4368c6a2e4e
+  checksum: 10/b0c2a1b1c0446158904cc6f6561a814d563e493158db23f23f3778d22c62baa40f48825a67781fbe21dbaec0f4670e2e88347b4aa6dc54502d4f14e250aa1ad9
   languageName: node
   linkType: hard
 
@@ -5419,7 +5843,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@backstage:^::backstage=1.55.0-next.1&npm=0.9.7-next.1, @backstage/plugin-user-settings@npm:^0.9.7-next.1":
+"@backstage/plugin-user-settings@backstage:^::backstage=1.55.0-next.2&npm=0.9.7-next.1, @backstage/plugin-user-settings@npm:^0.9.7-next.1":
   version: 0.9.7-next.1
   resolution: "@backstage/plugin-user-settings@npm:0.9.7-next.1"
   dependencies:
@@ -5460,7 +5884,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@backstage:^::backstage=1.55.0-next.1&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.3":
+"@backstage/theme@backstage:^::backstage=1.55.0-next.2&npm=0.7.3, @backstage/theme@npm:0.7.3, @backstage/theme@npm:^0.7.3":
   version: 0.7.3
   resolution: "@backstage/theme@npm:0.7.3"
   dependencies:
@@ -5487,7 +5911,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@backstage:^::backstage=1.55.0-next.1&npm=0.18.0-next.1, @backstage/ui@npm:0.18.0-next.1, @backstage/ui@npm:^0.18.0-next.1":
+"@backstage/ui@backstage:^::backstage=1.55.0-next.2&npm=0.18.0-next.2, @backstage/ui@npm:0.18.0-next.2, @backstage/ui@npm:^0.18.0-next.2":
+  version: 0.18.0-next.2
+  resolution: "@backstage/ui@npm:0.18.0-next.2"
+  dependencies:
+    "@backstage/version-bridge": "npm:1.0.12"
+    "@braintree/sanitize-url": "npm:^7.1.2"
+    "@internationalized/date": "npm:^3.12.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
+    "@tanstack/react-table": "npm:^8.21.3"
+    clsx: "npm:^2.1.1"
+    marked: "npm:^15.0.12"
+    react-aria: "npm:~3.48.0"
+    react-aria-components: "npm:~1.17.0"
+    react-stately: "npm:~3.46.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    "@types/react": ^18.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/d7982fd6627d4556920c72baa8ce780272d59654add1cfef355e48582a555e8003b1f7930f6a75135c04780331c58f8032c7a0c34a5258c8e999a539782aa4de
+  languageName: node
+  linkType: hard
+
+"@backstage/ui@npm:0.18.0-next.1":
   version: 0.18.0-next.1
   resolution: "@backstage/ui@npm:0.18.0-next.1"
   dependencies:
@@ -6277,7 +6728,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0, @eslint-community/eslint-utils@npm:^4.9.1":
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
@@ -8229,75 +8680,70 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@module-federation/bridge-react-webpack-plugin@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/bridge-react-webpack-plugin@npm:2.4.0"
+"@module-federation/bridge-react-webpack-plugin@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/bridge-react-webpack-plugin@npm:2.8.2"
   dependencies:
-    "@module-federation/sdk": "npm:2.4.0"
-    "@types/semver": "npm:7.5.8"
-    semver: "npm:7.6.3"
-  checksum: 10/16db2288eddbd94bff32ce925bdbf60af5bdcf0dc51dd7e4ae42d80e20f8004413d92211fc22b6d1852e40cbb7ab4f553f906f584664cfd820fe8dbf5dfe5159
+    "@module-federation/sdk": "npm:2.8.2"
+  checksum: 10/b0b2c44c4223c09b668770a54dd22606ac1080a957d5243e0989ef35b8a81a6380e63f7a08ac434cd292dd303dc114b083385454bb11240b2aede7c15dd0f496
   languageName: node
   linkType: hard
 
-"@module-federation/cli@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/cli@npm:2.4.0"
+"@module-federation/cli@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/cli@npm:2.8.2"
   dependencies:
-    "@module-federation/dts-plugin": "npm:2.4.0"
-    "@module-federation/sdk": "npm:2.4.0"
+    "@module-federation/dts-plugin": "npm:2.8.2"
+    "@module-federation/sdk": "npm:2.8.2"
     commander: "npm:11.1.0"
     jiti: "npm:2.4.2"
   bin:
     mf: bin/mf.js
-  checksum: 10/8cbd5f8d6f97c5ed8406712176dbe124c31628ad259863665fc219d42306e154108253e7aafd298a44afc451d90ef2c816964136c787f845c64e8a99bead7b8b
+  checksum: 10/08fe421786df31230bd490af04fc3d8efb837f9ddec9b22e8be8a9bfecc5f82f757bb0b44d4ef0e3a77ced7d6a5488d47a4017eafabaf5efce74db62aa706e78
   languageName: node
   linkType: hard
 
-"@module-federation/dts-plugin@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/dts-plugin@npm:2.4.0"
+"@module-federation/dts-plugin@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/dts-plugin@npm:2.8.2"
   dependencies:
-    "@module-federation/error-codes": "npm:2.4.0"
-    "@module-federation/managers": "npm:2.4.0"
-    "@module-federation/sdk": "npm:2.4.0"
-    "@module-federation/third-party-dts-extractor": "npm:2.4.0"
-    adm-zip: "npm:0.5.10"
-    ansi-colors: "npm:4.1.3"
+    "@module-federation/error-codes": "npm:2.8.2"
+    "@module-federation/managers": "npm:2.8.2"
+    "@module-federation/sdk": "npm:2.8.2"
+    "@module-federation/third-party-dts-extractor": "npm:2.8.2"
+    adm-zip: "npm:0.6.0"
     isomorphic-ws: "npm:5.0.0"
-    node-schedule: "npm:2.1.1"
-    undici: "npm:7.24.7"
-    ws: "npm:8.18.0"
+    undici: "npm:7.29.0"
+    ws: "npm:8.21.0"
   peerDependencies:
-    typescript: ^4.9.0 || ^5.0.0
+    typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
     vue-tsc: ">=1.0.24"
   peerDependenciesMeta:
     vue-tsc:
       optional: true
-  checksum: 10/f89796b1f751dcbc518b9e9b202179ff6fc612425243f2c679e2092324d4f182d0e669ac0ef42e4d1f07d6a00755e503240d1e7d661fcf9604eff073f90fff8d
+  checksum: 10/f326d9c8f14bf4aec6c41aec6bcbe064fb912fbbb008f980d6993e9796497aae13eb0fce877486bff32abdc757425bc0685ce68b4920d9a1553b64b1300fb1c8
   languageName: node
   linkType: hard
 
-"@module-federation/enhanced@npm:^2.3.3":
-  version: 2.4.0
-  resolution: "@module-federation/enhanced@npm:2.4.0"
+"@module-federation/enhanced@npm:~2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/enhanced@npm:2.8.2"
   dependencies:
-    "@module-federation/bridge-react-webpack-plugin": "npm:2.4.0"
-    "@module-federation/cli": "npm:2.4.0"
-    "@module-federation/dts-plugin": "npm:2.4.0"
-    "@module-federation/error-codes": "npm:2.4.0"
-    "@module-federation/inject-external-runtime-core-plugin": "npm:2.4.0"
-    "@module-federation/managers": "npm:2.4.0"
-    "@module-federation/manifest": "npm:2.4.0"
-    "@module-federation/rspack": "npm:2.4.0"
-    "@module-federation/runtime-tools": "npm:2.4.0"
-    "@module-federation/sdk": "npm:2.4.0"
-    "@module-federation/webpack-bundler-runtime": "npm:2.4.0"
+    "@module-federation/bridge-react-webpack-plugin": "npm:2.8.2"
+    "@module-federation/cli": "npm:2.8.2"
+    "@module-federation/dts-plugin": "npm:2.8.2"
+    "@module-federation/error-codes": "npm:2.8.2"
+    "@module-federation/inject-external-runtime-core-plugin": "npm:2.8.2"
+    "@module-federation/managers": "npm:2.8.2"
+    "@module-federation/manifest": "npm:2.8.2"
+    "@module-federation/rspack": "npm:2.8.2"
+    "@module-federation/runtime-tools": "npm:2.8.2"
+    "@module-federation/sdk": "npm:2.8.2"
+    "@module-federation/webpack-bundler-runtime": "npm:2.8.2"
     schema-utils: "npm:4.3.0"
     tapable: "npm:2.3.0"
-    upath: "npm:2.0.1"
   peerDependencies:
-    typescript: ^4.9.0 || ^5.0.0
+    typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
     vue-tsc: ">=1.0.24"
     webpack: ^5.0.0
   peerDependenciesMeta:
@@ -8309,7 +8755,7 @@ __metadata:
       optional: true
   bin:
     mf: bin/mf.js
-  checksum: 10/25e20b3bb948fc7e02805334e12acc69b490934920d21bb1a011d14cad76fe3a219517e31086c3173a4c62c29847d709f67f1c1847c44efe83e0db26c9f3e575
+  checksum: 10/41ea5399e551796c9d69f0680a1391b632e3d9ef4424a25802b57cce1758bb9f3d15f5becaca6e86d1d42e0df952f9eff0a6ec6c34d4c42402a3895b2ca246d1
   languageName: node
   linkType: hard
 
@@ -8320,65 +8766,63 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@module-federation/error-codes@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/error-codes@npm:2.4.0"
-  checksum: 10/6b42f023006171ba86003e0f6c7d6811e4313f81f2de5960b135bd8dcb5dc16a79fb555ef4e00648de3cc474857ebc743247200d6d977b8fbd7486207bc94d00
+"@module-federation/error-codes@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/error-codes@npm:2.8.2"
+  checksum: 10/81d70499d6855d0779023778f8b7e0c9175453172ca27c382f9d4fd51f17391db48c0747f0946a0dc22d5f9b3ecc4e5d0baddfa696242f7e5e09c4e388d7e166
   languageName: node
   linkType: hard
 
-"@module-federation/inject-external-runtime-core-plugin@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/inject-external-runtime-core-plugin@npm:2.4.0"
+"@module-federation/inject-external-runtime-core-plugin@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/inject-external-runtime-core-plugin@npm:2.8.2"
   peerDependencies:
-    "@module-federation/runtime-tools": 2.4.0
-  checksum: 10/1c09fbab89f3001f81b4315b5018715dc0fbdc3a230e78c92c5ec74af545d4411dcf17ae88aca3e58ef0e1f44154af56cfeb90a6fbe89773771491b303caef1a
+    "@module-federation/runtime-tools": 2.8.2
+  checksum: 10/a997a47f17316efa74fb6d365b773e669cf3c83c94f0a6fe4804b3246a4b1b1b368374a49b9a3e99f1e09a2474879472571282dc5e0c1f9f4744d15bce832577
   languageName: node
   linkType: hard
 
-"@module-federation/managers@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/managers@npm:2.4.0"
+"@module-federation/managers@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/managers@npm:2.8.2"
   dependencies:
-    "@module-federation/sdk": "npm:2.4.0"
-    find-pkg: "npm:2.0.0"
-  checksum: 10/92ab17e317a327cf4f396a94bf7da2dcea4d517ec811bb25ffa9a1b8fa5ac7be03358d8a97f04ff1c5b8f09f41dcd84a28576ef9d9852fa76b7a64603c413920
+    "@module-federation/sdk": "npm:2.8.2"
+  checksum: 10/abf7ec3231125d7134faeae7395a9d9da4a1e5bc843e104666e30cd2f061c1c3afe9c2c34e7d547954164cd9ba9e24dbc29cfc08babd3dccd0a04d7e5f4758dd
   languageName: node
   linkType: hard
 
-"@module-federation/manifest@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/manifest@npm:2.4.0"
+"@module-federation/manifest@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/manifest@npm:2.8.2"
   dependencies:
-    "@module-federation/dts-plugin": "npm:2.4.0"
-    "@module-federation/managers": "npm:2.4.0"
-    "@module-federation/sdk": "npm:2.4.0"
-    find-pkg: "npm:2.0.0"
-  checksum: 10/377ff69bbbfaf661758af56bbe003de1c8ed089fe51f2e2991a6f84860ad212edaa49f5be77f8cb2680a419e27f33348f8cb050a9182a8b9bcb09ffb97421a04
+    "@module-federation/dts-plugin": "npm:2.8.2"
+    "@module-federation/managers": "npm:2.8.2"
+    "@module-federation/sdk": "npm:2.8.2"
+  checksum: 10/f6792351664b74e9195b4d966250faa46277d779bfdf2ba4c8903e7f47bb03c98c47a0707b174cc07a1029a023bc462ee293ba14cf641df670c955d3271a494c
   languageName: node
   linkType: hard
 
-"@module-federation/rspack@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/rspack@npm:2.4.0"
+"@module-federation/rspack@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/rspack@npm:2.8.2"
   dependencies:
-    "@module-federation/bridge-react-webpack-plugin": "npm:2.4.0"
-    "@module-federation/dts-plugin": "npm:2.4.0"
-    "@module-federation/inject-external-runtime-core-plugin": "npm:2.4.0"
-    "@module-federation/managers": "npm:2.4.0"
-    "@module-federation/manifest": "npm:2.4.0"
-    "@module-federation/runtime-tools": "npm:2.4.0"
-    "@module-federation/sdk": "npm:2.4.0"
+    "@module-federation/bridge-react-webpack-plugin": "npm:2.8.2"
+    "@module-federation/dts-plugin": "npm:2.8.2"
+    "@module-federation/inject-external-runtime-core-plugin": "npm:2.8.2"
+    "@module-federation/managers": "npm:2.8.2"
+    "@module-federation/manifest": "npm:2.8.2"
+    "@module-federation/runtime-tools": "npm:2.8.2"
+    "@module-federation/sdk": "npm:2.8.2"
   peerDependencies:
     "@rspack/core": ^0.7.0 || ^1.0.0 || ^2.0.0-0
-    typescript: ^4.9.0 || ^5.0.0
+    typescript: ^4.9.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
     vue-tsc: ">=1.0.24"
   peerDependenciesMeta:
     typescript:
       optional: true
     vue-tsc:
       optional: true
-  checksum: 10/f442a7781a7d3825be57b92b597a002aad5cf7f26339bd982445658f04be7c93213e73226815546b43a42a3aa36a5404722515f61ced8412efc6a48b030aca8b
+  checksum: 10/cccce9839770c79989157d7f69f830d8ed737c81b20f27f41391271d917e6674b0f3753417385524024c0544e0a53fecc9eef8eaeada3740b280c6da9c64ca7f
   languageName: node
   linkType: hard
 
@@ -8392,13 +8836,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@module-federation/runtime-core@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/runtime-core@npm:2.4.0"
+"@module-federation/runtime-core@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/runtime-core@npm:2.8.2"
   dependencies:
-    "@module-federation/error-codes": "npm:2.4.0"
-    "@module-federation/sdk": "npm:2.4.0"
-  checksum: 10/2d8fc964539cd00a21185da32852ccb5005124c894f7b1db023d087838f4dece78780ed2b82ace7fb928f6abac46bfb46f3dc9cfd07fa9fbdfdc66dd2bdb14f3
+    "@module-federation/error-codes": "npm:2.8.2"
+    "@module-federation/sdk": "npm:2.8.2"
+  checksum: 10/7899271733facc96351001eee107cd41c684ea0602cf772596e7043b38201d665926fc6a4e7a5b7a3dd99eea6f6e06c60bbd229b557a6bb70f53027228a0636d
   languageName: node
   linkType: hard
 
@@ -8412,13 +8856,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@module-federation/runtime-tools@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/runtime-tools@npm:2.4.0"
+"@module-federation/runtime-tools@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/runtime-tools@npm:2.8.2"
   dependencies:
-    "@module-federation/runtime": "npm:2.4.0"
-    "@module-federation/webpack-bundler-runtime": "npm:2.4.0"
-  checksum: 10/e4f955b17165aa4f069460940e7b15028d1ad2ce04123cb544304b960417e7b29f92ef8ead2303bbe022120a573e9af94e23269aa78df91a39c8eed279895b62
+    "@module-federation/runtime": "npm:2.8.2"
+    "@module-federation/webpack-bundler-runtime": "npm:2.8.2"
+  checksum: 10/b1af8d2a3339696b27e2f9c2325f598c9d0676a737c225203adb3c77024ba0b1e2ea38d88b76b8e00ee5fdcc4395040ec698c714c09708c3d0c468a367e280c7
   languageName: node
   linkType: hard
 
@@ -8433,14 +8877,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@module-federation/runtime@npm:2.4.0, @module-federation/runtime@npm:^2.3.3":
-  version: 2.4.0
-  resolution: "@module-federation/runtime@npm:2.4.0"
+"@module-federation/runtime@npm:2.8.2, @module-federation/runtime@npm:~2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/runtime@npm:2.8.2"
   dependencies:
-    "@module-federation/error-codes": "npm:2.4.0"
-    "@module-federation/runtime-core": "npm:2.4.0"
-    "@module-federation/sdk": "npm:2.4.0"
-  checksum: 10/37af511fc15de48449f0880dbf2fbac92aa4ce2fc92bea9b88a05ca3a763f96a9f069ef47ce1a74c615f192e53cee871fb3b13353da2c7fd3a2dd669bf6f7956
+    "@module-federation/error-codes": "npm:2.8.2"
+    "@module-federation/runtime-core": "npm:2.8.2"
+    "@module-federation/sdk": "npm:2.8.2"
+  checksum: 10/356ef46ffcaf173efdfbe82ed14f7f94a20d961c97c058580f455503ee4003fd69a9a67e7387b92ad600569fa659d808e9867ae2b370789cb4e781b9072c516c
   languageName: node
   linkType: hard
 
@@ -8451,25 +8895,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@module-federation/sdk@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/sdk@npm:2.4.0"
-  peerDependencies:
-    node-fetch: ^2.7.0 || ^3.3.2
-  peerDependenciesMeta:
-    node-fetch:
-      optional: true
-  checksum: 10/86d230b74b033b21cb515ddd164c8cead272f02af87fb650eae1d5b44bf43a8a027f1ae95228e6caf65df7af7015648fb342238ed53f45db14fca8a644b0689a
+"@module-federation/sdk@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/sdk@npm:2.8.2"
+  checksum: 10/11dd8653499e702d74dcea03352267cbd39d82aa2a429186ef15912f98fe719ccf7a7f63d4ececce8f7a3d3df73903991feeb80fe45a65016bcf733697215ffa
   languageName: node
   linkType: hard
 
-"@module-federation/third-party-dts-extractor@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/third-party-dts-extractor@npm:2.4.0"
-  dependencies:
-    find-pkg: "npm:2.0.0"
-    resolve: "npm:1.22.8"
-  checksum: 10/31ce5bfc58f6680b714e1cf40a5f1948be3b2d95458a90d17c126630a69b2b3254bb614b12bf410e505472bf3c9451670f6972d942a99a4f535e5a759b466827
+"@module-federation/third-party-dts-extractor@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/third-party-dts-extractor@npm:2.8.2"
+  checksum: 10/8db40f3fc73dfcb2e0d6412c79c386a697b1ff6ef25b85e425bbfa22597dcd0235122de7ac035096b0d7572c43f462024bd63ca4e5f4db1fbaafb0a87ee3e8f2
   languageName: node
   linkType: hard
 
@@ -8483,14 +8919,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@module-federation/webpack-bundler-runtime@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@module-federation/webpack-bundler-runtime@npm:2.4.0"
+"@module-federation/webpack-bundler-runtime@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@module-federation/webpack-bundler-runtime@npm:2.8.2"
   dependencies:
-    "@module-federation/error-codes": "npm:2.4.0"
-    "@module-federation/runtime": "npm:2.4.0"
-    "@module-federation/sdk": "npm:2.4.0"
-  checksum: 10/20e85c452c45dcc2bb875b00b20ad322af41998a8985707a306041a2cc437324052650c9a57c00fb51bd22679ee39893e4c0719563e8da132f687195d20c0c30
+    "@module-federation/error-codes": "npm:2.8.2"
+    "@module-federation/runtime": "npm:2.8.2"
+    "@module-federation/sdk": "npm:2.8.2"
+  checksum: 10/63474c6057af511d9af77f5896a772e34ba03a7c00c147a5abe654d9c3a1fef3573723535e45a2dcacb417a9b06b2a59538d8fedcc634e349338761e087f04b6
   languageName: node
   linkType: hard
 
@@ -15329,13 +15765,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:7.5.8":
-  version: 7.5.8
-  resolution: "@types/semver@npm:7.5.8"
-  checksum: 10/3496808818ddb36deabfe4974fd343a78101fa242c4690044ccdc3b95dcf8785b494f5d628f2f47f38a702f8db9c53c67f47d7818f2be1b79f2efb09692e1178
-  languageName: node
-  linkType: hard
-
 "@types/semver@npm:^7.1.0":
   version: 7.8.0
   resolution: "@types/semver@npm:7.8.0"
@@ -15581,16 +16010,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:7.18.0":
-  version: 7.18.0
-  resolution: "@typescript-eslint/scope-manager@npm:7.18.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:7.18.0"
-    "@typescript-eslint/visitor-keys": "npm:7.18.0"
-  checksum: 10/9eb2ae5d69d9f723e706c16b2b97744fc016996a5473bed596035ac4d12429b3d24e7340a8235d704efa57f8f52e1b3b37925ff7c2e3384859d28b23a99b8bcc
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:8.59.1":
   version: 8.59.1
   resolution: "@typescript-eslint/scope-manager@npm:8.59.1"
@@ -15626,36 +16045,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:7.18.0":
-  version: 7.18.0
-  resolution: "@typescript-eslint/types@npm:7.18.0"
-  checksum: 10/0e30c73a3cc3c67dd06360a5a12fd12cee831e4092750eec3d6c031bdc4feafcb0ab1d882910a73e66b451a4f6e1dd015e9e2c4d45bf6bf716a474e5d123ddf0
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:8.59.1, @typescript-eslint/types@npm:^8.59.1":
   version: 8.59.1
   resolution: "@typescript-eslint/types@npm:8.59.1"
   checksum: 10/4d324a01c2314d8e196b43b9dc5fe9a4d82c1b65f4915cd2f965879c5565d4453603b6f7b6bcdc436fb629135f07ad0f9d274e4697b02ce8bc1c0310916f7ace
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:7.18.0":
-  version: 7.18.0
-  resolution: "@typescript-eslint/typescript-estree@npm:7.18.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:7.18.0"
-    "@typescript-eslint/visitor-keys": "npm:7.18.0"
-    debug: "npm:^4.3.4"
-    globby: "npm:^11.1.0"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:^9.0.4"
-    semver: "npm:^7.6.0"
-    ts-api-utils: "npm:^1.3.0"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 10/b01e66235a91aa4439d02081d4a5f8b4a7cf9cb24f26b334812f657e3c603493e5f41e5c1e89cf4efae7d64509fa1f73affc16afc5e15cb7f83f724577c82036
   languageName: node
   linkType: hard
 
@@ -15690,30 +16083,6 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10/26ae39a574e56d92b6fc406113e797c354fce8b377721cc5dd50579a0e9f8c3efe23c7693826ce2c16be96490520dd6ce7e145c4c39c22d8d00f2614791603ba
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/utils@npm:^7.0.0":
-  version: 7.18.0
-  resolution: "@typescript-eslint/utils@npm:7.18.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:7.18.0"
-    "@typescript-eslint/types": "npm:7.18.0"
-    "@typescript-eslint/typescript-estree": "npm:7.18.0"
-  peerDependencies:
-    eslint: ^8.56.0
-  checksum: 10/f43fedb4f4d2e3836bdf137889449063a55c0ece74fdb283929cd376197b992313be8ef4df920c1c801b5c3076b92964c84c6c3b9b749d263b648d0011f5926e
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:7.18.0":
-  version: 7.18.0
-  resolution: "@typescript-eslint/visitor-keys@npm:7.18.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:7.18.0"
-    eslint-visitor-keys: "npm:^3.4.3"
-  checksum: 10/b7cfe6fdeae86c507357ac6b2357813c64fb2fbf1aaf844393ba82f73a16e2599b41981b34200d9fc7765d70bc3a8181d76b503051e53f04bcb7c9afef637eab
   languageName: node
   linkType: hard
 
@@ -16181,7 +16550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/core@npm:^4.4.1":
+"@yarnpkg/core@npm:^4.9.1":
   version: 4.9.1
   resolution: "@yarnpkg/core@npm:4.9.1"
   dependencies:
@@ -16376,10 +16745,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"adm-zip@npm:0.5.10":
-  version: 0.5.10
-  resolution: "adm-zip@npm:0.5.10"
-  checksum: 10/c5ab79b77114d8277f0cbfd6cca830198d6c7ee4971f6960f48e08cd2375953b11dc71729b7f396abd51d2d6cce8c862fad185ea90cb2c84ab5161c37ed1b099
+"adm-zip@npm:0.6.0":
+  version: 0.6.0
+  resolution: "adm-zip@npm:0.6.0"
+  checksum: 10/6a49ab39055d8f716958d3a2055491ab86fe3359c4afeed9b14bbce78fb847bcd3cbaa0ff4921aaa19824aaa29d06691def1f53263db5224d06c068f922c5ba2
   languageName: node
   linkType: hard
 
@@ -16547,13 +16916,6 @@ __metadata:
   version: 2.3.5
   resolution: "anser@npm:2.3.5"
   checksum: 10/55301fd884ea18ac55fb2ececef2133cbb5ea9b9749f57815cc78f22f5f6fee7783f6d0f079f8664cb9a85638f94d321e53836a589315dad80ef6ea5d881194f
-  languageName: node
-  linkType: hard
-
-"ansi-colors@npm:4.1.3":
-  version: 4.1.3
-  resolution: "ansi-colors@npm:4.1.3"
-  checksum: 10/43d6e2fc7b1c6e4dc373de708ee76311ec2e0433e7e8bd3194e7ff123ea6a747428fc61afdcf5969da5be3a5f0fd054602bec56fc0ebe249ce2fcde6e649e3c2
   languageName: node
   linkType: hard
 
@@ -19211,15 +19573,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cron-parser@npm:^4.2.0":
-  version: 4.9.0
-  resolution: "cron-parser@npm:4.9.0"
-  dependencies:
-    luxon: "npm:^3.2.1"
-  checksum: 10/ffca5e532a5ee0923412ee6e4c7f9bbceacc6ddf8810c16d3e9fb4fe5ec7e2de1b6896d7956f304bb6bc96b0ce37ad7e3935304179d52951c18d84107184faa7
-  languageName: node
-  linkType: hard
-
 "cron@npm:^3.0.0":
   version: 3.5.0
   resolution: "cron@npm:3.5.0"
@@ -21237,20 +21590,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-deprecation@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "eslint-plugin-deprecation@npm:3.0.0"
-  dependencies:
-    "@typescript-eslint/utils": "npm:^7.0.0"
-    ts-api-utils: "npm:^1.3.0"
-    tslib: "npm:^2.3.1"
-  peerDependencies:
-    eslint: ^8.0.0
-    typescript: ^4.2.4 || ^5.0.0
-  checksum: 10/6b13f68be641b750b1e777d4818b554efe77df9900deb3f90580455991f32bad173245f11d628690096c99a01fb71e323c694bb2093329dc16da3417d3d90627
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-import@npm:^2.31.0":
   version: 2.32.0
   resolution: "eslint-plugin-import@npm:2.32.0"
@@ -21673,15 +22012,6 @@ __metadata:
   version: 2.0.3
   resolution: "expand-template@npm:2.0.3"
   checksum: 10/588c19847216421ed92befb521767b7018dc88f88b0576df98cb242f20961425e96a92cbece525ef28cc5becceae5d544ae0f5b9b5e2aa05acb13716ca5b3099
-  languageName: node
-  linkType: hard
-
-"expand-tilde@npm:^2.0.0, expand-tilde@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "expand-tilde@npm:2.0.2"
-  dependencies:
-    homedir-polyfill: "npm:^1.0.1"
-  checksum: 10/2efe6ed407d229981b1b6ceb552438fbc9e5c7d6a6751ad6ced3e0aa5cf12f0b299da695e90d6c2ac79191b5c53c613e508f7149e4573abfbb540698ddb7301a
   languageName: node
   linkType: hard
 
@@ -22179,24 +22509,6 @@ __metadata:
     statuses: "npm:~2.0.2"
     unpipe: "npm:~1.0.0"
   checksum: 10/6cb4f9f80eaeb5a0fac4fdbd27a65d39271f040a0034df16556d896bfd855fd42f09da886781b3102117ea8fceba97b903c1f8b08df1fb5740576d5e0f481eed
-  languageName: node
-  linkType: hard
-
-"find-file-up@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "find-file-up@npm:2.0.1"
-  dependencies:
-    resolve-dir: "npm:^1.0.1"
-  checksum: 10/dfe820bfb80e75bed5dd5080057858c0ad2393e1438c48a3bb682663e9ecdcfbe3224ed4768bfedd00776800b4ae76bc8953d250d15ae3feabf381d2c6d04268
-  languageName: node
-  linkType: hard
-
-"find-pkg@npm:2.0.0":
-  version: 2.0.0
-  resolution: "find-pkg@npm:2.0.0"
-  dependencies:
-    find-file-up: "npm:^2.0.1"
-  checksum: 10/44785204c8bbbdfeaece6b834ba81a35163421c30e20f531281d26e6b5890663d7ac884b82a9aebf6ce23e479336cd6f70ea5597da35495c16abdeba2fd4f845
   languageName: node
   linkType: hard
 
@@ -22987,36 +23299,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"global-modules@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "global-modules@npm:1.0.0"
-  dependencies:
-    global-prefix: "npm:^1.0.1"
-    is-windows: "npm:^1.0.1"
-    resolve-dir: "npm:^1.0.0"
-  checksum: 10/e4031a01c0c7401349bb69e1499c7268d636552b16374c0002d677c7a6185da6782a2927a7a3a7c046eb7be97cd26b3c7b1b736f9818ecc7ac09e9d61449065e
-  languageName: node
-  linkType: hard
-
 "global-modules@npm:^2.0.0":
   version: 2.0.0
   resolution: "global-modules@npm:2.0.0"
   dependencies:
     global-prefix: "npm:^3.0.0"
   checksum: 10/4aee73adf533fe82ead2ad15c8bfb6ea4fb29e16d2d067521ab39d3b45b8f834d71c47a807e4f8f696e79497c3946d4ccdcd708da6f3a4522d65b087b8852f64
-  languageName: node
-  linkType: hard
-
-"global-prefix@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "global-prefix@npm:1.0.2"
-  dependencies:
-    expand-tilde: "npm:^2.0.2"
-    homedir-polyfill: "npm:^1.0.1"
-    ini: "npm:^1.3.4"
-    is-windows: "npm:^1.0.1"
-    which: "npm:^1.2.14"
-  checksum: 10/68cf78f81cd85310095ca1f0ec22dd5f43a1059646b2c7b3fc4a7c9ce744356e66ca833adda4e5753e38021847aaec393a159a029ba2d257c08ccb3f00ca2899
   languageName: node
   linkType: hard
 
@@ -23643,15 +23931,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"homedir-polyfill@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "homedir-polyfill@npm:1.0.3"
-  dependencies:
-    parse-passwd: "npm:^1.0.0"
-  checksum: 10/18dd4db87052c6a2179d1813adea0c4bfcfa4f9996f0e226fefb29eb3d548e564350fa28ec46b0bf1fbc0a1d2d6922ceceb80093115ea45ff8842a4990139250
-  languageName: node
-  linkType: hard
-
 "hono@npm:^4.11.4":
   version: 4.13.0
   resolution: "hono@npm:4.13.0"
@@ -24219,7 +24498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ini@npm:^1.3.4, ini@npm:^1.3.5, ini@npm:~1.3.0":
+"ini@npm:^1.3.5, ini@npm:~1.3.0":
   version: 1.3.8
   resolution: "ini@npm:1.3.8"
   checksum: 10/314ae176e8d4deb3def56106da8002b462221c174ddb7ce0c49ee72c8cd1f9044f7b10cc555a7d8850982c3b9ca96fc212122749f5234bc2b6fb05fb942ed566
@@ -24491,7 +24770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.13.0, is-core-module@npm:^2.16.1":
+"is-core-module@npm:^2.16.1":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
@@ -24884,13 +25163,6 @@ __metadata:
     call-bound: "npm:^1.0.3"
     get-intrinsic: "npm:^1.2.6"
   checksum: 10/1d5e1d0179beeed3661125a6faa2e59bfb48afda06fc70db807f178aa0ebebc3758fb6358d76b3d528090d5ef85148c345dcfbf90839592fe293e3e5e82f2134
-  languageName: node
-  linkType: hard
-
-"is-windows@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "is-windows@npm:1.0.2"
-  checksum: 10/438b7e52656fe3b9b293b180defb4e448088e7023a523ec21a91a80b9ff8cdb3377ddb5b6e60f7c7de4fa8b63ab56e121b6705fe081b3cf1b828b0a380009ad7
   languageName: node
   linkType: hard
 
@@ -26773,13 +27045,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long-timeout@npm:0.1.1":
-  version: 0.1.1
-  resolution: "long-timeout@npm:0.1.1"
-  checksum: 10/48668e5362cb74c4b77a6b833d59f149b9bb9e99c5a5097609807e2597cd0920613b2a42b89bd0870848298be3691064d95599a04ae010023d07dba39932afa7
-  languageName: node
-  linkType: hard
-
 "long@npm:^5.0.0, long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
@@ -26889,7 +27154,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"luxon@npm:^3.0.0, luxon@npm:^3.2.1, luxon@npm:^3.4.3":
+"luxon@npm:^3.0.0, luxon@npm:^3.4.3":
   version: 3.7.2
   resolution: "luxon@npm:3.7.2"
   checksum: 10/b24cd205ed306ce7415991687897dcc4027921ae413c9116590bc33a95f93b86ce52cf74ba72b4f5c5ab1c10090517f54ac8edfb127c049e0bf55b90dc2260be
@@ -28515,17 +28780,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-schedule@npm:2.1.1":
-  version: 2.1.1
-  resolution: "node-schedule@npm:2.1.1"
-  dependencies:
-    cron-parser: "npm:^4.2.0"
-    long-timeout: "npm:0.1.1"
-    sorted-array-functions: "npm:^1.3.0"
-  checksum: 10/0b0449f8a1f784cd599a8d79b1fa404ed9e3e4e2b1a48f027c97fd0632cd86e48ad762d366d6b6f9d48a940cad5b7afbdb1b833649ee870407591a6cf1297749
-  languageName: node
-  linkType: hard
-
 "node-stdlib-browser@npm:^1.3.1":
   version: 1.3.1
   resolution: "node-stdlib-browser@npm:1.3.1"
@@ -29377,13 +29631,6 @@ __metadata:
   version: 1.5.0
   resolution: "parse-multipart-data@npm:1.5.0"
   checksum: 10/fb029f1446f086f2989fb24eaf549d28cfde7df1d323d069f343d5b0a62d8ee756c6a5a347874e148c9cf8c3fe523e295e6f2be3dd05ce73cb19e5e3cd5081ea
-  languageName: node
-  linkType: hard
-
-"parse-passwd@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "parse-passwd@npm:1.0.0"
-  checksum: 10/4e55e0231d58f828a41d0f1da2bf2ff7bcef8f4cb6146e69d16ce499190de58b06199e6bd9b17fbf0d4d8aef9052099cdf8c4f13a6294b1a522e8e958073066e
   languageName: node
   linkType: hard
 
@@ -32148,16 +32395,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-dir@npm:^1.0.0, resolve-dir@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "resolve-dir@npm:1.0.1"
-  dependencies:
-    expand-tilde: "npm:^2.0.0"
-    global-modules: "npm:^1.0.0"
-  checksum: 10/ef736b8ed60d6645c3b573da17d329bfb50ec4e1d6c5ffd6df49e3497acef9226f9810ea6823b8ece1560e01dcb13f77a9f6180d4f242d00cc9a8f4de909c65c
-  languageName: node
-  linkType: hard
-
 "resolve-from@npm:5.0.0, resolve-from@npm:^5.0.0":
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
@@ -32176,19 +32413,6 @@ __metadata:
   version: 1.0.0
   resolution: "resolve-pkg-maps@npm:1.0.0"
   checksum: 10/0763150adf303040c304009231314d1e84c6e5ebfa2d82b7d94e96a6e82bacd1dcc0b58ae257315f3c8adb89a91d8d0f12928241cba2df1680fbe6f60bf99b0e
-  languageName: node
-  linkType: hard
-
-"resolve@npm:1.22.8":
-  version: 1.22.8
-  resolution: "resolve@npm:1.22.8"
-  dependencies:
-    is-core-module: "npm:^2.13.0"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10/c473506ee01eb45cbcfefb68652ae5759e092e6b0fb64547feadf9736a6394f258fbc6f88e00c5ca36d5477fbb65388b272432a3600fa223062e54333c156753
   languageName: node
   linkType: hard
 
@@ -32219,19 +32443,6 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10/c95cb98b8d3f9e2a979e6eb8b7e0b0e13f08da62607a45207275f151d640152244568a9a9cd01662a21e3746792177cbf9be1dacb88f7355edf4db49d9ee27e5
-  languageName: node
-  linkType: hard
-
-"resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>":
-  version: 1.22.8
-  resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=9bd1a5"
-  dependencies:
-    is-core-module: "npm:^2.13.0"
-    path-parse: "npm:^1.0.7"
-    supports-preserve-symlinks-flag: "npm:^1.0.0"
-  bin:
-    resolve: bin/resolve
-  checksum: 10/b14c82cbce48701a1e963c60f196b91a289186e8b596334e09c881df8069cefcfb0ac9ce85ea768742b361a58005494bf2428a95dc5056d2ba441aa993731b1f
   languageName: node
   linkType: hard
 
@@ -32867,15 +33078,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.6.3":
-  version: 7.6.3
-  resolution: "semver@npm:7.6.3"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/36b1fbe1a2b6f873559cd57b238f1094a053dbfd997ceeb8757d79d1d2089c56d1321b9f1069ce263dc64cfa922fa1d2ad566b39426fe1ac6c723c1487589e10
-  languageName: node
-  linkType: hard
-
 "semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
@@ -32885,7 +33087,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.7.2, semver@npm:^7.7.3":
+"semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.3":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -33299,13 +33501,6 @@ __metadata:
     atomic-sleep: "npm:^1.0.0"
     flatstr: "npm:^1.0.12"
   checksum: 10/7d3e44cee6c311b9a0b944c90b171667183571a4391fba585930dbcf377248ada64aec70d8c9e6e355e89b54f5b5b96af4428beb6df8b612b9108814a41492b2
-  languageName: node
-  linkType: hard
-
-"sorted-array-functions@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "sorted-array-functions@npm:1.3.0"
-  checksum: 10/673fd39ca3b6c92644d4483eac1700bb7d7555713a536822a7522a35af559bef3e72f10d89356b75042dc394cd7c2e2ab6f40024385218ec3c85bb7335032857
   languageName: node
   linkType: hard
 
@@ -34688,15 +34883,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^1.3.0":
-  version: 1.4.3
-  resolution: "ts-api-utils@npm:1.4.3"
-  peerDependencies:
-    typescript: ">=4.2.0"
-  checksum: 10/713c51e7392323305bd4867422ba130fbf70873ef6edbf80ea6d7e9c8f41eeeb13e40e8e7fe7cd321d74e4864777329797077268c9f570464303a1723f1eed39
-  languageName: node
-  linkType: hard
-
 "ts-api-utils@npm:^2.5.0":
   version: 2.5.0
   resolution: "ts-api-utils@npm:2.5.0"
@@ -35106,10 +35292,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:7.24.7":
-  version: 7.24.7
-  resolution: "undici@npm:7.24.7"
-  checksum: 10/bce7b75fe2656bbd1f9c9d5d1b6b89670773281343be25d0b1f4d808dcce97d81509987d1f3183d37a63d3a57f5f217ed8ed15ee3e103384c54e190f4e360c48
+"undici@npm:7.29.0":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10/ca73639071bdcbc41e57be1800847fa18f86f8fbf7a5641ff9899f7bbb6f5cecdd593e225f5fd94e31703dcbfaea4a722a3b81cab90c5c4e2b406aec1ae55732
   languageName: node
   linkType: hard
 
@@ -35339,13 +35525,6 @@ __metadata:
     "@unrs/resolver-binding-win32-x64-msvc":
       optional: true
   checksum: 10/4de653508cbaae47883a896bd5cdfef0e5e87b428d62620d16fd35cd534beaebf08ebf0cf2f8b4922aa947b2fe745180facf6cc3f39ba364f7ce0f974cb06a70
-  languageName: node
-  linkType: hard
-
-"upath@npm:2.0.1":
-  version: 2.0.1
-  resolution: "upath@npm:2.0.1"
-  checksum: 10/7b98a83559a295d59f87f7a8d615c7549d19e4aec4dd9d52be2bf1ba93e1d6ee7d8f2188cdecbf303a22cea3768abff4268b960350152a0264125f577d9ed79e
   languageName: node
   linkType: hard
 
@@ -36107,7 +36286,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^1.2.14, which@npm:^1.3.1":
+"which@npm:^1.3.1":
   version: 1.3.1
   resolution: "which@npm:1.3.1"
   dependencies:
@@ -36234,7 +36413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:*, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.20.0, ws@npm:^8.20.1, ws@npm:^8.8.0":
+"ws@npm:*, ws@npm:8.21.0, ws@npm:^8.18.0, ws@npm:^8.18.2, ws@npm:^8.18.3, ws@npm:^8.20.0, ws@npm:^8.20.1, ws@npm:^8.8.0":
   version: 8.21.0
   resolution: "ws@npm:8.21.0"
   peerDependencies:
@@ -36246,21 +36425,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/088411956432c8f876158409d5a285cb9ad1382f593391f51d3a599bd0a5b277f876609ebd00fc3596321c4a4c9064d6fffe1ebad960e8ea7fd9ae25324f35c2
-  languageName: node
-  linkType: hard
-
-"ws@npm:8.18.0":
-  version: 8.18.0
-  resolution: "ws@npm:8.18.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10/70dfe53f23ff4368d46e4c0b1d4ca734db2c4149c6f68bc62cb16fc21f753c47b35fcc6e582f3bdfba0eaeb1c488cddab3c2255755a5c3eecb251431e42b3ff6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backstage release v1.55.0-next.2 has been published, this Pull Request contains the changes to upgrade to this new release
 
Please review the changelog before approving, there may be manual changes needed to enable new features:
 
- Changelog: [v1.55.0-next.2](https://github.com/backstage/backstage/blob/master/docs/releases/v1.55.0-next.2-changelog.md)
- Upgrade Helper: [From 1.55.0-next.1 to 1.55.0-next.2](https://backstage.github.io/upgrade-helper/?from=1.55.0-next.1&to=1.55.0-next.2)
 
Created by [Version Bump 34339075526](https://github.com/backstage/demo/actions/runs/34339075526)
 